### PR TITLE
Configureable custom source tags

### DIFF
--- a/java-lib/src/main/java/com/wavefront/ingester/GraphiteDecoder.java
+++ b/java-lib/src/main/java/com/wavefront/ingester/GraphiteDecoder.java
@@ -5,6 +5,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.base.Splitter;
 import com.google.common.collect.Lists;
 
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.regex.Pattern;
 
@@ -26,19 +27,24 @@ public class GraphiteDecoder implements Decoder {
       .appendOptionalTimestamp().whiteSpace()
       .appendAnnotationsConsumer().whiteSpace().build();
   private final String hostName;
+  private LinkedHashSet<String> customSourceTags;
 
-  public GraphiteDecoder() {
+  public GraphiteDecoder(LinkedHashSet<String> customSourceTags) {
     this.hostName = "unknown";
+    Preconditions.checkNotNull(customSourceTags);
+    this.customSourceTags = customSourceTags;
   }
 
-  public GraphiteDecoder(String hostName) {
+  public GraphiteDecoder(String hostName, LinkedHashSet<String> customSourceTags) {
     Preconditions.checkNotNull(hostName);
     this.hostName = hostName;
+    Preconditions.checkNotNull(customSourceTags);
+    this.customSourceTags = customSourceTags;
   }
 
   @Override
   public void decodeReportPoints(String msg, List<ReportPoint> out, String customerId) {
-    ReportPoint point = FORMAT.drive(msg, hostName, customerId);
+    ReportPoint point = FORMAT.drive(msg, hostName, customerId, customSourceTags);
     if (out != null) {
       out.add(point);
     }

--- a/java-lib/src/main/java/com/wavefront/ingester/GraphiteDecoder.java
+++ b/java-lib/src/main/java/com/wavefront/ingester/GraphiteDecoder.java
@@ -5,7 +5,6 @@ import com.google.common.base.Preconditions;
 import com.google.common.base.Splitter;
 import com.google.common.collect.Lists;
 
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.regex.Pattern;
 
@@ -27,15 +26,15 @@ public class GraphiteDecoder implements Decoder {
       .appendOptionalTimestamp().whiteSpace()
       .appendAnnotationsConsumer().whiteSpace().build();
   private final String hostName;
-  private LinkedHashSet<String> customSourceTags;
+  private List<String> customSourceTags;
 
-  public GraphiteDecoder(LinkedHashSet<String> customSourceTags) {
+  public GraphiteDecoder(List<String> customSourceTags) {
     this.hostName = "unknown";
     Preconditions.checkNotNull(customSourceTags);
     this.customSourceTags = customSourceTags;
   }
 
-  public GraphiteDecoder(String hostName, LinkedHashSet<String> customSourceTags) {
+  public GraphiteDecoder(String hostName, List<String> customSourceTags) {
     Preconditions.checkNotNull(hostName);
     this.hostName = hostName;
     Preconditions.checkNotNull(customSourceTags);

--- a/java-lib/src/main/java/com/wavefront/ingester/GraphiteHostAnnotator.java
+++ b/java-lib/src/main/java/com/wavefront/ingester/GraphiteHostAnnotator.java
@@ -1,6 +1,5 @@
 package com.wavefront.ingester;
 
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -17,7 +16,7 @@ public class GraphiteHostAnnotator extends MessageToMessageDecoder<String> {
   private final Pattern sourceExistencePattern;
   private final String hostName;
 
-  public GraphiteHostAnnotator(String hostName, LinkedHashSet<String> customSourceTags) {
+  public GraphiteHostAnnotator(String hostName, List<String> customSourceTags) {
     this.hostName = hostName;
     StringBuffer pattern = new StringBuffer(".+(");
     for (String tag : customSourceTags) {

--- a/java-lib/src/main/java/com/wavefront/ingester/GraphiteHostAnnotator.java
+++ b/java-lib/src/main/java/com/wavefront/ingester/GraphiteHostAnnotator.java
@@ -1,5 +1,6 @@
 package com.wavefront.ingester;
 
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -13,32 +14,29 @@ import io.netty.handler.codec.MessageToMessageDecoder;
  */
 public class GraphiteHostAnnotator extends MessageToMessageDecoder<String> {
 
-  // Host names may have spaces, but the first character must exist and be non-whitespace
-  private static final Pattern HOST_EXISTENCE_PATTERN = Pattern.compile("(.+)(host=[^\\s].+)",
-      Pattern.CASE_INSENSITIVE);
-  private static final Pattern SOURCE_EXISTENCE_PATTERN = Pattern.compile("(.+)(source=[^\\s].+)",
-      Pattern.CASE_INSENSITIVE);
+  private final Pattern sourceExistencePattern;
   private final String hostName;
 
-  public GraphiteHostAnnotator(String hostName) {
+  public GraphiteHostAnnotator(String hostName, LinkedHashSet<String> customSourceTags) {
     this.hostName = hostName;
+    StringBuffer pattern = new StringBuffer(".+(");
+    for (String tag : customSourceTags) {
+      pattern.append(tag);
+      pattern.append("|");
+    }
+    pattern.append("source|host)=[^\\s].+");
+    sourceExistencePattern = Pattern.compile(pattern.toString(), Pattern.CASE_INSENSITIVE);
   }
 
   // Decode from a possibly host-annotated graphite string to a definitely host-annotated graphite string.
   @Override
   protected void decode(ChannelHandlerContext ctx, String msg, List<Object> out) throws Exception {
-    Matcher m = HOST_EXISTENCE_PATTERN.matcher(msg);
+    Matcher m = sourceExistencePattern.matcher(msg);
     if (m.matches()) {
-      // Has a host; add without change
+      // Has a source; add without change
       out.add(msg);
     } else {
-      m = SOURCE_EXISTENCE_PATTERN.matcher(msg);
-      if (m.matches()) {
-        out.add(msg);
-      } else {
-        // No host? Add what we got from the socket
-        out.add(msg + " source=" + hostName);
-      }
+      out.add(msg + " source=" + hostName);
     }
   }
 }

--- a/java-lib/src/main/java/com/wavefront/ingester/IngesterFormatter.java
+++ b/java-lib/src/main/java/com/wavefront/ingester/IngesterFormatter.java
@@ -17,6 +17,7 @@ import org.antlr.v4.runtime.Recognizer;
 import org.antlr.v4.runtime.Token;
 
 import java.util.ArrayDeque;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Queue;
@@ -47,7 +48,7 @@ public class IngesterFormatter {
     this.elements = elements;
   }
 
-  public ReportPoint drive(String input, String defaultHostName, String customerId) {
+  public ReportPoint drive(String input, String defaultHostName, String customerId, LinkedHashSet<String> customSourceTags) {
     DSWrapperLexer lexer = new DSWrapperLexer(new ANTLRInputStream(input));
     // note that other errors are not thrown by the lexer and hence we only need to handle the
     // syntaxError case.
@@ -107,7 +108,13 @@ public class IngesterFormatter {
         annotations.put("_tag", annotations.remove("tag"));
       }
       if (host == null) {
-        host = annotations.remove("fqdn");
+        // iterate over the set of custom tags, breaking when one is found
+        for (String tag : customSourceTags) {
+          host = annotations.remove(tag);
+          if (host != null) {
+            break;
+          }
+        }
       }
     }
     if (host == null) {

--- a/java-lib/src/main/java/com/wavefront/ingester/IngesterFormatter.java
+++ b/java-lib/src/main/java/com/wavefront/ingester/IngesterFormatter.java
@@ -92,7 +92,7 @@ public class IngesterFormatter {
     if (!queue.isEmpty()) {
       throw new RuntimeException("Could not parse: " + input);
     }
-    
+
     String host = null;
     Map<String, String> annotations = point.getAnnotations();
     if (annotations != null) {

--- a/java-lib/src/main/java/com/wavefront/ingester/IngesterFormatter.java
+++ b/java-lib/src/main/java/com/wavefront/ingester/IngesterFormatter.java
@@ -17,7 +17,6 @@ import org.antlr.v4.runtime.Recognizer;
 import org.antlr.v4.runtime.Token;
 
 import java.util.ArrayDeque;
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Queue;
@@ -48,7 +47,7 @@ public class IngesterFormatter {
     this.elements = elements;
   }
 
-  public ReportPoint drive(String input, String defaultHostName, String customerId, LinkedHashSet<String> customSourceTags) {
+  public ReportPoint drive(String input, String defaultHostName, String customerId, List<String> customSourceTags) {
     DSWrapperLexer lexer = new DSWrapperLexer(new ANTLRInputStream(input));
     // note that other errors are not thrown by the lexer and hence we only need to handle the
     // syntaxError case.

--- a/java-lib/src/main/java/com/wavefront/ingester/OpenTSDBDecoder.java
+++ b/java-lib/src/main/java/com/wavefront/ingester/OpenTSDBDecoder.java
@@ -2,6 +2,7 @@ package com.wavefront.ingester;
 
 import com.google.common.base.Preconditions;
 
+import java.util.LinkedHashSet;
 import java.util.List;
 
 import sunnylabs.report.ReportPoint;
@@ -22,19 +23,24 @@ public class OpenTSDBDecoder implements Decoder {
       .appendTimestamp().whiteSpace()
       .appendValue().whiteSpace()
       .appendAnnotationsConsumer().whiteSpace().build();
+  private LinkedHashSet<String> customSourceTags;
 
-  public OpenTSDBDecoder() {
+  public OpenTSDBDecoder(LinkedHashSet<String> customSourceTags) {
     this.hostName = "unknown";
+    Preconditions.checkNotNull(customSourceTags);
+    this.customSourceTags = customSourceTags;
   }
 
-  public OpenTSDBDecoder(String hostName) {
+  public OpenTSDBDecoder(String hostName, LinkedHashSet<String> customSourceTags) {
     Preconditions.checkNotNull(hostName);
     this.hostName = hostName;
+    Preconditions.checkNotNull(customSourceTags);
+    this.customSourceTags = customSourceTags;
   }
 
   @Override
   public void decodeReportPoints(String msg, List<ReportPoint> out, String customerId) {
-    ReportPoint point = FORMAT.drive(msg, hostName, customerId);
+    ReportPoint point = FORMAT.drive(msg, hostName, customerId, customSourceTags);
     if (out != null) {
       out.add(point);
     }
@@ -42,7 +48,7 @@ public class OpenTSDBDecoder implements Decoder {
 
   @Override
   public void decodeReportPoints(String msg, List<ReportPoint> out) {
-    ReportPoint point = FORMAT.drive(msg, hostName, "dummy");
+    ReportPoint point = FORMAT.drive(msg, hostName, "dummy", customSourceTags);
     if (out != null) {
       out.add(point);
     }

--- a/java-lib/src/main/java/com/wavefront/ingester/OpenTSDBDecoder.java
+++ b/java-lib/src/main/java/com/wavefront/ingester/OpenTSDBDecoder.java
@@ -2,7 +2,6 @@ package com.wavefront.ingester;
 
 import com.google.common.base.Preconditions;
 
-import java.util.LinkedHashSet;
 import java.util.List;
 
 import sunnylabs.report.ReportPoint;
@@ -23,15 +22,15 @@ public class OpenTSDBDecoder implements Decoder {
       .appendTimestamp().whiteSpace()
       .appendValue().whiteSpace()
       .appendAnnotationsConsumer().whiteSpace().build();
-  private LinkedHashSet<String> customSourceTags;
+  private List<String> customSourceTags;
 
-  public OpenTSDBDecoder(LinkedHashSet<String> customSourceTags) {
+  public OpenTSDBDecoder(List<String> customSourceTags) {
     this.hostName = "unknown";
     Preconditions.checkNotNull(customSourceTags);
     this.customSourceTags = customSourceTags;
   }
 
-  public OpenTSDBDecoder(String hostName, LinkedHashSet<String> customSourceTags) {
+  public OpenTSDBDecoder(String hostName, List<String> customSourceTags) {
     Preconditions.checkNotNull(hostName);
     this.hostName = hostName;
     Preconditions.checkNotNull(customSourceTags);

--- a/java-lib/src/test/java/com/wavefront/ingester/GraphiteDecoderTest.java
+++ b/java-lib/src/test/java/com/wavefront/ingester/GraphiteDecoderTest.java
@@ -6,6 +6,7 @@ import org.junit.Ignore;
 import org.junit.Test;
 
 import java.util.ArrayList;
+import java.util.LinkedHashSet;
 import java.util.List;
 
 import sunnylabs.report.ReportPoint;
@@ -18,9 +19,11 @@ import static org.junit.Assert.fail;
  */
 public class GraphiteDecoderTest {
 
+  private final static LinkedHashSet<String> emptyCustomSourceTags = new LinkedHashSet<String>();
+
   @Test
   public void testDoubleFormat() throws Exception {
-    GraphiteDecoder decoder = new GraphiteDecoder("localhost");
+    GraphiteDecoder decoder = new GraphiteDecoder("localhost", emptyCustomSourceTags);
     List<ReportPoint> out = new ArrayList<>();
     decoder.decodeReportPoints("tsdb.vehicle.charge.battery_level 93.123e3 host=vehicle_2554", out);
     ReportPoint point = out.get(0);
@@ -92,7 +95,7 @@ public class GraphiteDecoderTest {
 
   @Test
   public void testFormat() throws Exception {
-    GraphiteDecoder decoder = new GraphiteDecoder("localhost");
+    GraphiteDecoder decoder = new GraphiteDecoder("localhost", emptyCustomSourceTags);
     List<ReportPoint> out = new ArrayList<>();
     decoder.decodeReportPoints("tsdb.vehicle.charge.battery_level 93 host=vehicle_2554", out);
     ReportPoint point = out.get(0);
@@ -104,7 +107,7 @@ public class GraphiteDecoderTest {
 
   @Test
   public void testIpV4Host() throws Exception {
-    GraphiteDecoder decoder = new GraphiteDecoder("localhost");
+    GraphiteDecoder decoder = new GraphiteDecoder("localhost", emptyCustomSourceTags);
     List<ReportPoint> out = new ArrayList<>();
     decoder.decodeReportPoints("tsdb.vehicle.charge.battery_level 93 host=10.0.0.1", out);
     ReportPoint point = out.get(0);
@@ -116,7 +119,7 @@ public class GraphiteDecoderTest {
 
   @Test
   public void testIpV6Host() throws Exception {
-    GraphiteDecoder decoder = new GraphiteDecoder("localhost");
+    GraphiteDecoder decoder = new GraphiteDecoder("localhost", emptyCustomSourceTags);
     List<ReportPoint> out = new ArrayList<>();
     decoder.decodeReportPoints("tsdb.vehicle.charge.battery_level 93 host=2001:db8:3333:4444:5555:6666:7777:8888", out);
     ReportPoint point = out.get(0);
@@ -128,7 +131,7 @@ public class GraphiteDecoderTest {
 
   @Test
   public void testFormatWithTimestamp() throws Exception {
-    GraphiteDecoder decoder = new GraphiteDecoder("localhost");
+    GraphiteDecoder decoder = new GraphiteDecoder("localhost", emptyCustomSourceTags);
     List<ReportPoint> out = new ArrayList<>();
     decoder.decodeReportPoints("tsdb.vehicle.charge.battery_level 93 1234567890.246 host=vehicle_2554", out);
     ReportPoint point = out.get(0);
@@ -141,7 +144,7 @@ public class GraphiteDecoderTest {
 
   @Test
   public void testFormatWithNoTags() throws Exception {
-    GraphiteDecoder decoder = new GraphiteDecoder("localhost");
+    GraphiteDecoder decoder = new GraphiteDecoder("localhost", emptyCustomSourceTags);
     List<ReportPoint> out = new ArrayList<>();
     decoder.decodeReportPoints("tsdb.vehicle.charge.battery_level 93", out);
     ReportPoint point = out.get(0);
@@ -152,7 +155,7 @@ public class GraphiteDecoderTest {
 
   @Test
   public void testFormatWithNoTagsAndTimestamp() throws Exception {
-    GraphiteDecoder decoder = new GraphiteDecoder("localhost");
+    GraphiteDecoder decoder = new GraphiteDecoder("localhost", emptyCustomSourceTags);
     List<ReportPoint> out = new ArrayList<>();
     decoder.decodeReportPoints("tsdb.vehicle.charge.battery_level 93 1234567890.246", out);
     ReportPoint point = out.get(0);
@@ -164,7 +167,7 @@ public class GraphiteDecoderTest {
 
   @Test
   public void testDecodeWithNoCustomer() throws Exception {
-    GraphiteDecoder decoder = new GraphiteDecoder();
+    GraphiteDecoder decoder = new GraphiteDecoder(emptyCustomSourceTags);
     List<ReportPoint> out = Lists.newArrayList();
     decoder.decodeReportPoints("vehicle.charge.battery_level 93 host=vehicle_2554", out, "customer");
     ReportPoint point = out.get(0);
@@ -176,7 +179,7 @@ public class GraphiteDecoderTest {
 
   @Test
   public void testDecodeWithNoCustomerWithTimestamp() throws Exception {
-    GraphiteDecoder decoder = new GraphiteDecoder();
+    GraphiteDecoder decoder = new GraphiteDecoder(emptyCustomSourceTags);
     List<ReportPoint> out = Lists.newArrayList();
     decoder.decodeReportPoints("vehicle.charge.battery_level 93 1234567890.246 host=vehicle_2554", out, "customer");
     ReportPoint point = out.get(0);
@@ -189,7 +192,7 @@ public class GraphiteDecoderTest {
 
   @Test
   public void testDecodeWithNoCustomerWithNoTags() throws Exception {
-    GraphiteDecoder decoder = new GraphiteDecoder();
+    GraphiteDecoder decoder = new GraphiteDecoder(emptyCustomSourceTags);
     List<ReportPoint> out = Lists.newArrayList();
     decoder.decodeReportPoints("vehicle.charge.battery_level 93", out, "customer");
     ReportPoint point = out.get(0);
@@ -200,7 +203,7 @@ public class GraphiteDecoderTest {
 
   @Test
   public void testDecodeWithNoCustomerWithNoTagsAndTimestamp() throws Exception {
-    GraphiteDecoder decoder = new GraphiteDecoder();
+    GraphiteDecoder decoder = new GraphiteDecoder(emptyCustomSourceTags);
     List<ReportPoint> out = Lists.newArrayList();
     decoder.decodeReportPoints("vehicle.charge.battery_level 93 1234567890.246", out, "customer");
     ReportPoint point = out.get(0);
@@ -212,7 +215,7 @@ public class GraphiteDecoderTest {
 
   @Test
   public void testDecodeWithMillisTimestamp() throws Exception {
-    GraphiteDecoder decoder = new GraphiteDecoder();
+    GraphiteDecoder decoder = new GraphiteDecoder(emptyCustomSourceTags);
     List<ReportPoint> out = Lists.newArrayList();
     decoder.decodeReportPoints("vehicle.charge.battery_level 93 1234567892468", out, "customer");
     ReportPoint point = out.get(0);
@@ -224,7 +227,7 @@ public class GraphiteDecoderTest {
 
   @Test
   public void testMetricWithNumberStarting() throws Exception {
-    GraphiteDecoder decoder = new GraphiteDecoder();
+    GraphiteDecoder decoder = new GraphiteDecoder(emptyCustomSourceTags);
     List<ReportPoint> out = Lists.newArrayList();
     decoder.decodeReportPoints("1vehicle.charge.battery_level 93 1234567890.246", out, "customer");
     ReportPoint point = out.get(0);
@@ -236,7 +239,7 @@ public class GraphiteDecoderTest {
 
   @Test
   public void testMetricWithAnnotationQuoted() throws Exception {
-    GraphiteDecoder decoder = new GraphiteDecoder();
+    GraphiteDecoder decoder = new GraphiteDecoder(emptyCustomSourceTags);
     List<ReportPoint> out = Lists.newArrayList();
     decoder.decodeReportPoints("1vehicle.charge.battery_level 93 1234567890.246 host=12345 blah=\"test hello\" " +
         "\"hello world\"=test", out, "customer");
@@ -252,7 +255,7 @@ public class GraphiteDecoderTest {
 
   @Test
   public void testQuotes() {
-    GraphiteDecoder decoder = new GraphiteDecoder();
+    GraphiteDecoder decoder = new GraphiteDecoder(emptyCustomSourceTags);
     List<ReportPoint> out = Lists.newArrayList();
     decoder.decodeReportPoints("\"1vehicle.charge.'battery_level\" 93 1234567890.246 " +
         "host=12345 blah=\"test'\\\"hello\" \"hello world\"=test", out, "customer");
@@ -268,7 +271,7 @@ public class GraphiteDecoderTest {
 
   @Test
   public void testSimple() throws Exception {
-    GraphiteDecoder decoder = new GraphiteDecoder();
+    GraphiteDecoder decoder = new GraphiteDecoder(emptyCustomSourceTags);
     List<ReportPoint> out = Lists.newArrayList();
     decoder.decodeReportPoints("test 1 host=test", out, "customer");
     ReportPoint point = out.get(0);
@@ -280,7 +283,7 @@ public class GraphiteDecoderTest {
 
   @Test
   public void testSource() throws Exception {
-    GraphiteDecoder decoder = new GraphiteDecoder();
+    GraphiteDecoder decoder = new GraphiteDecoder(emptyCustomSourceTags);
     List<ReportPoint> out = Lists.newArrayList();
     decoder.decodeReportPoints("test 1 source=test", out, "customer");
     ReportPoint point = out.get(0);
@@ -292,20 +295,56 @@ public class GraphiteDecoderTest {
 
   @Test
   public void testSourcePriority() throws Exception {
-    GraphiteDecoder decoder = new GraphiteDecoder();
+    LinkedHashSet<String> customSourceTags = new LinkedHashSet<String>();
+    customSourceTags.add("fqdn");
+    GraphiteDecoder decoder = new GraphiteDecoder(customSourceTags);
     List<ReportPoint> out = Lists.newArrayList();
-    decoder.decodeReportPoints("test 1 source=test host=bar", out, "customer");
+    decoder.decodeReportPoints("test 1 source=test host=bar fqdn=foo", out, "customer");
     ReportPoint point = out.get(0);
     assertEquals("customer", point.getTable());
     assertEquals("test", point.getMetric());
     assertEquals("test", point.getHost());
     assertEquals("bar", point.getAnnotations().get("_host"));
+    assertEquals("foo", point.getAnnotations().get("fqdn"));
+    assertEquals(1.0, point.getValue());
+  }
+
+  @Test
+  public void testFQDNasSource() throws Exception {
+    LinkedHashSet<String> customSourceTags = new LinkedHashSet<String>();
+    customSourceTags.add("fqdn");
+    customSourceTags.add("hostname");
+    GraphiteDecoder decoder = new GraphiteDecoder(customSourceTags);
+    List<ReportPoint> out = Lists.newArrayList();
+    decoder.decodeReportPoints("test 1 hostname=machine fqdn=machine.company.com", out, "customer");
+    ReportPoint point = out.get(0);
+    assertEquals("customer", point.getTable());
+    assertEquals("test", point.getMetric());
+    assertEquals("machine.company.com", point.getHost());
+    assertEquals(null, point.getAnnotations().get("fqdn"));
+    assertEquals("machine", point.getAnnotations().get("hostname"));
+    assertEquals(1.0, point.getValue());
+  }
+
+
+  @Test
+  public void testUserPrefOverridesDefault() throws Exception {
+    LinkedHashSet<String> customSourceTags = new LinkedHashSet<String>();
+    customSourceTags.add("fqdn");
+    GraphiteDecoder decoder = new GraphiteDecoder("localhost", customSourceTags);
+    List<ReportPoint> out = Lists.newArrayList();
+    decoder.decodeReportPoints("test 1 fqdn=machine.company.com", out, "customer");
+    ReportPoint point = out.get(0);
+    assertEquals("customer", point.getTable());
+    assertEquals("test", point.getMetric());
+    assertEquals("machine.company.com", point.getHost());
+    assertEquals(null, point.getAnnotations().get("fqdn"));
     assertEquals(1.0, point.getValue());
   }
 
   @Test
   public void testTagRewrite() throws Exception {
-    GraphiteDecoder decoder = new GraphiteDecoder();
+    GraphiteDecoder decoder = new GraphiteDecoder(emptyCustomSourceTags);
     List<ReportPoint> out = Lists.newArrayList();
     decoder.decodeReportPoints("test 1 source=test tag=bar", out, "customer");
     ReportPoint point = out.get(0);
@@ -318,15 +357,15 @@ public class GraphiteDecoderTest {
 
   @Test
   public void testMONIT2576() {
-    GraphiteDecoder decoder = new GraphiteDecoder();
+    GraphiteDecoder decoder = new GraphiteDecoder(emptyCustomSourceTags);
     List<ReportPoint> out = Lists.newArrayList();
     decoder.decodeReportPoints("vm.guest.virtualDisk.mediumSeeks.latest 4.00 1439250320 " +
-        "host=iadprdhyp02.iad.xactlycorp.com guest=47173170-2069-4bcc-9bd4-041055b554ec " +
+        "host=iadprdhyp02.iad.corp.com guest=47173170-2069-4bcc-9bd4-041055b554ec " +
         "instance=ide0_0", out, "customer");
     ReportPoint point = out.get(0);
     assertEquals("customer", point.getTable());
     assertEquals("vm.guest.virtualDisk.mediumSeeks.latest", point.getMetric());
-    assertEquals("iadprdhyp02.iad.xactlycorp.com", point.getHost());
+    assertEquals("iadprdhyp02.iad.corp.com", point.getHost());
     assertEquals("47173170-2069-4bcc-9bd4-041055b554ec", point.getAnnotations().get("guest"));
     assertEquals("ide0_0", point.getAnnotations().get("instance"));
     assertEquals(4.0, point.getValue());
@@ -342,16 +381,24 @@ public class GraphiteDecoderTest {
   @Ignore
   @Test
   public void testBenchmark() throws Exception {
-    GraphiteDecoder decoder = new GraphiteDecoder("localhost");
+    LinkedHashSet<String> customSourceTags = new LinkedHashSet<String>();
+    customSourceTags.add("fqdn");
+    customSourceTags.add("hostname");
+    customSourceTags.add("highcardinalitytag1");
+    customSourceTags.add("highcardinalitytag2");
+    customSourceTags.add("highcardinalitytag3");
+    customSourceTags.add("highcardinalitytag4");
+    customSourceTags.add("highcardinalitytag5");
+    GraphiteDecoder decoder = new GraphiteDecoder("localhost", emptyCustomSourceTags);
     int ITERATIONS = 1000000;
     for (int i = 0; i < ITERATIONS / 1000; i++) {
       List<ReportPoint> out = new ArrayList<>();
-      decoder.decodeReportPoints("tsdb.vehicle.charge.battery_level 93 123456 host=vehicle_2554", out);
+      decoder.decodeReportPoints("tsdb.vehicle.charge.battery_level 93 123456 highcardinalitytag5=vehicle_2554", out);
     }
     long start = System.currentTimeMillis();
     for (int i = 0; i < ITERATIONS; i++) {
       List<ReportPoint> out = new ArrayList<>();
-      decoder.decodeReportPoints("tsdb.vehicle.charge.battery_level 93 123456 host=vehicle_2554", out);
+      decoder.decodeReportPoints("tsdb.vehicle.charge.battery_level 93 123456 highcardinalitytag5=vehicle_2554", out);
     }
     double end = System.currentTimeMillis();
     System.out.println(ITERATIONS / ((end - start) / 1000) + " DPS");

--- a/java-lib/src/test/java/com/wavefront/ingester/GraphiteDecoderTest.java
+++ b/java-lib/src/test/java/com/wavefront/ingester/GraphiteDecoderTest.java
@@ -6,7 +6,7 @@ import org.junit.Ignore;
 import org.junit.Test;
 
 import java.util.ArrayList;
-import java.util.LinkedHashSet;
+import java.util.Collections;
 import java.util.List;
 
 import sunnylabs.report.ReportPoint;
@@ -19,7 +19,7 @@ import static org.junit.Assert.fail;
  */
 public class GraphiteDecoderTest {
 
-  private final static LinkedHashSet<String> emptyCustomSourceTags = new LinkedHashSet<String>();
+  private final static List<String> emptyCustomSourceTags = Collections.emptyList();
 
   @Test
   public void testDoubleFormat() throws Exception {
@@ -295,7 +295,7 @@ public class GraphiteDecoderTest {
 
   @Test
   public void testSourcePriority() throws Exception {
-    LinkedHashSet<String> customSourceTags = new LinkedHashSet<String>();
+    List<String> customSourceTags = new ArrayList<String>();
     customSourceTags.add("fqdn");
     GraphiteDecoder decoder = new GraphiteDecoder(customSourceTags);
     List<ReportPoint> out = Lists.newArrayList();
@@ -311,7 +311,7 @@ public class GraphiteDecoderTest {
 
   @Test
   public void testFQDNasSource() throws Exception {
-    LinkedHashSet<String> customSourceTags = new LinkedHashSet<String>();
+    List<String> customSourceTags = new ArrayList<String>();
     customSourceTags.add("fqdn");
     customSourceTags.add("hostname");
     GraphiteDecoder decoder = new GraphiteDecoder(customSourceTags);
@@ -329,7 +329,7 @@ public class GraphiteDecoderTest {
 
   @Test
   public void testUserPrefOverridesDefault() throws Exception {
-    LinkedHashSet<String> customSourceTags = new LinkedHashSet<String>();
+    List<String> customSourceTags = new ArrayList<String>();
     customSourceTags.add("fqdn");
     GraphiteDecoder decoder = new GraphiteDecoder("localhost", customSourceTags);
     List<ReportPoint> out = Lists.newArrayList();
@@ -381,7 +381,7 @@ public class GraphiteDecoderTest {
   @Ignore
   @Test
   public void testBenchmark() throws Exception {
-    LinkedHashSet<String> customSourceTags = new LinkedHashSet<String>();
+    List<String> customSourceTags = new ArrayList<String>();
     customSourceTags.add("fqdn");
     customSourceTags.add("hostname");
     customSourceTags.add("highcardinalitytag1");

--- a/java-lib/src/test/java/com/wavefront/ingester/GraphiteHostAnnotatorTest.java
+++ b/java-lib/src/test/java/com/wavefront/ingester/GraphiteHostAnnotatorTest.java
@@ -1,0 +1,43 @@
+package com.wavefront.ingester;
+
+import org.junit.Test;
+
+import java.util.LinkedList;
+import java.util.List;
+
+import static junit.framework.Assert.assertEquals;
+
+/**
+ * Tests for GraphiteHostAnnotator.
+ *
+ * @author Conor Beverland (conor@wavefront.com).
+ */
+public class GraphiteHostAnnotatorTest {
+
+  @Test
+  public void testHostMatches() throws Exception {
+    GraphiteHostAnnotator handler = new GraphiteHostAnnotator("test.host.com");
+    List<Object> out = new LinkedList<Object>();
+    String msg = "test.metric 1 host=foo";
+    handler.decode(null, msg, out);
+    assertEquals(msg, out.get(0));
+  }
+
+  @Test
+  public void testSourceMatches() throws Exception {
+    GraphiteHostAnnotator handler = new GraphiteHostAnnotator("test.host.com");
+    List<Object> out = new LinkedList<Object>();
+    String msg = "test.metric 1 source=foo";
+    handler.decode(null, msg, out);
+    assertEquals(msg, out.get(0));
+  }
+
+  @Test
+  public void testSourceAdded() throws Exception {
+    GraphiteHostAnnotator handler = new GraphiteHostAnnotator("test.host.com");
+    List<Object> out = new LinkedList<Object>();
+    String msg = "test.metric 1";
+    handler.decode(null, msg, out);
+    assertEquals("test.metric 1 source=test.host.com", out.get(0));
+  }
+}

--- a/java-lib/src/test/java/com/wavefront/ingester/GraphiteHostAnnotatorTest.java
+++ b/java-lib/src/test/java/com/wavefront/ingester/GraphiteHostAnnotatorTest.java
@@ -1,7 +1,10 @@
 package com.wavefront.ingester;
 
+import org.junit.Ignore;
 import org.junit.Test;
 
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
 import java.util.LinkedList;
 import java.util.List;
 
@@ -14,9 +17,11 @@ import static junit.framework.Assert.assertEquals;
  */
 public class GraphiteHostAnnotatorTest {
 
+  private final static LinkedHashSet<String> emptyCustomSourceTags = new LinkedHashSet<String>();
+
   @Test
   public void testHostMatches() throws Exception {
-    GraphiteHostAnnotator handler = new GraphiteHostAnnotator("test.host.com");
+    GraphiteHostAnnotator handler = new GraphiteHostAnnotator("test.host.com", emptyCustomSourceTags);
     List<Object> out = new LinkedList<Object>();
     String msg = "test.metric 1 host=foo";
     handler.decode(null, msg, out);
@@ -25,7 +30,7 @@ public class GraphiteHostAnnotatorTest {
 
   @Test
   public void testSourceMatches() throws Exception {
-    GraphiteHostAnnotator handler = new GraphiteHostAnnotator("test.host.com");
+    GraphiteHostAnnotator handler = new GraphiteHostAnnotator("test.host.com", emptyCustomSourceTags);
     List<Object> out = new LinkedList<Object>();
     String msg = "test.metric 1 source=foo";
     handler.decode(null, msg, out);
@@ -34,10 +39,62 @@ public class GraphiteHostAnnotatorTest {
 
   @Test
   public void testSourceAdded() throws Exception {
-    GraphiteHostAnnotator handler = new GraphiteHostAnnotator("test.host.com");
+    GraphiteHostAnnotator handler = new GraphiteHostAnnotator("test.host.com", emptyCustomSourceTags);
     List<Object> out = new LinkedList<Object>();
     String msg = "test.metric 1";
     handler.decode(null, msg, out);
     assertEquals("test.metric 1 source=test.host.com", out.get(0));
+  }
+
+  @Test
+  public void testCustomTagMatches() throws Exception {
+    LinkedHashSet<String> customSourceTags = new LinkedHashSet<String>();
+    customSourceTags.add("fqdn");
+    customSourceTags.add("hostname");
+    GraphiteHostAnnotator handler = new GraphiteHostAnnotator("test.host.com", customSourceTags);
+    List<Object> out = new LinkedList<Object>();
+    String msg = "test.metric 1 fqdn=test";
+    handler.decode(null, msg, out);
+    assertEquals(msg, out.get(0));
+  }
+
+  @Test
+  public void testSourceAddedWithCustomTags() throws Exception {
+    LinkedHashSet<String> customSourceTags = new LinkedHashSet<String>();
+    customSourceTags.add("fqdn");
+    customSourceTags.add("hostname");
+    GraphiteHostAnnotator handler = new GraphiteHostAnnotator("test.host.com", customSourceTags);
+    List<Object> out = new LinkedList<Object>();
+    String msg = "test.metric 1 foo=bar";
+    handler.decode(null, msg, out);
+    assertEquals("test.metric 1 foo=bar source=test.host.com", out.get(0));
+  }
+
+  @Ignore
+  @Test
+  public void testBenchmark() throws Exception {
+    LinkedHashSet<String> customSourceTags = new LinkedHashSet<String>();
+    customSourceTags.add("fqdn");
+    customSourceTags.add("hostname");
+    customSourceTags.add("highcardinalitytag1");
+    customSourceTags.add("highcardinalitytag2");
+    customSourceTags.add("highcardinalitytag3");
+    customSourceTags.add("highcardinalitytag4");
+    customSourceTags.add("highcardinalitytag5");
+
+    GraphiteHostAnnotator handler = new GraphiteHostAnnotator("test.host.com", customSourceTags);
+    int ITERATIONS = 1000000;
+
+    for (int i = 0; i < ITERATIONS / 1000; i++) {
+      List<Object> out = new ArrayList<>();
+      handler.decode(null, "tsdb.vehicle.charge.battery_level 93 123456 host=vehicle_2554", out);
+    }
+    long start = System.currentTimeMillis();
+    for (int i = 0; i < ITERATIONS; i++) {
+      List<Object> out = new ArrayList<>();
+      handler.decode(null, "tsdb.vehicle.charge.battery_level 93 123456 host=vehicle_2554", out);
+    }
+    double end = System.currentTimeMillis();
+    System.out.println(ITERATIONS / ((end - start) / 1000) + " DPS");
   }
 }

--- a/java-lib/src/test/java/com/wavefront/ingester/GraphiteHostAnnotatorTest.java
+++ b/java-lib/src/test/java/com/wavefront/ingester/GraphiteHostAnnotatorTest.java
@@ -4,7 +4,7 @@ import org.junit.Ignore;
 import org.junit.Test;
 
 import java.util.ArrayList;
-import java.util.LinkedHashSet;
+import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 
@@ -17,7 +17,7 @@ import static junit.framework.Assert.assertEquals;
  */
 public class GraphiteHostAnnotatorTest {
 
-  private final static LinkedHashSet<String> emptyCustomSourceTags = new LinkedHashSet<String>();
+  private final static List<String> emptyCustomSourceTags = Collections.emptyList();
 
   @Test
   public void testHostMatches() throws Exception {
@@ -48,7 +48,7 @@ public class GraphiteHostAnnotatorTest {
 
   @Test
   public void testCustomTagMatches() throws Exception {
-    LinkedHashSet<String> customSourceTags = new LinkedHashSet<String>();
+    List<String> customSourceTags = new ArrayList<String>();
     customSourceTags.add("fqdn");
     customSourceTags.add("hostname");
     GraphiteHostAnnotator handler = new GraphiteHostAnnotator("test.host.com", customSourceTags);
@@ -60,7 +60,7 @@ public class GraphiteHostAnnotatorTest {
 
   @Test
   public void testSourceAddedWithCustomTags() throws Exception {
-    LinkedHashSet<String> customSourceTags = new LinkedHashSet<String>();
+    List<String> customSourceTags = new ArrayList<String>();
     customSourceTags.add("fqdn");
     customSourceTags.add("hostname");
     GraphiteHostAnnotator handler = new GraphiteHostAnnotator("test.host.com", customSourceTags);
@@ -73,7 +73,7 @@ public class GraphiteHostAnnotatorTest {
   @Ignore
   @Test
   public void testBenchmark() throws Exception {
-    LinkedHashSet<String> customSourceTags = new LinkedHashSet<String>();
+    List<String> customSourceTags = new ArrayList<String>();
     customSourceTags.add("fqdn");
     customSourceTags.add("hostname");
     customSourceTags.add("highcardinalitytag1");

--- a/java-lib/src/test/java/com/wavefront/ingester/OpenTSDBDecoderTest.java
+++ b/java-lib/src/test/java/com/wavefront/ingester/OpenTSDBDecoderTest.java
@@ -3,6 +3,7 @@ package com.wavefront.ingester;
 import org.junit.Test;
 
 import java.util.ArrayList;
+import java.util.LinkedHashSet;
 import java.util.List;
 
 import sunnylabs.report.ReportPoint;
@@ -19,7 +20,9 @@ public class OpenTSDBDecoderTest {
 
   @Test
   public void testDoubleFormat() throws Exception {
-    OpenTSDBDecoder decoder = new OpenTSDBDecoder("localhost");
+    LinkedHashSet<String> customSourceTags = new LinkedHashSet<String>();
+    customSourceTags.add("fqdn");
+    OpenTSDBDecoder decoder = new OpenTSDBDecoder("localhost", customSourceTags);
     List<ReportPoint> out = new ArrayList<>();
     decoder.decodeReportPoints("put tsdb.vehicle.charge.battery_level 12345.678 93.123e3 host=vehicle_2554", out);
     ReportPoint point = out.get(0);

--- a/java-lib/src/test/java/com/wavefront/ingester/OpenTSDBDecoderTest.java
+++ b/java-lib/src/test/java/com/wavefront/ingester/OpenTSDBDecoderTest.java
@@ -3,7 +3,6 @@ package com.wavefront.ingester;
 import org.junit.Test;
 
 import java.util.ArrayList;
-import java.util.LinkedHashSet;
 import java.util.List;
 
 import sunnylabs.report.ReportPoint;
@@ -20,7 +19,7 @@ public class OpenTSDBDecoderTest {
 
   @Test
   public void testDoubleFormat() throws Exception {
-    LinkedHashSet<String> customSourceTags = new LinkedHashSet<String>();
+    List<String> customSourceTags = new ArrayList<String>();
     customSourceTags.add("fqdn");
     OpenTSDBDecoder decoder = new OpenTSDBDecoder("localhost", customSourceTags);
     List<ReportPoint> out = new ArrayList<>();

--- a/pkg/opt/wavefront/wavefront-proxy/conf/wavefront.conf
+++ b/pkg/opt/wavefront/wavefront-proxy/conf/wavefront.conf
@@ -64,6 +64,11 @@ pushLogLevel=SUMMARY
 #   Options: NUMERIC_ONLY, NO_VALIDATION.
 pushValidationLevel=NUMERIC_ONLY
 
+# When using the Wavefront or TSDB data formats the Proxy will automatically look for a tag named
+# source= or host= (preferring source=) and treat that as the source/host within Wavefront.
+# customSourceTags is a comma separated, ordered list of additional tag keys to use if neither
+# source= or host= is present
+customSourceTags=fqdn, hostname
 
 ## Which ports should listen for collectd/graphite-formatted data?
 ## If you uncomment graphitePorts, make sure to uncomment and set 'graphiteFormat' and 'graphiteDelimiters' as well.

--- a/pkg/opt/wavefront/wavefront-proxy/conf/wavefront.conf
+++ b/pkg/opt/wavefront/wavefront-proxy/conf/wavefront.conf
@@ -8,11 +8,11 @@
 
 ##############################################################################
 #
-# The prefix should either be left undefined, or can be any  prefix you want 
+# The prefix should either be left undefined, or can be any  prefix you want
 #    prepended to all data points coming from this agent (such as 'prod').
-# 
+#
 # Examples:
-# 
+#
 #    #prefix=
 #    prefix=prod.nyc
 #
@@ -25,14 +25,14 @@
 server=https://metrics.wavefront.com/api/
 
 # The hostname will be used to identify the internal agent statistics around point rates, JVM info, etc.
-#  We strongly recommend setting this to a name that is unique among your entire infrastructure, 
+#  We strongly recommend setting this to a name that is unique among your entire infrastructure,
 #   possibly including the datacenter information, etc. This hostname does not need to correspond to
 #   any actual hostname or DNS entry; it's merely a string that we pass with the internal stats.
 #
 #hostname=my.agent.host.com
 
 # The Token is any valid API Token for your account, which can be generated from the gear icon
-#   at the top right of the Wavefront site, under 'Settings'. Paste that hexadecimal token 
+#   at the top right of the Wavefront site, under 'Settings'. Paste that hexadecimal token
 #   after the '=' below, and the agent will automatically generate a machine-specific UUID and
 #   self-register.
 # If you don't set this token here, you can still register the agent through the normal web flow.
@@ -59,7 +59,7 @@ pushBlockedSamples=5
 #   Options: NONE, SUMMARY, DETAILED. Typically SUMMARY.
 pushLogLevel=SUMMARY
 
-# The validation level keeps certain data from being sent to Wavefront. 
+# The validation level keeps certain data from being sent to Wavefront.
 #   We strongly recommend keeping this at NUMERIC_ONLY
 #   Options: NUMERIC_ONLY, NO_VALIDATION.
 pushValidationLevel=NUMERIC_ONLY

--- a/proxy/src/main/java/com/wavefront/agent/AbstractAgent.java
+++ b/proxy/src/main/java/com/wavefront/agent/AbstractAgent.java
@@ -169,7 +169,7 @@ public abstract class AbstractAgent {
 
   @Parameter(names = {"--retryBackoffBaseSeconds"}, description = "For exponential backoff when retry threads are throttled, the base (a in a^b) in seconds.  Default 2.0")
   protected double retryBackoffBaseSeconds = 2.0;
-  
+
   @Parameter(names = {"--customSourceTags"}, description = "Comma separated list of point tag keys that should be treated as the source in Wavefront in the absence of a tag named source or host")
   protected String customSourceTags = "fqdn";
 
@@ -309,7 +309,7 @@ public abstract class AbstractAgent {
 
       // read build information.
       props = ResourceBundle.getBundle("build");
-      
+
       // create Set of custom tags from the configuration string
       String[] tags = customSourceTags.split(",");
       for (String tag : tags) {

--- a/proxy/src/main/java/com/wavefront/agent/PushAgent.java
+++ b/proxy/src/main/java/com/wavefront/agent/PushAgent.java
@@ -91,7 +91,7 @@ public class PushAgent extends AbstractAgent {
     int port = Integer.parseInt(strPort);
 
     // Set up a custom graphite handler, with no formatter
-    ChannelHandler graphiteHandler = new ChannelStringHandler(new OpenTSDBDecoder("unknown", customSourceTagsSet),
+    ChannelHandler graphiteHandler = new ChannelStringHandler(new OpenTSDBDecoder("unknown", customSourceTags),
         agentAPI, agentId, port, prefix, pushLogLevel, pushValidationLevel, pushFlushInterval,
         pushBlockedSamples, null, opentsdbWhitelistRegex,
         opentsdbBlacklistRegex);
@@ -103,7 +103,7 @@ public class PushAgent extends AbstractAgent {
     int port = Integer.parseInt(strPort);
 
     // Set up a custom graphite handler, with no formatter
-    ChannelHandler graphiteHandler = new ChannelStringHandler(new GraphiteDecoder("unknown", customSourceTagsSet),
+    ChannelHandler graphiteHandler = new ChannelStringHandler(new GraphiteDecoder("unknown", customSourceTags),
         agentAPI, agentId, port, prefix, pushLogLevel, pushValidationLevel, pushFlushInterval,
         pushBlockedSamples, formatter, whitelistRegex, blacklistRegex);
 
@@ -112,7 +112,7 @@ public class PushAgent extends AbstractAgent {
       handler.add(new Function<SocketChannel, ChannelHandler>() {
         @Override
         public ChannelHandler apply(SocketChannel input) {
-          return new GraphiteHostAnnotator(input.remoteAddress().getHostName(), customSourceTagsSet);
+          return new GraphiteHostAnnotator(input.remoteAddress().getHostName(), customSourceTags);
         }
       });
       new Thread(new Ingester(handler, graphiteHandler, port)).start();

--- a/proxy/src/main/java/com/wavefront/agent/PushAgent.java
+++ b/proxy/src/main/java/com/wavefront/agent/PushAgent.java
@@ -91,7 +91,7 @@ public class PushAgent extends AbstractAgent {
     int port = Integer.parseInt(strPort);
 
     // Set up a custom graphite handler, with no formatter
-    ChannelHandler graphiteHandler = new ChannelStringHandler(new OpenTSDBDecoder("unknown"),
+    ChannelHandler graphiteHandler = new ChannelStringHandler(new OpenTSDBDecoder("unknown", customSourceTagsSet),
         agentAPI, agentId, port, prefix, pushLogLevel, pushValidationLevel, pushFlushInterval,
         pushBlockedSamples, null, opentsdbWhitelistRegex,
         opentsdbBlacklistRegex);
@@ -103,7 +103,7 @@ public class PushAgent extends AbstractAgent {
     int port = Integer.parseInt(strPort);
 
     // Set up a custom graphite handler, with no formatter
-    ChannelHandler graphiteHandler = new ChannelStringHandler(new GraphiteDecoder("unknown"),
+    ChannelHandler graphiteHandler = new ChannelStringHandler(new GraphiteDecoder("unknown", customSourceTagsSet),
         agentAPI, agentId, port, prefix, pushLogLevel, pushValidationLevel, pushFlushInterval,
         pushBlockedSamples, formatter, whitelistRegex, blacklistRegex);
 
@@ -112,7 +112,7 @@ public class PushAgent extends AbstractAgent {
       handler.add(new Function<SocketChannel, ChannelHandler>() {
         @Override
         public ChannelHandler apply(SocketChannel input) {
-          return new GraphiteHostAnnotator(input.remoteAddress().getHostName());
+          return new GraphiteHostAnnotator(input.remoteAddress().getHostName(), customSourceTagsSet);
         }
       });
       new Thread(new Ingester(handler, graphiteHandler, port)).start();


### PR DESCRIPTION
We already had a hard coded "extra" tag that could resolve to source/host which was "fqdn".

This adds the ability for a user to specify additional tags that should be used as the source in cases where neither a source= or host= tag exists