### PR TITLE
Dropwizard metrics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,8 @@ hs_err_pid*
 **/target/
 
 proxy/unitTest*
+
+# Eclipse files
+.classpath
+.project
+.settings/

--- a/dropwizard-metrics/3.1/README.md
+++ b/dropwizard-metrics/3.1/README.md
@@ -14,7 +14,7 @@ It is designed to be used with the [stable version 3.1.x of Dropwizard Metrics](
 
 ### Setting up Maven
 
-You will need both the DropWizard `metrics-core` and the Wavefront `metrics-wavefront` libraries as dependencies:
+You will need both the DropWizard `metrics-core` and the Wavefront `metrics-wavefront` libraries as dependencies. Logging depends on `org.slf4j`:
 
 ```Maven
    <dependency>
@@ -27,6 +27,11 @@ You will need both the DropWizard `metrics-core` and the Wavefront `metrics-wave
       <artifactId>dropwizard-metrics-3.1</artifactId>
       <version>3.7</version>
     </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-simple</artifactId>
+      <version>1.7.16</version>
+    </dependency>       
 ```
 
 Versions `3.1.0` and `3.1.1` of `metrics-core` will also work.

--- a/dropwizard-metrics/3.1/README.md
+++ b/dropwizard-metrics/3.1/README.md
@@ -1,0 +1,93 @@
+# Wavefront dropwizard-metrics Reporter
+
+This is a Wavefront Reporter for the Stable version of [Dropwizard Metrics](https://dropwizard.github.io/metrics/3.1.0/) (formerly Coda Hale & Yammer Metrics).
+
+It sends data to the Wavefront service via a Proxy and supports Point Tags being assigned at the Reporter level.
+
+## Usage
+
+This Reporter sends data via to Wavefront via a Proxy. Version 3.5 or later is required. You can easily install the Proxy by following [these instructions](https://github.com/wavefrontHQ/install).
+
+To use the Reporter you'll need to know the hostname and port (which by default is 2878) where the Wavefront Proxy is running.
+
+It is designed to be used with the [stable version 3.1.x of Dropwizard Metrics](https://dropwizard.github.io/metrics/3.1.0/getting-started/).
+
+### Setting up Maven
+
+You will need both the DropWizard `metrics-core` and the Wavefront `metrics-wavefront` libraries as dependencies:
+
+```Maven
+   <dependency>
+      <groupId>io.dropwizard.metrics</groupId>
+      <artifactId>metrics-core</artifactId>
+      <version>3.1.2</version>
+    </dependency>
+    <dependency>
+      <groupId>com.wavefront</groupId>
+      <artifactId>metrics-wavefront</artifactId>
+      <version>3.1.2</version>
+    </dependency>
+```
+
+Versions `3.1.0` and `3.1.1` of `metrics-core` will also work.
+
+### Example Usage
+
+The Wavefront Reporter lets you use DropWizard metrics exactly as you normally would. See its [getting started guide](https://dropwizard.github.io/metrics/3.1.0/getting-started/) if you haven't used it before.
+
+It simply gives you a new Reporter that will seamlessly work with Wavefront. First `import com.wavefront.integrations.metrics.WavefrontReporter;`
+
+Then for example to create a Reporter which will emit data every 10 seconds for:
+
+- A `MetricsRegistry` named `metrics`
+- A Wavefront Proxy on `localhost` at port `2878`
+- Data that should appear in Wavefront as `source=app-1.company.com`
+- Two point tags named `dc` and `service`
+
+you would do something like this:
+
+```java
+WavefrontReporter reporter = WavefrontReporter.forRegistry(metrics)
+        .withSource("app-1.company.com")
+    	.withPointTag("dc", "dallas")
+    	.withPointTag("service", "query")
+    	.build("localhost", 2878);
+```
+
+You must provide the source using the `.withSource(String source)` method and pass the Hostname and Port of the Wavefront Proxy using the `.build(String hostname, long port)` method.
+
+The Reporter provides all the same options that the [GraphiteReporter](http://metrics.dropwizard.io/3.1.0/manual/graphite/) does. By default:
+
+- There is no prefix on the Metrics
+- Rates will be converted to Seconds
+- Durations will be converted to Milliseconds
+- `MetricFilter.ALL` will be used for the Filter
+- `Clock.defaultClock()` will be used for the Clock
+
+In addition you can also:
+
+- Supply point tags for the Reporter to use. There are two ways to specify point tags at the Reporter level, individually using `.withPointTag(String tagK, String tagV)` or create a `Map<String,String>` and call `.withPointTags(my-map)` to do many at once.
+- Call `.withJvmMetrics()` when building the Reporter if you want it to add some default JVM metrics to the given MetricsRegistry
+
+If `.withJvmMetrics()` is used the following metrics will be added to the registry:
+
+```java
+registry.register("jvm.uptime", new Gauge<Long>() {
+    @Override
+	public Long getValue() {
+	    return ManagementFactory.getRuntimeMXBean().getUptime();
+	}
+});
+registry.register("jvm.current_time", new Gauge<Long>() {
+    @Override
+	public Long getValue() {
+	    return clock.getTime();
+    }
+});
+    
+registry.register("jvm.classes", new ClassLoadingGaugeSet());
+registry.register("jvm.fd_usage", new FileDescriptorRatioGauge());
+registry.register("jvm.buffers", new BufferPoolMetricSet(ManagementFactory.getPlatformMBeanServer()));
+registry.register("jvm.gc", new GarbageCollectorMetricSet());
+registry.register("jvm.memory", new MemoryUsageGaugeSet());
+```

--- a/dropwizard-metrics/3.1/README.md
+++ b/dropwizard-metrics/3.1/README.md
@@ -24,8 +24,8 @@ You will need both the DropWizard `metrics-core` and the Wavefront `metrics-wave
     </dependency>
     <dependency>
       <groupId>com.wavefront</groupId>
-      <artifactId>metrics-wavefront</artifactId>
-      <version>3.1.2</version>
+      <artifactId>dropwizard-metrics-3.1</artifactId>
+      <version>3.7</version>
     </dependency>
 ```
 

--- a/dropwizard-metrics/3.1/pom.xml
+++ b/dropwizard-metrics/3.1/pom.xml
@@ -9,9 +9,9 @@
     <relativePath>../../pom.xml</relativePath>
   </parent>
   
-  <artifactId>metrics-wavefront</artifactId>
-  <version>3.1.2</version>
-  <name>Wavefront Dropwizard Metrics Reporter</name>
+  <artifactId>dropwizard-metrics-3.1</artifactId>
+  <version>3.7-SNAPSHOT</version>
+  <name>Wavefront Dropwizard Metrics 3.1 Reporter</name>
   <description>Report metrics via the Wavefront Proxy</description>
 
   <dependencies>

--- a/dropwizard-metrics/3.1/pom.xml
+++ b/dropwizard-metrics/3.1/pom.xml
@@ -1,0 +1,35 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>com.wavefront</groupId>
+    <artifactId>wavefront</artifactId>
+    <version>3.7-SNAPSHOT</version>
+    <relativePath>../../pom.xml</relativePath>
+  </parent>
+  
+  <artifactId>metrics-wavefront</artifactId>
+  <version>3.1.2</version>
+  <name>Wavefront Dropwizard Metrics Reporter</name>
+  <description>Report metrics via the Wavefront Proxy</description>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.wavefront</groupId>
+      <artifactId>java-client</artifactId>
+      <version>3.7-SNAPSHOT</version>
+    </dependency>
+    <dependency>
+      <groupId>io.dropwizard.metrics</groupId>
+      <artifactId>metrics-core</artifactId>
+      <version>3.1.2</version>
+    </dependency>
+    <dependency>
+      <groupId>io.dropwizard.metrics</groupId>
+      <artifactId>metrics-jvm</artifactId>
+      <version>3.1.2</version>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/dropwizard-metrics/3.1/src/main/java/com/wavefront/integrations/metrics/WavefrontReporter.java
+++ b/dropwizard-metrics/3.1/src/main/java/com/wavefront/integrations/metrics/WavefrontReporter.java
@@ -25,354 +25,353 @@ import java.util.concurrent.TimeUnit;
  *
  */
 public class WavefrontReporter extends ScheduledReporter {
+  /**
+   * Returns a new {@link Builder} for {@link WavefrontReporter}.
+   *
+   * @param registry the registry to report
+   * @return a {@link Builder} instance for a {@link WavefrontReporter}
+   */
+  public static Builder forRegistry(MetricRegistry registry) {
+    return new Builder(registry);
+  }
+
+  /**
+   * A builder for {@link WavefrontReporter} instances. Defaults to not using a prefix, using the
+   * default clock, converting rates to events/second, converting durations to milliseconds,
+   * a host named "unknown", no point Tags, and not filtering any metrics.
+   */
+  public static class Builder {
+    private final MetricRegistry registry;
+    private Clock clock;
+    private String prefix;
+    private TimeUnit rateUnit;
+    private TimeUnit durationUnit;
+    private MetricFilter filter;
+    private String source;
+    private Map<String, String> pointTags;
+    private boolean includeJvmMetrics;
+
+    private Builder(MetricRegistry registry) {
+      this.registry = registry;
+      this.clock = Clock.defaultClock();
+      this.prefix = null;
+      this.rateUnit = TimeUnit.SECONDS;
+      this.durationUnit = TimeUnit.MILLISECONDS;
+      this.filter = MetricFilter.ALL;
+      this.source = "dropwizard-metrics";
+      this.pointTags = new HashMap<String, String>();
+      this.includeJvmMetrics = false;
+    }
+
     /**
-     * Returns a new {@link Builder} for {@link WavefrontReporter}.
+     * Use the given {@link Clock} instance for the time. Defaults to Clock.defaultClock()
      *
-     * @param registry the registry to report
-     * @return a {@link Builder} instance for a {@link WavefrontReporter}
+     * @param clock a {@link Clock} instance
+     * @return {@code this}
      */
-    public static Builder forRegistry(MetricRegistry registry) {
-        return new Builder(registry);
+    public Builder withClock(Clock clock) {
+      this.clock = clock;
+      return this;
     }
 
     /**
-     * A builder for {@link WavefrontReporter} instances. Defaults to not using a prefix, using the
-     * default clock, converting rates to events/second, converting durations to milliseconds, 
-     * a host named "unknown", no point Tags, and not filtering any metrics.
+     * Prefix all metric names with the given string. Defaults to null.
+     *
+     * @param prefix the prefix for all metric names
+     * @return {@code this}
      */
-    public static class Builder {
-        private final MetricRegistry registry;
-        private Clock clock;
-        private String prefix;
-        private TimeUnit rateUnit;
-        private TimeUnit durationUnit;
-        private MetricFilter filter;
-        private String source;
-        private Map<String, String> pointTags;
-        private boolean includeJvmMetrics;
-
-        private Builder(MetricRegistry registry) {
-            this.registry = registry;
-            this.clock = Clock.defaultClock();
-            this.prefix = null;
-            this.rateUnit = TimeUnit.SECONDS;
-            this.durationUnit = TimeUnit.MILLISECONDS;
-            this.filter = MetricFilter.ALL;
-            this.source = "dropwizard-metrics";
-            this.pointTags = new HashMap<String, String>();
-            this.includeJvmMetrics = false;
-        }
-
-        /**
-         * Use the given {@link Clock} instance for the time. Defaults to Clock.defaultClock()
-         *
-         * @param clock a {@link Clock} instance
-         * @return {@code this}
-         */
-        public Builder withClock(Clock clock) {
-            this.clock = clock;
-            return this;
-        }
-
-        /**
-         * Prefix all metric names with the given string. Defaults to null.
-         *
-         * @param prefix the prefix for all metric names
-         * @return {@code this}
-         */
-        public Builder prefixedWith(String prefix) {
-            this.prefix = prefix;
-            return this;
-        }
-        
-        /**
-         * Set the host for this reporter. This is equivalent to withSource.
-         *
-         * @param host the host for all metrics
-         * @return {@code this}
-         */
-        public Builder withHost(String host) {
-            this.source = host;
-            return this;
-        }
-        
-        /**
-         * Set the source for this reporter. This is equivalent to withHost.
-         *
-         * @param source the host for all metrics
-         * @return {@code this}
-         */
-        public Builder withSource(String source) {
-            this.source = source;
-            return this;
-        }
-        
-        /**
-         * Set the Point Tags for this reporter.
-         *
-         * @param pointTags the pointTags Map for all metrics
-         * @return {@code this}
-         */
-        public Builder withPointTags(Map<String, String> pointTags) {
-            this.pointTags.putAll(pointTags);
-            return this;
-        }
-        
-        /**
-         * Set a point tag for this reporter.
-         *
-         * @param ptagK the key of the Point Tag
-         * @param ptagV the value of the Point Tag
-         * @return {@code this}
-         */
-        public Builder withPointTag(String ptagK, String ptagV) {
-            this.pointTags.put(ptagK, ptagV);
-            return this;
-        }
-
-        /**
-         * Convert rates to the given time unit. Defaults to Seconds.
-         *
-         * @param rateUnit a unit of time
-         * @return {@code this}
-         */
-        public Builder convertRatesTo(TimeUnit rateUnit) {
-            this.rateUnit = rateUnit;
-            return this;
-        }
-
-        /**
-         * Convert durations to the given time unit. Defaults to Milliseconds.
-         *
-         * @param durationUnit a unit of time
-         * @return {@code this}
-         */
-        public Builder convertDurationsTo(TimeUnit durationUnit) {
-            this.durationUnit = durationUnit;
-            return this;
-        }
-
-        /**
-         * Only report metrics which match the given filter. Defaults to MetricFilter.ALL
-         *
-         * @param filter a {@link MetricFilter}
-         * @return {@code this}
-         */
-        public Builder filter(MetricFilter filter) {
-            this.filter = filter;
-            return this;
-        }
-        
-        /**
-         * Include JVM Metrics from this Reporter.
-         * 
-         * @return
-         */
-        public Builder withJvmMetrics() {
-        	this.includeJvmMetrics = true;
-        	return this;
-        }
-
-        /**
-         * Builds a {@link WavefrontReporter} with the given properties, sending metrics using the
-         * given {@link WavefrontSender}.
-         *
-         * @param Wavefront a {@link WavefrontSender}
-         * @return a {@link WavefrontReporter}
-         */
-        public WavefrontReporter build(String proxyHostname, int proxyPort) {
-            return new WavefrontReporter(registry,
-                                        proxyHostname,
-                                        proxyPort,
-                                        clock,
-                                        prefix,
-                                        source,
-                                        pointTags,
-                                        rateUnit,
-                                        durationUnit,
-                                        filter,
-                                        includeJvmMetrics);
-        }
+    public Builder prefixedWith(String prefix) {
+      this.prefix = prefix;
+      return this;
     }
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(WavefrontReporter.class);
-
-    private final WavefrontSender wavefront;
-    private final Clock clock;
-    private final String prefix;
-    private final String source;
-    private final Map<String, String> pointTags;
-
-    private WavefrontReporter(MetricRegistry registry,
-    						 String proxyHostname,
-    						 int proxyPort,
-                             final Clock clock,
-                             String prefix,
-                             String source,
-                             Map<String, String> pointTags,
-                             TimeUnit rateUnit,
-                             TimeUnit durationUnit,
-                             MetricFilter filter,
-                             boolean includeJvmMetrics) {
-        super(registry, "wavefront-reporter", filter, rateUnit, durationUnit);
-        this.wavefront = new Wavefront(proxyHostname, proxyPort);
-        this.clock = clock;
-        this.prefix = prefix;
-        this.source = source;       
-        this.pointTags = pointTags;
-        
-		if (includeJvmMetrics) {
-			registry.register("jvm.uptime", new Gauge<Long>() {
-				@Override
-				public Long getValue() {
-					return ManagementFactory.getRuntimeMXBean().getUptime();
-				}
-			});
-			registry.register("jvm.current_time", new Gauge<Long>() {
-				@Override
-				public Long getValue() {
-					return clock.getTime();
-				}
-			});
-			registry.register("jvm.classes", new ClassLoadingGaugeSet());
-			registry.register("jvm.fd_usage", new FileDescriptorRatioGauge());
-			registry.register("jvm.buffers", new BufferPoolMetricSet(ManagementFactory.getPlatformMBeanServer()));
-			registry.register("jvm.gc", new GarbageCollectorMetricSet());
-			registry.register("jvm.memory", new MemoryUsageGaugeSet());
-		}
+    /**
+     * Set the host for this reporter. This is equivalent to withSource.
+     *
+     * @param host the host for all metrics
+     * @return {@code this}
+     */
+    public Builder withHost(String host) {
+      this.source = host;
+      return this;
     }
 
-    @Override
-    public void report(SortedMap<String, Gauge> gauges,
-                       SortedMap<String, Counter> counters,
-                       SortedMap<String, Histogram> histograms,
-                       SortedMap<String, Meter> meters,
-                       SortedMap<String, Timer> timers) {
-        final long timestamp = clock.getTime() / 1000;
+    /**
+     * Set the source for this reporter. This is equivalent to withHost.
+     *
+     * @param source the host for all metrics
+     * @return {@code this}
+     */
+    public Builder withSource(String source) {
+      this.source = source;
+      return this;
+    }
 
-        try {
-            if (!wavefront.isConnected()) {
-    	          wavefront.connect();
-            }
+    /**
+     * Set the Point Tags for this reporter.
+     *
+     * @param pointTags the pointTags Map for all metrics
+     * @return {@code this}
+     */
+    public Builder withPointTags(Map<String, String> pointTags) {
+      this.pointTags.putAll(pointTags);
+      return this;
+    }
 
-            for (Map.Entry<String, Gauge> entry : gauges.entrySet()) {
-            	if (entry.getValue() instanceof Number) {
-            		reportGauge(entry.getKey(), entry.getValue(), timestamp);
-            	}
-            }
+    /**
+     * Set a point tag for this reporter.
+     *
+     * @param ptagK the key of the Point Tag
+     * @param ptagV the value of the Point Tag
+     * @return {@code this}
+     */
+    public Builder withPointTag(String ptagK, String ptagV) {
+      this.pointTags.put(ptagK, ptagV);
+      return this;
+    }
 
-            for (Map.Entry<String, Counter> entry : counters.entrySet()) {
-                reportCounter(entry.getKey(), entry.getValue(), timestamp);
-            }
+    /**
+     * Convert rates to the given time unit. Defaults to Seconds.
+     *
+     * @param rateUnit a unit of time
+     * @return {@code this}
+     */
+    public Builder convertRatesTo(TimeUnit rateUnit) {
+      this.rateUnit = rateUnit;
+      return this;
+    }
 
-            for (Map.Entry<String, Histogram> entry : histograms.entrySet()) {
-                reportHistogram(entry.getKey(), entry.getValue(), timestamp);
-            }
+    /**
+     * Convert durations to the given time unit. Defaults to Milliseconds.
+     *
+     * @param durationUnit a unit of time
+     * @return {@code this}
+     */
+    public Builder convertDurationsTo(TimeUnit durationUnit) {
+      this.durationUnit = durationUnit;
+      return this;
+    }
 
-            for (Map.Entry<String, Meter> entry : meters.entrySet()) {
-                reportMetered(entry.getKey(), entry.getValue(), timestamp);
-            }
+    /**
+     * Only report metrics which match the given filter. Defaults to MetricFilter.ALL
+     *
+     * @param filter a {@link MetricFilter}
+     * @return {@code this}
+     */
+    public Builder filter(MetricFilter filter) {
+      this.filter = filter;
+      return this;
+    }
 
-            for (Map.Entry<String, Timer> entry : timers.entrySet()) {
-                reportTimer(entry.getKey(), entry.getValue(), timestamp);
-            }
+    /**
+     * Include JVM Metrics from this Reporter.
+     *
+     * @return
+     */
+    public Builder withJvmMetrics() {
+      this.includeJvmMetrics = true;
+      return this;
+    }
 
-            wavefront.flush();
-        } catch (IOException e) {
-            LOGGER.warn("Unable to report to Wavefront", wavefront, e);
-            try {
-                wavefront.close();
-            } catch (IOException e1) {
-                LOGGER.warn("Error closing Wavefront", wavefront, e);
-            }
+    /**
+     * Builds a {@link WavefrontReporter} with the given properties, sending metrics using the
+     * given {@link WavefrontSender}.
+     *
+     * @param Wavefront a {@link WavefrontSender}
+     * @return a {@link WavefrontReporter}
+     */
+    public WavefrontReporter build(String proxyHostname, int proxyPort) {
+      return new WavefrontReporter(registry,
+                                   proxyHostname,
+                                   proxyPort,
+                                   clock,
+                                   prefix,
+                                   source,
+                                   pointTags,
+                                   rateUnit,
+                                   durationUnit,
+                                   filter,
+                                   includeJvmMetrics);
+    }
+  }
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(WavefrontReporter.class);
+
+  private final WavefrontSender wavefront;
+  private final Clock clock;
+  private final String prefix;
+  private final String source;
+  private final Map<String, String> pointTags;
+
+  private WavefrontReporter(MetricRegistry registry,
+                            String proxyHostname,
+                            int proxyPort,
+                            final Clock clock,
+                            String prefix,
+                            String source,
+                            Map<String, String> pointTags,
+                            TimeUnit rateUnit,
+                            TimeUnit durationUnit,
+                            MetricFilter filter,
+                            boolean includeJvmMetrics) {
+    super(registry, "wavefront-reporter", filter, rateUnit, durationUnit);
+    this.wavefront = new Wavefront(proxyHostname, proxyPort);
+    this.clock = clock;
+    this.prefix = prefix;
+    this.source = source;
+    this.pointTags = pointTags;
+
+    if (includeJvmMetrics) {
+      registry.register("jvm.uptime", new Gauge<Long>() {
+          @Override
+          public Long getValue() {
+            return ManagementFactory.getRuntimeMXBean().getUptime();
+          }
+        });
+      registry.register("jvm.current_time", new Gauge<Long>() {
+          @Override
+          public Long getValue() {
+            return clock.getTime();
+          }
+        });
+      registry.register("jvm.classes", new ClassLoadingGaugeSet());
+      registry.register("jvm.fd_usage", new FileDescriptorRatioGauge());
+      registry.register("jvm.buffers", new BufferPoolMetricSet(ManagementFactory.getPlatformMBeanServer()));
+      registry.register("jvm.gc", new GarbageCollectorMetricSet());
+      registry.register("jvm.memory", new MemoryUsageGaugeSet());
+    }
+  }
+
+  @Override
+  public void report(SortedMap<String, Gauge> gauges,
+                     SortedMap<String, Counter> counters,
+                     SortedMap<String, Histogram> histograms,
+                     SortedMap<String, Meter> meters,
+                     SortedMap<String, Timer> timers) {
+    final long timestamp = clock.getTime() / 1000;
+
+    try {
+      if (!wavefront.isConnected()) {
+        wavefront.connect();
+      }
+
+      for (Map.Entry<String, Gauge> entry : gauges.entrySet()) {
+        if (entry.getValue() instanceof Number) {
+          reportGauge(entry.getKey(), entry.getValue(), timestamp);
         }
+      }
+
+      for (Map.Entry<String, Counter> entry : counters.entrySet()) {
+        reportCounter(entry.getKey(), entry.getValue(), timestamp);
+      }
+
+      for (Map.Entry<String, Histogram> entry : histograms.entrySet()) {
+        reportHistogram(entry.getKey(), entry.getValue(), timestamp);
+      }
+
+      for (Map.Entry<String, Meter> entry : meters.entrySet()) {
+        reportMetered(entry.getKey(), entry.getValue(), timestamp);
+      }
+
+      for (Map.Entry<String, Timer> entry : timers.entrySet()) {
+        reportTimer(entry.getKey(), entry.getValue(), timestamp);
+      }
+
+      wavefront.flush();
+    } catch (IOException e) {
+      LOGGER.warn("Unable to report to Wavefront", wavefront, e);
+      try {
+        wavefront.close();
+      } catch (IOException e1) {
+        LOGGER.warn("Error closing Wavefront", wavefront, e);
+      }
     }
+  }
 
-    @Override
-    public void stop() {
-        try {
-            super.stop();
-        } finally {
-            try {
-                wavefront.close();
-            } catch (IOException e) {
-                LOGGER.debug("Error disconnecting from Wavefront", wavefront, e);
-            }
-        }
+  @Override
+  public void stop() {
+    try {
+      super.stop();
+    } finally {
+      try {
+        wavefront.close();
+      } catch (IOException e) {
+        LOGGER.debug("Error disconnecting from Wavefront", wavefront, e);
+      }
     }
+  }
 
-    private void reportTimer(String name, Timer timer, long timestamp) throws IOException {
-        final Snapshot snapshot = timer.getSnapshot();
+  private void reportTimer(String name, Timer timer, long timestamp) throws IOException {
+    final Snapshot snapshot = timer.getSnapshot();
 
-        wavefront.send(prefix(name, "max"), convertDuration(snapshot.getMax()), timestamp, source, pointTags);
-        wavefront.send(prefix(name, "mean"), convertDuration(snapshot.getMean()), timestamp, source, pointTags);
-        wavefront.send(prefix(name, "min"), convertDuration(snapshot.getMin()), timestamp, source, pointTags);
-        wavefront.send(prefix(name, "stddev"),
-                      convertDuration(snapshot.getStdDev()),
-                      timestamp, source, pointTags);
-        wavefront.send(prefix(name, "p50"),
-                      convertDuration(snapshot.getMedian()),
-                      timestamp, source, pointTags);
-        wavefront.send(prefix(name, "p75"),
-                      convertDuration(snapshot.get75thPercentile()),
-                      timestamp, source, pointTags);
-        wavefront.send(prefix(name, "p95"),
-                      convertDuration(snapshot.get95thPercentile()),
-                      timestamp, source, pointTags);
-        wavefront.send(prefix(name, "p98"),
-                      convertDuration(snapshot.get98thPercentile()),
-                      timestamp, source, pointTags);
-        wavefront.send(prefix(name, "p99"),
-                      convertDuration(snapshot.get99thPercentile()),
-                      timestamp, source, pointTags);
-        wavefront.send(prefix(name, "p999"),
-                      convertDuration(snapshot.get999thPercentile()),
-                      timestamp, source, pointTags);
+    wavefront.send(prefix(name, "max"), convertDuration(snapshot.getMax()), timestamp, source, pointTags);
+    wavefront.send(prefix(name, "mean"), convertDuration(snapshot.getMean()), timestamp, source, pointTags);
+    wavefront.send(prefix(name, "min"), convertDuration(snapshot.getMin()), timestamp, source, pointTags);
+    wavefront.send(prefix(name, "stddev"),
+                   convertDuration(snapshot.getStdDev()),
+                   timestamp, source, pointTags);
+    wavefront.send(prefix(name, "p50"),
+                   convertDuration(snapshot.getMedian()),
+                   timestamp, source, pointTags);
+    wavefront.send(prefix(name, "p75"),
+                   convertDuration(snapshot.get75thPercentile()),
+                   timestamp, source, pointTags);
+    wavefront.send(prefix(name, "p95"),
+                   convertDuration(snapshot.get95thPercentile()),
+                   timestamp, source, pointTags);
+    wavefront.send(prefix(name, "p98"),
+                   convertDuration(snapshot.get98thPercentile()),
+                   timestamp, source, pointTags);
+    wavefront.send(prefix(name, "p99"),
+                   convertDuration(snapshot.get99thPercentile()),
+                   timestamp, source, pointTags);
+    wavefront.send(prefix(name, "p999"),
+                   convertDuration(snapshot.get999thPercentile()),
+                   timestamp, source, pointTags);
 
-        reportMetered(name, timer, timestamp);
-    }
+    reportMetered(name, timer, timestamp);
+  }
 
-    private void reportMetered(String name, Metered meter, long timestamp) throws IOException {
-        wavefront.send(prefix(name, "count"), meter.getCount(), timestamp, source, pointTags);
-        wavefront.send(prefix(name, "m1_rate"),
-                      convertRate(meter.getOneMinuteRate()),
-                      timestamp, source, pointTags);
-        wavefront.send(prefix(name, "m5_rate"),
-                      convertRate(meter.getFiveMinuteRate()),
-                      timestamp, source, pointTags);
-        wavefront.send(prefix(name, "m15_rate"),
-                      convertRate(meter.getFifteenMinuteRate()),
-                      timestamp, source, pointTags);
-        wavefront.send(prefix(name, "mean_rate"),
-                      convertRate(meter.getMeanRate()),
-                      timestamp, source, pointTags);
-    }
+  private void reportMetered(String name, Metered meter, long timestamp) throws IOException {
+    wavefront.send(prefix(name, "count"), meter.getCount(), timestamp, source, pointTags);
+    wavefront.send(prefix(name, "m1_rate"),
+                   convertRate(meter.getOneMinuteRate()),
+                   timestamp, source, pointTags);
+    wavefront.send(prefix(name, "m5_rate"),
+                   convertRate(meter.getFiveMinuteRate()),
+                   timestamp, source, pointTags);
+    wavefront.send(prefix(name, "m15_rate"),
+                   convertRate(meter.getFifteenMinuteRate()),
+                   timestamp, source, pointTags);
+    wavefront.send(prefix(name, "mean_rate"),
+                   convertRate(meter.getMeanRate()),
+                   timestamp, source, pointTags);
+  }
 
-    private void reportHistogram(String name, Histogram histogram, long timestamp) throws IOException {
-        final Snapshot snapshot = histogram.getSnapshot();
-        wavefront.send(prefix(name, "count"), histogram.getCount(), timestamp, source, pointTags);
-        wavefront.send(prefix(name, "max"), snapshot.getMax(), timestamp, source, pointTags);
-        wavefront.send(prefix(name, "mean"), snapshot.getMean(), timestamp, source, pointTags);
-        wavefront.send(prefix(name, "min"), snapshot.getMin(), timestamp, source, pointTags);
-        wavefront.send(prefix(name, "stddev"), snapshot.getStdDev(), timestamp, source, pointTags);
-        wavefront.send(prefix(name, "p50"), snapshot.getMedian(), timestamp, source, pointTags);
-        wavefront.send(prefix(name, "p75"), snapshot.get75thPercentile(), timestamp, source, pointTags);
-        wavefront.send(prefix(name, "p95"), snapshot.get95thPercentile(), timestamp, source, pointTags);
-        wavefront.send(prefix(name, "p98"), snapshot.get98thPercentile(), timestamp, source, pointTags);
-        wavefront.send(prefix(name, "p99"), snapshot.get99thPercentile(), timestamp, source, pointTags);
-        wavefront.send(prefix(name, "p999"), snapshot.get999thPercentile(), timestamp, source, pointTags);
-    }
+  private void reportHistogram(String name, Histogram histogram, long timestamp) throws IOException {
+    final Snapshot snapshot = histogram.getSnapshot();
+    wavefront.send(prefix(name, "count"), histogram.getCount(), timestamp, source, pointTags);
+    wavefront.send(prefix(name, "max"), snapshot.getMax(), timestamp, source, pointTags);
+    wavefront.send(prefix(name, "mean"), snapshot.getMean(), timestamp, source, pointTags);
+    wavefront.send(prefix(name, "min"), snapshot.getMin(), timestamp, source, pointTags);
+    wavefront.send(prefix(name, "stddev"), snapshot.getStdDev(), timestamp, source, pointTags);
+    wavefront.send(prefix(name, "p50"), snapshot.getMedian(), timestamp, source, pointTags);
+    wavefront.send(prefix(name, "p75"), snapshot.get75thPercentile(), timestamp, source, pointTags);
+    wavefront.send(prefix(name, "p95"), snapshot.get95thPercentile(), timestamp, source, pointTags);
+    wavefront.send(prefix(name, "p98"), snapshot.get98thPercentile(), timestamp, source, pointTags);
+    wavefront.send(prefix(name, "p99"), snapshot.get99thPercentile(), timestamp, source, pointTags);
+    wavefront.send(prefix(name, "p999"), snapshot.get999thPercentile(), timestamp, source, pointTags);
+  }
 
-    private void reportCounter(String name, Counter counter, long timestamp) throws IOException {
-        wavefront.send(prefix(name, "count"), counter.getCount(), timestamp, source, pointTags);
-    }
+  private void reportCounter(String name, Counter counter, long timestamp) throws IOException {
+    wavefront.send(prefix(name, "count"), counter.getCount(), timestamp, source, pointTags);
+  }
 
-    private void reportGauge(String name, Gauge<Number> gauge, long timestamp) throws IOException {
-        wavefront.send(prefix(name), gauge.getValue().doubleValue(), timestamp, source, pointTags);
-    }
+  private void reportGauge(String name, Gauge<Number> gauge, long timestamp) throws IOException {
+    wavefront.send(prefix(name), gauge.getValue().doubleValue(), timestamp, source, pointTags);
+  }
 
-    private String prefix(String... components) {
-        return MetricRegistry.name(prefix, components);
-    }
-
+  private String prefix(String... components) {
+    return MetricRegistry.name(prefix, components);
+  }
 }

--- a/dropwizard-metrics/3.1/src/main/java/com/wavefront/integrations/metrics/WavefrontReporter.java
+++ b/dropwizard-metrics/3.1/src/main/java/com/wavefront/integrations/metrics/WavefrontReporter.java
@@ -1,0 +1,378 @@
+package com.wavefront.integrations.metrics;
+
+import com.codahale.metrics.*;
+import com.codahale.metrics.jvm.BufferPoolMetricSet;
+import com.codahale.metrics.jvm.ClassLoadingGaugeSet;
+import com.codahale.metrics.jvm.FileDescriptorRatioGauge;
+import com.codahale.metrics.jvm.GarbageCollectorMetricSet;
+import com.codahale.metrics.jvm.MemoryUsageGaugeSet;
+import com.wavefront.integrations.Wavefront;
+import com.wavefront.integrations.WavefrontSender;
+
+import java.lang.management.ManagementFactory;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.SortedMap;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * A reporter which publishes metric values to a Wavefront Proxy.
+ *
+ */
+public class WavefrontReporter extends ScheduledReporter {
+    /**
+     * Returns a new {@link Builder} for {@link WavefrontReporter}.
+     *
+     * @param registry the registry to report
+     * @return a {@link Builder} instance for a {@link WavefrontReporter}
+     */
+    public static Builder forRegistry(MetricRegistry registry) {
+        return new Builder(registry);
+    }
+
+    /**
+     * A builder for {@link WavefrontReporter} instances. Defaults to not using a prefix, using the
+     * default clock, converting rates to events/second, converting durations to milliseconds, 
+     * a host named "unknown", no point Tags, and not filtering any metrics.
+     */
+    public static class Builder {
+        private final MetricRegistry registry;
+        private Clock clock;
+        private String prefix;
+        private TimeUnit rateUnit;
+        private TimeUnit durationUnit;
+        private MetricFilter filter;
+        private String source;
+        private Map<String, String> pointTags;
+        private boolean includeJvmMetrics;
+
+        private Builder(MetricRegistry registry) {
+            this.registry = registry;
+            this.clock = Clock.defaultClock();
+            this.prefix = null;
+            this.rateUnit = TimeUnit.SECONDS;
+            this.durationUnit = TimeUnit.MILLISECONDS;
+            this.filter = MetricFilter.ALL;
+            this.source = "dropwizard-metrics";
+            this.pointTags = new HashMap<String, String>();
+            this.includeJvmMetrics = false;
+        }
+
+        /**
+         * Use the given {@link Clock} instance for the time. Defaults to Clock.defaultClock()
+         *
+         * @param clock a {@link Clock} instance
+         * @return {@code this}
+         */
+        public Builder withClock(Clock clock) {
+            this.clock = clock;
+            return this;
+        }
+
+        /**
+         * Prefix all metric names with the given string. Defaults to null.
+         *
+         * @param prefix the prefix for all metric names
+         * @return {@code this}
+         */
+        public Builder prefixedWith(String prefix) {
+            this.prefix = prefix;
+            return this;
+        }
+        
+        /**
+         * Set the host for this reporter. This is equivalent to withSource.
+         *
+         * @param host the host for all metrics
+         * @return {@code this}
+         */
+        public Builder withHost(String host) {
+            this.source = host;
+            return this;
+        }
+        
+        /**
+         * Set the source for this reporter. This is equivalent to withHost.
+         *
+         * @param source the host for all metrics
+         * @return {@code this}
+         */
+        public Builder withSource(String source) {
+            this.source = source;
+            return this;
+        }
+        
+        /**
+         * Set the Point Tags for this reporter.
+         *
+         * @param pointTags the pointTags Map for all metrics
+         * @return {@code this}
+         */
+        public Builder withPointTags(Map<String, String> pointTags) {
+            this.pointTags.putAll(pointTags);
+            return this;
+        }
+        
+        /**
+         * Set a point tag for this reporter.
+         *
+         * @param ptagK the key of the Point Tag
+         * @param ptagV the value of the Point Tag
+         * @return {@code this}
+         */
+        public Builder withPointTag(String ptagK, String ptagV) {
+            this.pointTags.put(ptagK, ptagV);
+            return this;
+        }
+
+        /**
+         * Convert rates to the given time unit. Defaults to Seconds.
+         *
+         * @param rateUnit a unit of time
+         * @return {@code this}
+         */
+        public Builder convertRatesTo(TimeUnit rateUnit) {
+            this.rateUnit = rateUnit;
+            return this;
+        }
+
+        /**
+         * Convert durations to the given time unit. Defaults to Milliseconds.
+         *
+         * @param durationUnit a unit of time
+         * @return {@code this}
+         */
+        public Builder convertDurationsTo(TimeUnit durationUnit) {
+            this.durationUnit = durationUnit;
+            return this;
+        }
+
+        /**
+         * Only report metrics which match the given filter. Defaults to MetricFilter.ALL
+         *
+         * @param filter a {@link MetricFilter}
+         * @return {@code this}
+         */
+        public Builder filter(MetricFilter filter) {
+            this.filter = filter;
+            return this;
+        }
+        
+        /**
+         * Include JVM Metrics from this Reporter.
+         * 
+         * @return
+         */
+        public Builder withJvmMetrics() {
+        	this.includeJvmMetrics = true;
+        	return this;
+        }
+
+        /**
+         * Builds a {@link WavefrontReporter} with the given properties, sending metrics using the
+         * given {@link WavefrontSender}.
+         *
+         * @param Wavefront a {@link WavefrontSender}
+         * @return a {@link WavefrontReporter}
+         */
+        public WavefrontReporter build(String proxyHostname, int proxyPort) {
+            return new WavefrontReporter(registry,
+                                        proxyHostname,
+                                        proxyPort,
+                                        clock,
+                                        prefix,
+                                        source,
+                                        pointTags,
+                                        rateUnit,
+                                        durationUnit,
+                                        filter,
+                                        includeJvmMetrics);
+        }
+    }
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(WavefrontReporter.class);
+
+    private final WavefrontSender wavefront;
+    private final Clock clock;
+    private final String prefix;
+    private final String source;
+    private final Map<String, String> pointTags;
+
+    private WavefrontReporter(MetricRegistry registry,
+    						 String proxyHostname,
+    						 int proxyPort,
+                             final Clock clock,
+                             String prefix,
+                             String source,
+                             Map<String, String> pointTags,
+                             TimeUnit rateUnit,
+                             TimeUnit durationUnit,
+                             MetricFilter filter,
+                             boolean includeJvmMetrics) {
+        super(registry, "wavefront-reporter", filter, rateUnit, durationUnit);
+        this.wavefront = new Wavefront(proxyHostname, proxyPort);
+        this.clock = clock;
+        this.prefix = prefix;
+        this.source = source;       
+        this.pointTags = pointTags;
+        
+		if (includeJvmMetrics) {
+			registry.register("jvm.uptime", new Gauge<Long>() {
+				@Override
+				public Long getValue() {
+					return ManagementFactory.getRuntimeMXBean().getUptime();
+				}
+			});
+			registry.register("jvm.current_time", new Gauge<Long>() {
+				@Override
+				public Long getValue() {
+					return clock.getTime();
+				}
+			});
+			registry.register("jvm.classes", new ClassLoadingGaugeSet());
+			registry.register("jvm.fd_usage", new FileDescriptorRatioGauge());
+			registry.register("jvm.buffers", new BufferPoolMetricSet(ManagementFactory.getPlatformMBeanServer()));
+			registry.register("jvm.gc", new GarbageCollectorMetricSet());
+			registry.register("jvm.memory", new MemoryUsageGaugeSet());
+		}
+    }
+
+    @Override
+    public void report(SortedMap<String, Gauge> gauges,
+                       SortedMap<String, Counter> counters,
+                       SortedMap<String, Histogram> histograms,
+                       SortedMap<String, Meter> meters,
+                       SortedMap<String, Timer> timers) {
+        final long timestamp = clock.getTime() / 1000;
+
+        try {
+            if (!wavefront.isConnected()) {
+    	          wavefront.connect();
+            }
+
+            for (Map.Entry<String, Gauge> entry : gauges.entrySet()) {
+            	if (entry.getValue() instanceof Number) {
+            		reportGauge(entry.getKey(), entry.getValue(), timestamp);
+            	}
+            }
+
+            for (Map.Entry<String, Counter> entry : counters.entrySet()) {
+                reportCounter(entry.getKey(), entry.getValue(), timestamp);
+            }
+
+            for (Map.Entry<String, Histogram> entry : histograms.entrySet()) {
+                reportHistogram(entry.getKey(), entry.getValue(), timestamp);
+            }
+
+            for (Map.Entry<String, Meter> entry : meters.entrySet()) {
+                reportMetered(entry.getKey(), entry.getValue(), timestamp);
+            }
+
+            for (Map.Entry<String, Timer> entry : timers.entrySet()) {
+                reportTimer(entry.getKey(), entry.getValue(), timestamp);
+            }
+
+            wavefront.flush();
+        } catch (IOException e) {
+            LOGGER.warn("Unable to report to Wavefront", wavefront, e);
+            try {
+                wavefront.close();
+            } catch (IOException e1) {
+                LOGGER.warn("Error closing Wavefront", wavefront, e);
+            }
+        }
+    }
+
+    @Override
+    public void stop() {
+        try {
+            super.stop();
+        } finally {
+            try {
+                wavefront.close();
+            } catch (IOException e) {
+                LOGGER.debug("Error disconnecting from Wavefront", wavefront, e);
+            }
+        }
+    }
+
+    private void reportTimer(String name, Timer timer, long timestamp) throws IOException {
+        final Snapshot snapshot = timer.getSnapshot();
+
+        wavefront.send(prefix(name, "max"), convertDuration(snapshot.getMax()), timestamp, source, pointTags);
+        wavefront.send(prefix(name, "mean"), convertDuration(snapshot.getMean()), timestamp, source, pointTags);
+        wavefront.send(prefix(name, "min"), convertDuration(snapshot.getMin()), timestamp, source, pointTags);
+        wavefront.send(prefix(name, "stddev"),
+                      convertDuration(snapshot.getStdDev()),
+                      timestamp, source, pointTags);
+        wavefront.send(prefix(name, "p50"),
+                      convertDuration(snapshot.getMedian()),
+                      timestamp, source, pointTags);
+        wavefront.send(prefix(name, "p75"),
+                      convertDuration(snapshot.get75thPercentile()),
+                      timestamp, source, pointTags);
+        wavefront.send(prefix(name, "p95"),
+                      convertDuration(snapshot.get95thPercentile()),
+                      timestamp, source, pointTags);
+        wavefront.send(prefix(name, "p98"),
+                      convertDuration(snapshot.get98thPercentile()),
+                      timestamp, source, pointTags);
+        wavefront.send(prefix(name, "p99"),
+                      convertDuration(snapshot.get99thPercentile()),
+                      timestamp, source, pointTags);
+        wavefront.send(prefix(name, "p999"),
+                      convertDuration(snapshot.get999thPercentile()),
+                      timestamp, source, pointTags);
+
+        reportMetered(name, timer, timestamp);
+    }
+
+    private void reportMetered(String name, Metered meter, long timestamp) throws IOException {
+        wavefront.send(prefix(name, "count"), meter.getCount(), timestamp, source, pointTags);
+        wavefront.send(prefix(name, "m1_rate"),
+                      convertRate(meter.getOneMinuteRate()),
+                      timestamp, source, pointTags);
+        wavefront.send(prefix(name, "m5_rate"),
+                      convertRate(meter.getFiveMinuteRate()),
+                      timestamp, source, pointTags);
+        wavefront.send(prefix(name, "m15_rate"),
+                      convertRate(meter.getFifteenMinuteRate()),
+                      timestamp, source, pointTags);
+        wavefront.send(prefix(name, "mean_rate"),
+                      convertRate(meter.getMeanRate()),
+                      timestamp, source, pointTags);
+    }
+
+    private void reportHistogram(String name, Histogram histogram, long timestamp) throws IOException {
+        final Snapshot snapshot = histogram.getSnapshot();
+        wavefront.send(prefix(name, "count"), histogram.getCount(), timestamp, source, pointTags);
+        wavefront.send(prefix(name, "max"), snapshot.getMax(), timestamp, source, pointTags);
+        wavefront.send(prefix(name, "mean"), snapshot.getMean(), timestamp, source, pointTags);
+        wavefront.send(prefix(name, "min"), snapshot.getMin(), timestamp, source, pointTags);
+        wavefront.send(prefix(name, "stddev"), snapshot.getStdDev(), timestamp, source, pointTags);
+        wavefront.send(prefix(name, "p50"), snapshot.getMedian(), timestamp, source, pointTags);
+        wavefront.send(prefix(name, "p75"), snapshot.get75thPercentile(), timestamp, source, pointTags);
+        wavefront.send(prefix(name, "p95"), snapshot.get95thPercentile(), timestamp, source, pointTags);
+        wavefront.send(prefix(name, "p98"), snapshot.get98thPercentile(), timestamp, source, pointTags);
+        wavefront.send(prefix(name, "p99"), snapshot.get99thPercentile(), timestamp, source, pointTags);
+        wavefront.send(prefix(name, "p999"), snapshot.get999thPercentile(), timestamp, source, pointTags);
+    }
+
+    private void reportCounter(String name, Counter counter, long timestamp) throws IOException {
+        wavefront.send(prefix(name, "count"), counter.getCount(), timestamp, source, pointTags);
+    }
+
+    private void reportGauge(String name, Gauge<Number> gauge, long timestamp) throws IOException {
+        wavefront.send(prefix(name), gauge.getValue().doubleValue(), timestamp, source, pointTags);
+    }
+
+    private String prefix(String... components) {
+        return MetricRegistry.name(prefix, components);
+    }
+
+}

--- a/dropwizard-metrics/3.1/src/main/java/com/wavefront/integrations/metrics/WavefrontReporter.java
+++ b/dropwizard-metrics/3.1/src/main/java/com/wavefront/integrations/metrics/WavefrontReporter.java
@@ -6,6 +6,7 @@ import com.codahale.metrics.jvm.ClassLoadingGaugeSet;
 import com.codahale.metrics.jvm.FileDescriptorRatioGauge;
 import com.codahale.metrics.jvm.GarbageCollectorMetricSet;
 import com.codahale.metrics.jvm.MemoryUsageGaugeSet;
+import com.codahale.metrics.jvm.ThreadStatesGaugeSet;
 import com.wavefront.integrations.Wavefront;
 import com.wavefront.integrations.WavefrontSender;
 
@@ -239,6 +240,7 @@ public class WavefrontReporter extends ScheduledReporter {
       registry.register("jvm.buffers", new BufferPoolMetricSet(ManagementFactory.getPlatformMBeanServer()));
       registry.register("jvm.gc", new GarbageCollectorMetricSet());
       registry.register("jvm.memory", new MemoryUsageGaugeSet());
+      registry.register("jvm.thread-states", new ThreadStatesGaugeSet());
     }
   }
 

--- a/dropwizard-metrics/3.1/src/main/java/com/wavefront/integrations/metrics/WavefrontReporter.java
+++ b/dropwizard-metrics/3.1/src/main/java/com/wavefront/integrations/metrics/WavefrontReporter.java
@@ -256,7 +256,7 @@ public class WavefrontReporter extends ScheduledReporter {
       }
 
       for (Map.Entry<String, Gauge> entry : gauges.entrySet()) {
-        if (entry.getValue() instanceof Number) {
+        if (entry.getValue().getValue() instanceof Number) {
           reportGauge(entry.getKey(), entry.getValue(), timestamp);
         }
       }

--- a/dropwizard-metrics/4.0/README.md
+++ b/dropwizard-metrics/4.0/README.md
@@ -20,12 +20,12 @@ You will need both the DropWizard `metrics-core` and the Wavefront `metrics-wave
    <dependency>
       <groupId>io.dropwizard.metrics</groupId>
       <artifactId>metrics-core</artifactId>
-      <version>https://github.com/dropwizard/metrics</version>
+      <version>4.0.0-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>com.wavefront</groupId>
-      <artifactId>metrics-wavefront</artifactId>
-      <version>4.0.0</version>
+      <artifactId>dropwizard-metrics-4.0</artifactId>
+      <version>3.7</version>
     </dependency>
 ```
 

--- a/dropwizard-metrics/4.0/README.md
+++ b/dropwizard-metrics/4.0/README.md
@@ -14,7 +14,7 @@ It is designed to be used with [the 4.0.0-SNAPSHOT of Dropwizard Metrics](https:
 
 ### Setting up Maven
 
-You will need both the DropWizard `metrics-core` and the Wavefront `metrics-wavefront` libraries as dependencies:
+You will need both the DropWizard `metrics-core` and the Wavefront `metrics-wavefront` libraries as dependencies. Logging depends on `org.slf4j`:
 
 ```Maven
    <dependency>
@@ -26,6 +26,11 @@ You will need both the DropWizard `metrics-core` and the Wavefront `metrics-wave
       <groupId>com.wavefront</groupId>
       <artifactId>dropwizard-metrics-4.0</artifactId>
       <version>3.7</version>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-simple</artifactId>
+      <version>1.7.16</version>
     </dependency>
 ```
 
@@ -46,15 +51,15 @@ Then for example to create a Reporter which will emit data every 10 seconds for:
 you would do something like this:
 
 ```java
-MetricRegistry registry = new MetricRegistry();   	
-Map<String, String> tag = new HashMap<String,String>();  	
-tag.put("type", "counter");
-MetricName name = new MetricName("requests", tag);
-Counter counter = metrics.counter(metricName);
+MetricRegistry metrics = new MetricRegistry();   	
+Map<String, String> tags = new HashMap<String,String>();  	
+tags.put("type", "counter");
+MetricName name = new MetricName("requests", tags);
+Counter counter = metrics.counter(name);
     			
 // NB If you specify the same tag name at the Metric and Reporter 
 // level the Metric level one will overwrite it
-WavefrontReporter reporter = WavefrontReporter.forRegistry(registry)
+WavefrontReporter reporter = WavefrontReporter.forRegistry(metrics)
         .withSource("app-1.company.com")
         .withPointTag("dc", "dallas")
     	.withPointTag("service", "query")

--- a/dropwizard-metrics/4.0/README.md
+++ b/dropwizard-metrics/4.0/README.md
@@ -1,0 +1,103 @@
+# Wavefront dropwizard-metrics Reporter
+
+This is a Wavefront Reporter for latest Master of [Dropwizard Metrics](https://github.com/dropwizard/metrics) (formerly Coda Hale & Yammer Metrics).
+
+It sends data to the Wavefront service via a Proxy and supports Point Tags being assigned both at the Reporter level _and_ the Metric level.
+
+## Usage
+
+This Reporter sends data via to Wavefront via a Proxy. Version 3.5 or later is required. You can easily install the Proxy by following [these instructions](https://github.com/wavefrontHQ/install).
+
+To use the Reporter you'll need to know the hostname and port (which by default is 2878) where the Wavefront Proxy is running.
+
+It is designed to be used with [the 4.0.0-SNAPSHOT of Dropwizard Metrics](https://github.com/dropwizard/metrics).
+
+### Setting up Maven
+
+You will need both the DropWizard `metrics-core` and the Wavefront `metrics-wavefront` libraries as dependencies:
+
+```Maven
+   <dependency>
+      <groupId>io.dropwizard.metrics</groupId>
+      <artifactId>metrics-core</artifactId>
+      <version>https://github.com/dropwizard/metrics</version>
+    </dependency>
+    <dependency>
+      <groupId>com.wavefront</groupId>
+      <artifactId>metrics-wavefront</artifactId>
+      <version>4.0.0</version>
+    </dependency>
+```
+
+### Example Usage
+
+The Wavefront Reporter lets you use DropWizard metrics exactly as you normally would. See its [getting started guide](https://dropwizard.github.io/metrics/3.1.0/getting-started/) if you haven't used it before.
+
+It simply gives you a new Reporter that will seamlessly work with Wavefront. First `import com.wavefront.integrations.metrics.WavefrontReporter;`
+
+Then for example to create a Reporter which will emit data every 10 seconds for:
+
+- A `MetricsRegistry` named `metrics` with a Counter that has a tag named `type`
+- A Wavefront Proxy on `localhost` at port `2878`
+- Data that should appear in Wavefront as `source=app-1.company.com`
+- Two point tags named `dc` and `service` on the Reporter
+- All metrics in Wavefront should be prefixed with "dropwizard."
+
+you would do something like this:
+
+```java
+MetricRegistry registry = new MetricRegistry();   	
+Map<String, String> tag = new HashMap<String,String>();  	
+tag.put("type", "counter");
+MetricName name = new MetricName("requests", tag);
+Counter counter = metrics.counter(metricName);
+    			
+// NB If you specify the same tag name at the Metric and Reporter 
+// level the Metric level one will overwrite it
+WavefrontReporter reporter = WavefrontReporter.forRegistry(registry)
+        .withSource("app-1.company.com")
+        .withPointTag("dc", "dallas")
+    	.withPointTag("service", "query")
+    	.prefixedWith("dropwizard")
+    	.build("localhost", 2878);
+    	
+reporter.start(10, TimeUnit.SECONDS);
+```
+
+You must provide the source using the `.withSource(String source)` method and pass the Hostname and Port of the Wavefront Proxy using the `.build(String hostname, long port)` method.
+
+The Reporter provides all the same options that the [GraphiteReporter](http://metrics.dropwizard.io/3.1.0/manual/graphite/) does. By default:
+
+- There is no prefix on the Metrics
+- Rates will be converted to Seconds
+- Durations will be converted to Milliseconds
+- `MetricFilter.ALL` will be used for the Filter
+- `Clock.defaultClock()` will be used for the Clock
+
+In addition you can also:
+
+- Supply point tags for the Reporter to use. There are two ways to specify point tags at the Reporter level, individually using `.withPointTag(String tagK, String tagV)` or create a `Map<String,String>` and call `.withPointTags(my-map)` to do many at once. Note that if you specify the same tag name at the Metric and Reporter level the Metric level one will overwrite it.
+- Call `.withJvmMetrics()` when building the Reporter if you want it to add some default JVM metrics to the given MetricsRegistry.
+
+If `.withJvmMetrics()` is used the following metrics will be added to the registry:
+
+```java
+registry.register("jvm.uptime", new Gauge<Long>() {
+    @Override
+	public Long getValue() {
+	    return ManagementFactory.getRuntimeMXBean().getUptime();
+	}
+});
+registry.register("jvm.current_time", new Gauge<Long>() {
+    @Override
+	public Long getValue() {
+	    return clock.getTime();
+    }
+});
+    
+registry.register("jvm.classes", new ClassLoadingGaugeSet());
+registry.register("jvm.fd_usage", new FileDescriptorRatioGauge());
+registry.register("jvm.buffers", new BufferPoolMetricSet(ManagementFactory.getPlatformMBeanServer()));
+registry.register("jvm.gc", new GarbageCollectorMetricSet());
+registry.register("jvm.memory", new MemoryUsageGaugeSet());
+```

--- a/dropwizard-metrics/4.0/pom.xml
+++ b/dropwizard-metrics/4.0/pom.xml
@@ -9,9 +9,9 @@
     <relativePath>../../pom.xml</relativePath>
   </parent>
   
-  <artifactId>metrics-wavefront</artifactId>
-  <version>4.0.0</version>
-  <name>Wavefront Dropwizard Metrics Reporter</name>
+  <artifactId>dropwizard-metrics-4.0</artifactId>
+  <version>3.7-SNAPSHOT</version>
+  <name>Wavefront Dropwizard Metrics 4.0 Reporter</name>
   <description>Report metrics via the Wavefront Proxy</description>
 
   <dependencies>

--- a/dropwizard-metrics/4.0/pom.xml
+++ b/dropwizard-metrics/4.0/pom.xml
@@ -1,0 +1,35 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>com.wavefront</groupId>
+    <artifactId>wavefront</artifactId>
+    <version>3.7-SNAPSHOT</version>
+    <relativePath>../../pom.xml</relativePath>
+  </parent>
+  
+  <artifactId>metrics-wavefront</artifactId>
+  <version>4.0.0</version>
+  <name>Wavefront Dropwizard Metrics Reporter</name>
+  <description>Report metrics via the Wavefront Proxy</description>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.wavefront</groupId>
+      <artifactId>java-client</artifactId>
+      <version>3.7-SNAPSHOT</version>
+    </dependency>
+    <dependency>
+      <groupId>io.dropwizard.metrics</groupId>
+      <artifactId>metrics-core</artifactId>
+      <version>4.0.0-SNAPSHOT</version>
+    </dependency>
+    <dependency>
+      <groupId>io.dropwizard.metrics</groupId>
+      <artifactId>metrics-jvm</artifactId>
+      <version>4.0.0-SNAPSHOT</version>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/dropwizard-metrics/4.0/src/main/java/com/wavefront/integrations/metrics/WavefrontReporter.java
+++ b/dropwizard-metrics/4.0/src/main/java/com/wavefront/integrations/metrics/WavefrontReporter.java
@@ -3,6 +3,7 @@ package com.wavefront.integrations.metrics;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import io.dropwizard.metrics.jvm.ThreadStatesGaugeSet;
 import com.wavefront.integrations.Wavefront;
 import com.wavefront.integrations.WavefrontSender;
 
@@ -252,6 +253,7 @@ public class WavefrontReporter extends ScheduledReporter {
       registry.register("jvm.buffers", new BufferPoolMetricSet(ManagementFactory.getPlatformMBeanServer()));
       registry.register("jvm.gc", new GarbageCollectorMetricSet());
       registry.register("jvm.memory", new MemoryUsageGaugeSet());
+      registry.register("jvm.thread-states", new ThreadStatesGaugeSet());
     }
   }
 

--- a/dropwizard-metrics/4.0/src/main/java/com/wavefront/integrations/metrics/WavefrontReporter.java
+++ b/dropwizard-metrics/4.0/src/main/java/com/wavefront/integrations/metrics/WavefrontReporter.java
@@ -269,7 +269,7 @@ public class WavefrontReporter extends ScheduledReporter {
       }
 
       for (Entry<MetricName, Gauge> entry : gauges.entrySet()) {
-        if (entry.getValue() instanceof Number) {
+        if (entry.getValue().getValue() instanceof Number) {
           reportGauge(entry.getKey(), entry.getValue(), timestamp, combineTags(reporterPTags, entry));
         }
       }

--- a/dropwizard-metrics/4.0/src/main/java/com/wavefront/integrations/metrics/WavefrontReporter.java
+++ b/dropwizard-metrics/4.0/src/main/java/com/wavefront/integrations/metrics/WavefrontReporter.java
@@ -1,0 +1,397 @@
+package com.wavefront.integrations.metrics;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.wavefront.integrations.Wavefront;
+import com.wavefront.integrations.WavefrontSender;
+
+import io.dropwizard.metrics.Clock;
+import io.dropwizard.metrics.Counter;
+import io.dropwizard.metrics.Gauge;
+import io.dropwizard.metrics.Histogram;
+import io.dropwizard.metrics.Meter;
+import io.dropwizard.metrics.Metered;
+import io.dropwizard.metrics.MetricFilter;
+import io.dropwizard.metrics.MetricName;
+import io.dropwizard.metrics.MetricRegistry;
+import io.dropwizard.metrics.ScheduledReporter;
+import io.dropwizard.metrics.Snapshot;
+import io.dropwizard.metrics.Timer;
+import io.dropwizard.metrics.jvm.BufferPoolMetricSet;
+import io.dropwizard.metrics.jvm.ClassLoadingGaugeSet;
+import io.dropwizard.metrics.jvm.FileDescriptorRatioGauge;
+import io.dropwizard.metrics.jvm.GarbageCollectorMetricSet;
+import io.dropwizard.metrics.jvm.MemoryUsageGaugeSet;
+
+import java.io.IOException;
+import java.lang.management.ManagementFactory;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.SortedMap;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * A reporter which publishes metric values to a Wavefront Proxy.
+ *
+ */
+public class WavefrontReporter extends ScheduledReporter {
+    /**
+     * Returns a new {@link Builder} for {@link WavefrontReporter}.
+     *
+     * @param registry the registry to report
+     * @return a {@link Builder} instance for a {@link WavefrontReporter}
+     */
+    public static Builder forRegistry(MetricRegistry registry) {
+        return new Builder(registry);
+    }
+
+    /**
+     * A builder for {@link WavefrontReporter} instances. Defaults to not using a prefix, using the
+     * default clock, converting rates to events/second, converting durations to milliseconds, 
+     * a host named "unknown", no point Tags, and not filtering metrics.
+     */
+    public static class Builder {
+        private final MetricRegistry registry;
+        private Clock clock;
+        private String prefix;
+        private TimeUnit rateUnit;
+        private TimeUnit durationUnit;
+        private MetricFilter filter;
+        private String source;
+        private Map<String, String> reporterPTags;
+        private boolean includeJvmMetrics;
+
+        private Builder(MetricRegistry registry) {
+            this.registry = registry;
+            this.clock = Clock.defaultClock();
+            this.prefix = null;
+            this.rateUnit = TimeUnit.SECONDS;
+            this.durationUnit = TimeUnit.MILLISECONDS;
+            this.filter = MetricFilter.ALL;
+            this.source = "dropwizard-metrics";
+            this.reporterPTags = new HashMap<String, String>();
+            this.includeJvmMetrics = false;
+        }
+
+        /**
+         * Use the given {@link Clock} instance for the time. Defaults to Clock.defaultClock()
+         *
+         * @param clock a {@link Clock} instance
+         * @return {@code this}
+         */
+        public Builder withClock(Clock clock) {
+            this.clock = clock;
+            return this;
+        }
+
+        /**
+         * Prefix all metric names with the given string. Defaults to null.
+         *
+         * @param prefix the prefix for all metric names
+         * @return {@code this}
+         */
+        public Builder prefixedWith(String prefix) {
+            this.prefix = prefix;
+            return this;
+        }
+        
+        /**
+         * Set the host for this reporter. This is equivalent to withSource.
+         *
+         * @param host the host for all metrics
+         * @return {@code this}
+         */
+        public Builder withHost(String host) {
+            this.source = host;
+            return this;
+        }
+        
+        /**
+         * Set the source for this reporter. This is equivalent to withHost.
+         *
+         * @param source the host for all metrics
+         * @return {@code this}
+         */
+        public Builder withSource(String source) {
+            this.source = source;
+            return this;
+        }
+        
+        /**
+         * Set the Point Tags for this reporter.
+         *
+         * @param metricPTags the metricPTags Map for all metrics
+         * @return {@code this}
+         */
+        public Builder withPointTags(Map<String, String> reporterPTags) {
+            this.reporterPTags.putAll(reporterPTags);
+            return this;
+        }
+        
+        /**
+         * Set a point tag for this reporter.
+         *
+         * @param ptagK the key of the Point Tag
+         * @param ptagV the value of the Point Tag
+         * @return {@code this}
+         */
+        public Builder withPointTag(String ptagK, String ptagV) {
+            this.reporterPTags.put(ptagK, ptagV);
+            return this;
+        }
+
+        /**
+         * Convert rates to the given time unit. Defaults to Seconds.
+         *
+         * @param rateUnit a unit of time
+         * @return {@code this}
+         */
+        public Builder convertRatesTo(TimeUnit rateUnit) {
+            this.rateUnit = rateUnit;
+            return this;
+        }
+
+        /**
+         * Convert durations to the given time unit. Defaults to Milliseconds.
+         *
+         * @param durationUnit a unit of time
+         * @return {@code this}
+         */
+        public Builder convertDurationsTo(TimeUnit durationUnit) {
+            this.durationUnit = durationUnit;
+            return this;
+        }
+
+        /**
+         * Only report metrics which match the given filter. Defaults to MetricFilter.ALL
+         *
+         * @param filter a {@link MetricFilter}
+         * @return {@code this}
+         */
+        public Builder filter(MetricFilter filter) {
+            this.filter = filter;
+            return this;
+        }
+        
+        /**
+         * Include JVM Metrics from this Reporter.
+         * 
+         * @return
+         */
+        public Builder withJvmMetrics() {
+        	this.includeJvmMetrics = true;
+        	return this;
+        }
+
+        /**
+         * Builds a {@link WavefrontReporter} with the given properties, sending metrics using the
+         * given {@link WavefrontSender}.
+         *
+         * @param Wavefront a {@link WavefrontSender}
+         * @return a {@link WavefrontReporter}
+         */
+        public WavefrontReporter build(String proxyHostname, int proxyPort) {
+            return new WavefrontReporter(registry,
+                                        proxyHostname,
+                                        proxyPort,
+                                        clock,
+                                        prefix,
+                                        source,
+                                        reporterPTags,
+                                        rateUnit,
+                                        durationUnit,
+                                        filter,
+                                        includeJvmMetrics);
+        }
+    }
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(WavefrontReporter.class);
+
+    private final WavefrontSender wavefront;
+    private final Clock clock;
+    private final MetricName prefix;
+    private final String source;
+    private final Map<String, String> reporterPTags;
+
+    private WavefrontReporter(MetricRegistry registry,
+			                  String proxyHostname,
+			                  int proxyPort,
+			                  final Clock clock,
+			                  String prefix,
+			                  String source,
+			                  Map<String, String> reporterPTags,
+			                  TimeUnit rateUnit,
+			                  TimeUnit durationUnit,
+			                  MetricFilter filter,
+			                  boolean includeJvmMetrics) {
+
+        super(registry, "wavefront-reporter", filter, rateUnit, durationUnit);
+        this.wavefront = new Wavefront(proxyHostname, proxyPort);
+        this.clock = clock;
+        this.prefix = MetricName.build(prefix);
+        this.source = source;
+        this.reporterPTags = reporterPTags;
+        
+		if (includeJvmMetrics) {
+			registry.register("jvm.uptime", new Gauge<Long>() {
+				@Override
+				public Long getValue() {
+					return ManagementFactory.getRuntimeMXBean().getUptime();
+				}
+			});
+			registry.register("jvm.current_time", new Gauge<Long>() {
+				@Override
+				public Long getValue() {
+					return clock.getTime();
+				}
+			});
+			registry.register("jvm.classes", new ClassLoadingGaugeSet());
+			registry.register("jvm.fd_usage", new FileDescriptorRatioGauge());
+			registry.register("jvm.buffers", new BufferPoolMetricSet(ManagementFactory.getPlatformMBeanServer()));
+			registry.register("jvm.gc", new GarbageCollectorMetricSet());
+			registry.register("jvm.memory", new MemoryUsageGaugeSet());
+		}
+    }
+
+    @Override
+    public void report(SortedMap<MetricName, Gauge> gauges,
+                       SortedMap<MetricName, Counter> counters,
+                       SortedMap<MetricName, Histogram> histograms,
+                       SortedMap<MetricName, Meter> meters,
+                       SortedMap<MetricName, Timer> timers) {
+        final long timestamp = clock.getTime() / 1000;
+
+        try {
+            if (!wavefront.isConnected()) {
+    	          wavefront.connect();
+            }
+
+            for (Entry<MetricName, Gauge> entry : gauges.entrySet()) {
+            	if (entry.getValue() instanceof Number) {
+            		reportGauge(entry.getKey(), entry.getValue(), timestamp, combineTags(reporterPTags, entry));
+            	}
+            }
+
+            for (Map.Entry<MetricName, Counter> entry : counters.entrySet()) {
+                reportCounter(entry.getKey(), entry.getValue(), timestamp, combineTags(reporterPTags, entry));
+            }
+
+            for (Map.Entry<MetricName, Histogram> entry : histograms.entrySet()) {
+                reportHistogram(entry.getKey(), entry.getValue(), timestamp, combineTags(reporterPTags, entry));
+            }
+
+            for (Map.Entry<MetricName, Meter> entry : meters.entrySet()) {
+                reportMetered(entry.getKey(), entry.getValue(), timestamp, combineTags(reporterPTags, entry));
+            }
+
+            for (Map.Entry<MetricName, Timer> entry : timers.entrySet()) {
+                reportTimer(entry.getKey(), entry.getValue(), timestamp, combineTags(reporterPTags, entry));
+            }
+
+            wavefront.flush();
+        } catch (IOException e) {
+            LOGGER.warn("Unable to report to Wavefront", wavefront, e);
+            try {
+                wavefront.close();
+            } catch (IOException e1) {
+                LOGGER.warn("Error closing Wavefront", wavefront, e1);
+            }
+        }
+    }
+
+    @Override
+    public void stop() {
+        try {
+            super.stop();
+        } finally {
+            try {
+                wavefront.close();
+            } catch (IOException e) {
+                LOGGER.debug("Error disconnecting from Wavefront", wavefront, e);
+            }
+        }
+    }
+    
+    private void reportTimer(MetricName name, Timer timer, long timestamp, Map<String, String> combinedTags) throws IOException {
+        final Snapshot snapshot = timer.getSnapshot();
+
+        wavefront.send(prefix(name, "max"), convertDuration(snapshot.getMax()), timestamp, source, combinedTags);
+        wavefront.send(prefix(name, "mean"), convertDuration(snapshot.getMean()), timestamp, source, combinedTags);
+        wavefront.send(prefix(name, "min"), convertDuration(snapshot.getMin()), timestamp, source, combinedTags);
+        wavefront.send(prefix(name, "stddev"),
+                      convertDuration(snapshot.getStdDev()),
+                      timestamp, source, combinedTags);
+        wavefront.send(prefix(name, "p50"),
+                      convertDuration(snapshot.getMedian()),
+                      timestamp, source, combinedTags);
+        wavefront.send(prefix(name, "p75"),
+                      convertDuration(snapshot.get75thPercentile()),
+                      timestamp, source, combinedTags);
+        wavefront.send(prefix(name, "p95"),
+                      convertDuration(snapshot.get95thPercentile()),
+                      timestamp, source, combinedTags);
+        wavefront.send(prefix(name, "p98"),
+                      convertDuration(snapshot.get98thPercentile()),
+                      timestamp, source, combinedTags);
+        wavefront.send(prefix(name, "p99"),
+                      convertDuration(snapshot.get99thPercentile()),
+                      timestamp, source, combinedTags);
+        wavefront.send(prefix(name, "p999"),
+                      convertDuration(snapshot.get999thPercentile()),
+                      timestamp, source, combinedTags);
+
+        reportMetered(name, timer, timestamp, combinedTags);
+    }
+    
+    private void reportMetered(MetricName name, Metered meter, long timestamp, Map<String, String> combinedTags) throws IOException {
+        wavefront.send(prefix(name, "count"), meter.getCount(), timestamp, source, combinedTags);
+        wavefront.send(prefix(name, "m1_rate"),
+                      convertRate(meter.getOneMinuteRate()),
+                      timestamp, source, combinedTags);
+        wavefront.send(prefix(name, "m5_rate"),
+                      convertRate(meter.getFiveMinuteRate()),
+                      timestamp, source, combinedTags);
+        wavefront.send(prefix(name, "m15_rate"),
+                      convertRate(meter.getFifteenMinuteRate()),
+                      timestamp, source, combinedTags);
+        wavefront.send(prefix(name, "mean_rate"),
+                      convertRate(meter.getMeanRate()),
+                      timestamp, source, combinedTags);
+    }
+
+    private void reportHistogram(MetricName name, Histogram histogram, long timestamp, Map<String, String> combinedTags) throws IOException {
+        final Snapshot snapshot = histogram.getSnapshot();
+        wavefront.send(prefix(name, "count"), histogram.getCount(), timestamp, source, combinedTags);
+        wavefront.send(prefix(name, "max"), snapshot.getMax(), timestamp, source, combinedTags);
+        wavefront.send(prefix(name, "mean"), snapshot.getMean(), timestamp, source, combinedTags);
+        wavefront.send(prefix(name, "min"), snapshot.getMin(), timestamp, source, combinedTags);
+        wavefront.send(prefix(name, "stddev"), snapshot.getStdDev(), timestamp, source, combinedTags);
+        wavefront.send(prefix(name, "p50"), snapshot.getMedian(), timestamp, source, combinedTags);
+        wavefront.send(prefix(name, "p75"), snapshot.get75thPercentile(), timestamp, source, combinedTags);
+        wavefront.send(prefix(name, "p95"), snapshot.get95thPercentile(), timestamp, source, combinedTags);
+        wavefront.send(prefix(name, "p98"), snapshot.get98thPercentile(), timestamp, source, combinedTags);
+        wavefront.send(prefix(name, "p99"), snapshot.get99thPercentile(), timestamp, source, combinedTags);
+        wavefront.send(prefix(name, "p999"), snapshot.get999thPercentile(), timestamp, source, combinedTags);
+    }
+
+    private void reportCounter(MetricName name, Counter counter, long timestamp, Map<String, String> combinedTags) throws IOException {
+        wavefront.send(prefix(name, "count"), counter.getCount(), timestamp, source, combinedTags);
+    }
+    
+    private void reportGauge(MetricName name, Gauge<Number> gauge, long timestamp, Map<String, String> combinedTags) throws IOException {
+        wavefront.send(prefix(name), gauge.getValue().doubleValue(), timestamp, source, combinedTags);
+    }
+
+    private String prefix(MetricName name, String... components) {
+        return MetricName.join(MetricName.join(prefix, name), MetricName.build(components)).getKey();
+    }
+    
+    private Map<String, String> combineTags(Map<String, String> rTags, Map.Entry<MetricName, ?> entry) {
+    	Map<String, String> combinedTags = new HashMap<String, String>();
+    	combinedTags.putAll(rTags);
+    	combinedTags.putAll(entry.getKey().getTags());
+    	return combinedTags;
+    }
+}

--- a/dropwizard-metrics/4.0/src/main/java/com/wavefront/integrations/metrics/WavefrontReporter.java
+++ b/dropwizard-metrics/4.0/src/main/java/com/wavefront/integrations/metrics/WavefrontReporter.java
@@ -37,361 +37,361 @@ import java.util.concurrent.TimeUnit;
  *
  */
 public class WavefrontReporter extends ScheduledReporter {
+  /**
+   * Returns a new {@link Builder} for {@link WavefrontReporter}.
+   *
+   * @param registry the registry to report
+   * @return a {@link Builder} instance for a {@link WavefrontReporter}
+   */
+  public static Builder forRegistry(MetricRegistry registry) {
+    return new Builder(registry);
+  }
+
+  /**
+   * A builder for {@link WavefrontReporter} instances. Defaults to not using a prefix, using the
+   * default clock, converting rates to events/second, converting durations to milliseconds,
+   * a host named "unknown", no point Tags, and not filtering metrics.
+   */
+  public static class Builder {
+    private final MetricRegistry registry;
+    private Clock clock;
+    private String prefix;
+    private TimeUnit rateUnit;
+    private TimeUnit durationUnit;
+    private MetricFilter filter;
+    private String source;
+    private Map<String, String> reporterPTags;
+    private boolean includeJvmMetrics;
+
+    private Builder(MetricRegistry registry) {
+      this.registry = registry;
+      this.clock = Clock.defaultClock();
+      this.prefix = null;
+      this.rateUnit = TimeUnit.SECONDS;
+      this.durationUnit = TimeUnit.MILLISECONDS;
+      this.filter = MetricFilter.ALL;
+      this.source = "dropwizard-metrics";
+      this.reporterPTags = new HashMap<String, String>();
+      this.includeJvmMetrics = false;
+    }
+
     /**
-     * Returns a new {@link Builder} for {@link WavefrontReporter}.
+     * Use the given {@link Clock} instance for the time. Defaults to Clock.defaultClock()
      *
-     * @param registry the registry to report
-     * @return a {@link Builder} instance for a {@link WavefrontReporter}
+     * @param clock a {@link Clock} instance
+     * @return {@code this}
      */
-    public static Builder forRegistry(MetricRegistry registry) {
-        return new Builder(registry);
+    public Builder withClock(Clock clock) {
+      this.clock = clock;
+      return this;
     }
 
     /**
-     * A builder for {@link WavefrontReporter} instances. Defaults to not using a prefix, using the
-     * default clock, converting rates to events/second, converting durations to milliseconds, 
-     * a host named "unknown", no point Tags, and not filtering metrics.
+     * Prefix all metric names with the given string. Defaults to null.
+     *
+     * @param prefix the prefix for all metric names
+     * @return {@code this}
      */
-    public static class Builder {
-        private final MetricRegistry registry;
-        private Clock clock;
-        private String prefix;
-        private TimeUnit rateUnit;
-        private TimeUnit durationUnit;
-        private MetricFilter filter;
-        private String source;
-        private Map<String, String> reporterPTags;
-        private boolean includeJvmMetrics;
-
-        private Builder(MetricRegistry registry) {
-            this.registry = registry;
-            this.clock = Clock.defaultClock();
-            this.prefix = null;
-            this.rateUnit = TimeUnit.SECONDS;
-            this.durationUnit = TimeUnit.MILLISECONDS;
-            this.filter = MetricFilter.ALL;
-            this.source = "dropwizard-metrics";
-            this.reporterPTags = new HashMap<String, String>();
-            this.includeJvmMetrics = false;
-        }
-
-        /**
-         * Use the given {@link Clock} instance for the time. Defaults to Clock.defaultClock()
-         *
-         * @param clock a {@link Clock} instance
-         * @return {@code this}
-         */
-        public Builder withClock(Clock clock) {
-            this.clock = clock;
-            return this;
-        }
-
-        /**
-         * Prefix all metric names with the given string. Defaults to null.
-         *
-         * @param prefix the prefix for all metric names
-         * @return {@code this}
-         */
-        public Builder prefixedWith(String prefix) {
-            this.prefix = prefix;
-            return this;
-        }
-        
-        /**
-         * Set the host for this reporter. This is equivalent to withSource.
-         *
-         * @param host the host for all metrics
-         * @return {@code this}
-         */
-        public Builder withHost(String host) {
-            this.source = host;
-            return this;
-        }
-        
-        /**
-         * Set the source for this reporter. This is equivalent to withHost.
-         *
-         * @param source the host for all metrics
-         * @return {@code this}
-         */
-        public Builder withSource(String source) {
-            this.source = source;
-            return this;
-        }
-        
-        /**
-         * Set the Point Tags for this reporter.
-         *
-         * @param metricPTags the metricPTags Map for all metrics
-         * @return {@code this}
-         */
-        public Builder withPointTags(Map<String, String> reporterPTags) {
-            this.reporterPTags.putAll(reporterPTags);
-            return this;
-        }
-        
-        /**
-         * Set a point tag for this reporter.
-         *
-         * @param ptagK the key of the Point Tag
-         * @param ptagV the value of the Point Tag
-         * @return {@code this}
-         */
-        public Builder withPointTag(String ptagK, String ptagV) {
-            this.reporterPTags.put(ptagK, ptagV);
-            return this;
-        }
-
-        /**
-         * Convert rates to the given time unit. Defaults to Seconds.
-         *
-         * @param rateUnit a unit of time
-         * @return {@code this}
-         */
-        public Builder convertRatesTo(TimeUnit rateUnit) {
-            this.rateUnit = rateUnit;
-            return this;
-        }
-
-        /**
-         * Convert durations to the given time unit. Defaults to Milliseconds.
-         *
-         * @param durationUnit a unit of time
-         * @return {@code this}
-         */
-        public Builder convertDurationsTo(TimeUnit durationUnit) {
-            this.durationUnit = durationUnit;
-            return this;
-        }
-
-        /**
-         * Only report metrics which match the given filter. Defaults to MetricFilter.ALL
-         *
-         * @param filter a {@link MetricFilter}
-         * @return {@code this}
-         */
-        public Builder filter(MetricFilter filter) {
-            this.filter = filter;
-            return this;
-        }
-        
-        /**
-         * Include JVM Metrics from this Reporter.
-         * 
-         * @return
-         */
-        public Builder withJvmMetrics() {
-        	this.includeJvmMetrics = true;
-        	return this;
-        }
-
-        /**
-         * Builds a {@link WavefrontReporter} with the given properties, sending metrics using the
-         * given {@link WavefrontSender}.
-         *
-         * @param Wavefront a {@link WavefrontSender}
-         * @return a {@link WavefrontReporter}
-         */
-        public WavefrontReporter build(String proxyHostname, int proxyPort) {
-            return new WavefrontReporter(registry,
-                                        proxyHostname,
-                                        proxyPort,
-                                        clock,
-                                        prefix,
-                                        source,
-                                        reporterPTags,
-                                        rateUnit,
-                                        durationUnit,
-                                        filter,
-                                        includeJvmMetrics);
-        }
+    public Builder prefixedWith(String prefix) {
+      this.prefix = prefix;
+      return this;
     }
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(WavefrontReporter.class);
-
-    private final WavefrontSender wavefront;
-    private final Clock clock;
-    private final MetricName prefix;
-    private final String source;
-    private final Map<String, String> reporterPTags;
-
-    private WavefrontReporter(MetricRegistry registry,
-			                  String proxyHostname,
-			                  int proxyPort,
-			                  final Clock clock,
-			                  String prefix,
-			                  String source,
-			                  Map<String, String> reporterPTags,
-			                  TimeUnit rateUnit,
-			                  TimeUnit durationUnit,
-			                  MetricFilter filter,
-			                  boolean includeJvmMetrics) {
-
-        super(registry, "wavefront-reporter", filter, rateUnit, durationUnit);
-        this.wavefront = new Wavefront(proxyHostname, proxyPort);
-        this.clock = clock;
-        this.prefix = MetricName.build(prefix);
-        this.source = source;
-        this.reporterPTags = reporterPTags;
-        
-		if (includeJvmMetrics) {
-			registry.register("jvm.uptime", new Gauge<Long>() {
-				@Override
-				public Long getValue() {
-					return ManagementFactory.getRuntimeMXBean().getUptime();
-				}
-			});
-			registry.register("jvm.current_time", new Gauge<Long>() {
-				@Override
-				public Long getValue() {
-					return clock.getTime();
-				}
-			});
-			registry.register("jvm.classes", new ClassLoadingGaugeSet());
-			registry.register("jvm.fd_usage", new FileDescriptorRatioGauge());
-			registry.register("jvm.buffers", new BufferPoolMetricSet(ManagementFactory.getPlatformMBeanServer()));
-			registry.register("jvm.gc", new GarbageCollectorMetricSet());
-			registry.register("jvm.memory", new MemoryUsageGaugeSet());
-		}
+    /**
+     * Set the host for this reporter. This is equivalent to withSource.
+     *
+     * @param host the host for all metrics
+     * @return {@code this}
+     */
+    public Builder withHost(String host) {
+      this.source = host;
+      return this;
     }
 
-    @Override
-    public void report(SortedMap<MetricName, Gauge> gauges,
-                       SortedMap<MetricName, Counter> counters,
-                       SortedMap<MetricName, Histogram> histograms,
-                       SortedMap<MetricName, Meter> meters,
-                       SortedMap<MetricName, Timer> timers) {
-        final long timestamp = clock.getTime() / 1000;
+    /**
+     * Set the source for this reporter. This is equivalent to withHost.
+     *
+     * @param source the host for all metrics
+     * @return {@code this}
+     */
+    public Builder withSource(String source) {
+      this.source = source;
+      return this;
+    }
 
-        try {
-            if (!wavefront.isConnected()) {
-    	          wavefront.connect();
-            }
+    /**
+     * Set the Point Tags for this reporter.
+     *
+     * @param metricPTags the metricPTags Map for all metrics
+     * @return {@code this}
+     */
+    public Builder withPointTags(Map<String, String> reporterPTags) {
+      this.reporterPTags.putAll(reporterPTags);
+      return this;
+    }
 
-            for (Entry<MetricName, Gauge> entry : gauges.entrySet()) {
-            	if (entry.getValue() instanceof Number) {
-            		reportGauge(entry.getKey(), entry.getValue(), timestamp, combineTags(reporterPTags, entry));
-            	}
-            }
+    /**
+     * Set a point tag for this reporter.
+     *
+     * @param ptagK the key of the Point Tag
+     * @param ptagV the value of the Point Tag
+     * @return {@code this}
+     */
+    public Builder withPointTag(String ptagK, String ptagV) {
+      this.reporterPTags.put(ptagK, ptagV);
+      return this;
+    }
 
-            for (Map.Entry<MetricName, Counter> entry : counters.entrySet()) {
-                reportCounter(entry.getKey(), entry.getValue(), timestamp, combineTags(reporterPTags, entry));
-            }
+    /**
+     * Convert rates to the given time unit. Defaults to Seconds.
+     *
+     * @param rateUnit a unit of time
+     * @return {@code this}
+     */
+    public Builder convertRatesTo(TimeUnit rateUnit) {
+      this.rateUnit = rateUnit;
+      return this;
+    }
 
-            for (Map.Entry<MetricName, Histogram> entry : histograms.entrySet()) {
-                reportHistogram(entry.getKey(), entry.getValue(), timestamp, combineTags(reporterPTags, entry));
-            }
+    /**
+     * Convert durations to the given time unit. Defaults to Milliseconds.
+     *
+     * @param durationUnit a unit of time
+     * @return {@code this}
+     */
+    public Builder convertDurationsTo(TimeUnit durationUnit) {
+      this.durationUnit = durationUnit;
+      return this;
+    }
 
-            for (Map.Entry<MetricName, Meter> entry : meters.entrySet()) {
-                reportMetered(entry.getKey(), entry.getValue(), timestamp, combineTags(reporterPTags, entry));
-            }
+    /**
+     * Only report metrics which match the given filter. Defaults to MetricFilter.ALL
+     *
+     * @param filter a {@link MetricFilter}
+     * @return {@code this}
+     */
+    public Builder filter(MetricFilter filter) {
+      this.filter = filter;
+      return this;
+    }
 
-            for (Map.Entry<MetricName, Timer> entry : timers.entrySet()) {
-                reportTimer(entry.getKey(), entry.getValue(), timestamp, combineTags(reporterPTags, entry));
-            }
+    /**
+     * Include JVM Metrics from this Reporter.
+     *
+     * @return
+     */
+    public Builder withJvmMetrics() {
+      this.includeJvmMetrics = true;
+      return this;
+    }
 
-            wavefront.flush();
-        } catch (IOException e) {
-            LOGGER.warn("Unable to report to Wavefront", wavefront, e);
-            try {
-                wavefront.close();
-            } catch (IOException e1) {
-                LOGGER.warn("Error closing Wavefront", wavefront, e1);
-            }
+    /**
+     * Builds a {@link WavefrontReporter} with the given properties, sending metrics using the
+     * given {@link WavefrontSender}.
+     *
+     * @param Wavefront a {@link WavefrontSender}
+     * @return a {@link WavefrontReporter}
+     */
+    public WavefrontReporter build(String proxyHostname, int proxyPort) {
+      return new WavefrontReporter(registry,
+                                   proxyHostname,
+                                   proxyPort,
+                                   clock,
+                                   prefix,
+                                   source,
+                                   reporterPTags,
+                                   rateUnit,
+                                   durationUnit,
+                                   filter,
+                                   includeJvmMetrics);
+    }
+  }
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(WavefrontReporter.class);
+
+  private final WavefrontSender wavefront;
+  private final Clock clock;
+  private final MetricName prefix;
+  private final String source;
+  private final Map<String, String> reporterPTags;
+
+  private WavefrontReporter(MetricRegistry registry,
+                            String proxyHostname,
+                            int proxyPort,
+                            final Clock clock,
+                            String prefix,
+                            String source,
+                            Map<String, String> reporterPTags,
+                            TimeUnit rateUnit,
+                            TimeUnit durationUnit,
+                            MetricFilter filter,
+                            boolean includeJvmMetrics) {
+
+    super(registry, "wavefront-reporter", filter, rateUnit, durationUnit);
+    this.wavefront = new Wavefront(proxyHostname, proxyPort);
+    this.clock = clock;
+    this.prefix = MetricName.build(prefix);
+    this.source = source;
+    this.reporterPTags = reporterPTags;
+
+    if (includeJvmMetrics) {
+      registry.register("jvm.uptime", new Gauge<Long>() {
+          @Override
+          public Long getValue() {
+            return ManagementFactory.getRuntimeMXBean().getUptime();
+          }
+        });
+      registry.register("jvm.current_time", new Gauge<Long>() {
+          @Override
+          public Long getValue() {
+            return clock.getTime();
+          }
+        });
+      registry.register("jvm.classes", new ClassLoadingGaugeSet());
+      registry.register("jvm.fd_usage", new FileDescriptorRatioGauge());
+      registry.register("jvm.buffers", new BufferPoolMetricSet(ManagementFactory.getPlatformMBeanServer()));
+      registry.register("jvm.gc", new GarbageCollectorMetricSet());
+      registry.register("jvm.memory", new MemoryUsageGaugeSet());
+    }
+  }
+
+  @Override
+  public void report(SortedMap<MetricName, Gauge> gauges,
+                     SortedMap<MetricName, Counter> counters,
+                     SortedMap<MetricName, Histogram> histograms,
+                     SortedMap<MetricName, Meter> meters,
+                     SortedMap<MetricName, Timer> timers) {
+    final long timestamp = clock.getTime() / 1000;
+
+    try {
+      if (!wavefront.isConnected()) {
+        wavefront.connect();
+      }
+
+      for (Entry<MetricName, Gauge> entry : gauges.entrySet()) {
+        if (entry.getValue() instanceof Number) {
+          reportGauge(entry.getKey(), entry.getValue(), timestamp, combineTags(reporterPTags, entry));
         }
-    }
+      }
 
-    @Override
-    public void stop() {
-        try {
-            super.stop();
-        } finally {
-            try {
-                wavefront.close();
-            } catch (IOException e) {
-                LOGGER.debug("Error disconnecting from Wavefront", wavefront, e);
-            }
-        }
-    }
-    
-    private void reportTimer(MetricName name, Timer timer, long timestamp, Map<String, String> combinedTags) throws IOException {
-        final Snapshot snapshot = timer.getSnapshot();
+      for (Map.Entry<MetricName, Counter> entry : counters.entrySet()) {
+        reportCounter(entry.getKey(), entry.getValue(), timestamp, combineTags(reporterPTags, entry));
+      }
 
-        wavefront.send(prefix(name, "max"), convertDuration(snapshot.getMax()), timestamp, source, combinedTags);
-        wavefront.send(prefix(name, "mean"), convertDuration(snapshot.getMean()), timestamp, source, combinedTags);
-        wavefront.send(prefix(name, "min"), convertDuration(snapshot.getMin()), timestamp, source, combinedTags);
-        wavefront.send(prefix(name, "stddev"),
-                      convertDuration(snapshot.getStdDev()),
-                      timestamp, source, combinedTags);
-        wavefront.send(prefix(name, "p50"),
-                      convertDuration(snapshot.getMedian()),
-                      timestamp, source, combinedTags);
-        wavefront.send(prefix(name, "p75"),
-                      convertDuration(snapshot.get75thPercentile()),
-                      timestamp, source, combinedTags);
-        wavefront.send(prefix(name, "p95"),
-                      convertDuration(snapshot.get95thPercentile()),
-                      timestamp, source, combinedTags);
-        wavefront.send(prefix(name, "p98"),
-                      convertDuration(snapshot.get98thPercentile()),
-                      timestamp, source, combinedTags);
-        wavefront.send(prefix(name, "p99"),
-                      convertDuration(snapshot.get99thPercentile()),
-                      timestamp, source, combinedTags);
-        wavefront.send(prefix(name, "p999"),
-                      convertDuration(snapshot.get999thPercentile()),
-                      timestamp, source, combinedTags);
+      for (Map.Entry<MetricName, Histogram> entry : histograms.entrySet()) {
+        reportHistogram(entry.getKey(), entry.getValue(), timestamp, combineTags(reporterPTags, entry));
+      }
 
-        reportMetered(name, timer, timestamp, combinedTags);
-    }
-    
-    private void reportMetered(MetricName name, Metered meter, long timestamp, Map<String, String> combinedTags) throws IOException {
-        wavefront.send(prefix(name, "count"), meter.getCount(), timestamp, source, combinedTags);
-        wavefront.send(prefix(name, "m1_rate"),
-                      convertRate(meter.getOneMinuteRate()),
-                      timestamp, source, combinedTags);
-        wavefront.send(prefix(name, "m5_rate"),
-                      convertRate(meter.getFiveMinuteRate()),
-                      timestamp, source, combinedTags);
-        wavefront.send(prefix(name, "m15_rate"),
-                      convertRate(meter.getFifteenMinuteRate()),
-                      timestamp, source, combinedTags);
-        wavefront.send(prefix(name, "mean_rate"),
-                      convertRate(meter.getMeanRate()),
-                      timestamp, source, combinedTags);
-    }
+      for (Map.Entry<MetricName, Meter> entry : meters.entrySet()) {
+        reportMetered(entry.getKey(), entry.getValue(), timestamp, combineTags(reporterPTags, entry));
+      }
 
-    private void reportHistogram(MetricName name, Histogram histogram, long timestamp, Map<String, String> combinedTags) throws IOException {
-        final Snapshot snapshot = histogram.getSnapshot();
-        wavefront.send(prefix(name, "count"), histogram.getCount(), timestamp, source, combinedTags);
-        wavefront.send(prefix(name, "max"), snapshot.getMax(), timestamp, source, combinedTags);
-        wavefront.send(prefix(name, "mean"), snapshot.getMean(), timestamp, source, combinedTags);
-        wavefront.send(prefix(name, "min"), snapshot.getMin(), timestamp, source, combinedTags);
-        wavefront.send(prefix(name, "stddev"), snapshot.getStdDev(), timestamp, source, combinedTags);
-        wavefront.send(prefix(name, "p50"), snapshot.getMedian(), timestamp, source, combinedTags);
-        wavefront.send(prefix(name, "p75"), snapshot.get75thPercentile(), timestamp, source, combinedTags);
-        wavefront.send(prefix(name, "p95"), snapshot.get95thPercentile(), timestamp, source, combinedTags);
-        wavefront.send(prefix(name, "p98"), snapshot.get98thPercentile(), timestamp, source, combinedTags);
-        wavefront.send(prefix(name, "p99"), snapshot.get99thPercentile(), timestamp, source, combinedTags);
-        wavefront.send(prefix(name, "p999"), snapshot.get999thPercentile(), timestamp, source, combinedTags);
-    }
+      for (Map.Entry<MetricName, Timer> entry : timers.entrySet()) {
+        reportTimer(entry.getKey(), entry.getValue(), timestamp, combineTags(reporterPTags, entry));
+      }
 
-    private void reportCounter(MetricName name, Counter counter, long timestamp, Map<String, String> combinedTags) throws IOException {
-        wavefront.send(prefix(name, "count"), counter.getCount(), timestamp, source, combinedTags);
+      wavefront.flush();
+    } catch (IOException e) {
+      LOGGER.warn("Unable to report to Wavefront", wavefront, e);
+      try {
+        wavefront.close();
+      } catch (IOException e1) {
+        LOGGER.warn("Error closing Wavefront", wavefront, e1);
+      }
     }
-    
-    private void reportGauge(MetricName name, Gauge<Number> gauge, long timestamp, Map<String, String> combinedTags) throws IOException {
-        wavefront.send(prefix(name), gauge.getValue().doubleValue(), timestamp, source, combinedTags);
-    }
+  }
 
-    private String prefix(MetricName name, String... components) {
-        return MetricName.join(MetricName.join(prefix, name), MetricName.build(components)).getKey();
+  @Override
+  public void stop() {
+    try {
+      super.stop();
+    } finally {
+      try {
+        wavefront.close();
+      } catch (IOException e) {
+        LOGGER.debug("Error disconnecting from Wavefront", wavefront, e);
+      }
     }
-    
-    private Map<String, String> combineTags(Map<String, String> rTags, Map.Entry<MetricName, ?> entry) {
-    	Map<String, String> combinedTags = new HashMap<String, String>();
-    	combinedTags.putAll(rTags);
-    	combinedTags.putAll(entry.getKey().getTags());
-    	return combinedTags;
-    }
+  }
+
+  private void reportTimer(MetricName name, Timer timer, long timestamp, Map<String, String> combinedTags) throws IOException {
+    final Snapshot snapshot = timer.getSnapshot();
+
+    wavefront.send(prefix(name, "max"), convertDuration(snapshot.getMax()), timestamp, source, combinedTags);
+    wavefront.send(prefix(name, "mean"), convertDuration(snapshot.getMean()), timestamp, source, combinedTags);
+    wavefront.send(prefix(name, "min"), convertDuration(snapshot.getMin()), timestamp, source, combinedTags);
+    wavefront.send(prefix(name, "stddev"),
+                   convertDuration(snapshot.getStdDev()),
+                   timestamp, source, combinedTags);
+    wavefront.send(prefix(name, "p50"),
+                   convertDuration(snapshot.getMedian()),
+                   timestamp, source, combinedTags);
+    wavefront.send(prefix(name, "p75"),
+                   convertDuration(snapshot.get75thPercentile()),
+                   timestamp, source, combinedTags);
+    wavefront.send(prefix(name, "p95"),
+                   convertDuration(snapshot.get95thPercentile()),
+                   timestamp, source, combinedTags);
+    wavefront.send(prefix(name, "p98"),
+                   convertDuration(snapshot.get98thPercentile()),
+                   timestamp, source, combinedTags);
+    wavefront.send(prefix(name, "p99"),
+                   convertDuration(snapshot.get99thPercentile()),
+                   timestamp, source, combinedTags);
+    wavefront.send(prefix(name, "p999"),
+                   convertDuration(snapshot.get999thPercentile()),
+                   timestamp, source, combinedTags);
+
+    reportMetered(name, timer, timestamp, combinedTags);
+  }
+
+  private void reportMetered(MetricName name, Metered meter, long timestamp, Map<String, String> combinedTags) throws IOException {
+    wavefront.send(prefix(name, "count"), meter.getCount(), timestamp, source, combinedTags);
+    wavefront.send(prefix(name, "m1_rate"),
+                   convertRate(meter.getOneMinuteRate()),
+                   timestamp, source, combinedTags);
+    wavefront.send(prefix(name, "m5_rate"),
+                   convertRate(meter.getFiveMinuteRate()),
+                   timestamp, source, combinedTags);
+    wavefront.send(prefix(name, "m15_rate"),
+                   convertRate(meter.getFifteenMinuteRate()),
+                   timestamp, source, combinedTags);
+    wavefront.send(prefix(name, "mean_rate"),
+                   convertRate(meter.getMeanRate()),
+                   timestamp, source, combinedTags);
+  }
+
+  private void reportHistogram(MetricName name, Histogram histogram, long timestamp, Map<String, String> combinedTags) throws IOException {
+    final Snapshot snapshot = histogram.getSnapshot();
+    wavefront.send(prefix(name, "count"), histogram.getCount(), timestamp, source, combinedTags);
+    wavefront.send(prefix(name, "max"), snapshot.getMax(), timestamp, source, combinedTags);
+    wavefront.send(prefix(name, "mean"), snapshot.getMean(), timestamp, source, combinedTags);
+    wavefront.send(prefix(name, "min"), snapshot.getMin(), timestamp, source, combinedTags);
+    wavefront.send(prefix(name, "stddev"), snapshot.getStdDev(), timestamp, source, combinedTags);
+    wavefront.send(prefix(name, "p50"), snapshot.getMedian(), timestamp, source, combinedTags);
+    wavefront.send(prefix(name, "p75"), snapshot.get75thPercentile(), timestamp, source, combinedTags);
+    wavefront.send(prefix(name, "p95"), snapshot.get95thPercentile(), timestamp, source, combinedTags);
+    wavefront.send(prefix(name, "p98"), snapshot.get98thPercentile(), timestamp, source, combinedTags);
+    wavefront.send(prefix(name, "p99"), snapshot.get99thPercentile(), timestamp, source, combinedTags);
+    wavefront.send(prefix(name, "p999"), snapshot.get999thPercentile(), timestamp, source, combinedTags);
+  }
+
+  private void reportCounter(MetricName name, Counter counter, long timestamp, Map<String, String> combinedTags) throws IOException {
+    wavefront.send(prefix(name, "count"), counter.getCount(), timestamp, source, combinedTags);
+  }
+
+  private void reportGauge(MetricName name, Gauge<Number> gauge, long timestamp, Map<String, String> combinedTags) throws IOException {
+    wavefront.send(prefix(name), gauge.getValue().doubleValue(), timestamp, source, combinedTags);
+  }
+
+  private String prefix(MetricName name, String... components) {
+    return MetricName.join(MetricName.join(prefix, name), MetricName.build(components)).getKey();
+  }
+
+  private Map<String, String> combineTags(Map<String, String> rTags, Map.Entry<MetricName, ?> entry) {
+    Map<String, String> combinedTags = new HashMap<String, String>();
+    combinedTags.putAll(rTags);
+    combinedTags.putAll(entry.getKey().getTags());
+    return combinedTags;
+  }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -10,6 +10,8 @@
     <module>java-lib</module>
     <module>proxy</module>
     <module>java-client</module>
+    <module>dropwizard-metrics/3.1</module>
+    <module>dropwizard-metrics/4.0</module>
   </modules>
   <packaging>pom</packaging>
 


### PR DESCRIPTION
This adds DropWizard Metrics Reporters which use the Wavefront Proxy for the stable version of DropWizard Metrics (which only supports point tags at the Reporter level) and the latest Master of DropWizard Metrics (which supports point tags at the Reporter and Metric level)

It seems like the way JVM metrics are collected has changed quite a bit since the YammerMetrics version that the existing JsonMetricsReporter uses (For instance the VirtualMachineMetrics class no longer exists). 

I have tried to implement something similar via the .includeJvmMetrics() option that can be passed to the Reporter at build time. A user could also ignore that option (it is not on by default) and add exactly whichever JVM metrics they wish to their own MetricsRegistry.