### PR TITLE
Add a space between tags

### DIFF
--- a/java-client/src/main/java/com/wavefront/integrations/Wavefront.java
+++ b/java-client/src/main/java/com/wavefront/integrations/Wavefront.java
@@ -164,6 +164,7 @@ public class Wavefront implements WavefrontSender {
           if (StringUtils.isBlank(tag.getValue())) {
             throw new IllegalArgumentException("point tag value cannot be blank");
           }
+          writer.write(" ");
           writer.write(sanitize(tag.getKey()));
           writer.write("=");
           writer.write(sanitize(tag.getValue()));


### PR DESCRIPTION
Discovered while testing DropWizard integration. The host= and any other tags don't currently have any space separating them which leads to blocked lines.