### PR TITLE
added explicit dependency on jetty-util to fix exception

### DIFF
--- a/proxy/pom.xml
+++ b/proxy/pom.xml
@@ -64,6 +64,11 @@
       <version>${jetty.version}</version>
     </dependency>
     <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-util</artifactId>
+      <version>${jetty.version}</version>
+    </dependency>
+    <dependency>
       <groupId>org.glassfish.jersey.bundles</groupId>
       <artifactId>jaxrs-ri</artifactId>
       <version>2.17</version>


### PR DESCRIPTION
Caused by: java.lang.ClassNotFoundException: org.eclipse.jetty.util.thread.NonBlockingThread