### PR TITLE
add support for write_http JSON format

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ proxy/unitTest*
 .classpath
 .project
 .settings/
+
+test/buffer.*
+test/proxy.out

--- a/proxy/src/main/java/com/wavefront/agent/AbstractAgent.java
+++ b/proxy/src/main/java/com/wavefront/agent/AbstractAgent.java
@@ -62,6 +62,7 @@ public abstract class AbstractAgent {
   private static final int GRAPHITE_LISTENING_PORT = 2878;
   private static final int OPENTSDB_LISTENING_PORT = 4242;
   private static final int HTTP_JSON_LISTENING_PORT = 3878;
+  private static final int WRITE_HTTP_JSON_LISTENING_PORT = 4878;
 
   @Parameter(names = {"-f", "--file"}, description =
       "Proxy configuration file")
@@ -133,6 +134,10 @@ public abstract class AbstractAgent {
   @Parameter(names = {"--httpJsonPorts"}, description = "Comma-separated list of ports to listen on for json metrics " +
       "data. Binds, by default, to " + HTTP_JSON_LISTENING_PORT)
   protected String httpJsonPorts = "" + HTTP_JSON_LISTENING_PORT;
+
+  @Parameter(names = {"--writeHttpJsonPorts"}, description = "Comma-separated list of ports to listen on for json metrics from collectd write_http json format " +
+      "data. Binds, by default, to " + WRITE_HTTP_JSON_LISTENING_PORT)
+  protected String writeHttpJsonPorts = "" + WRITE_HTTP_JSON_LISTENING_PORT;
 
   @Parameter(names = {"--hostname"}, description = "Hostname for the agent. Defaults to FQDN of machine.")
   protected String hostname;
@@ -246,6 +251,7 @@ public abstract class AbstractAgent {
             String.valueOf(pushBlockedSamples)));
         pushListenerPorts = prop.getProperty("pushListenerPorts", pushListenerPorts);
         httpJsonPorts = prop.getProperty("jsonListenerPorts", httpJsonPorts);
+        writeHttpJsonPorts = prop.getProperty("writeHttpJsonListenerPorts", writeHttpJsonPorts);
         graphitePorts = prop.getProperty("graphitePorts", graphitePorts);
         graphiteFormat = prop.getProperty("graphiteFormat", graphiteFormat);
         graphiteDelimiters = prop.getProperty("graphiteDelimiters", graphiteDelimiters);

--- a/proxy/src/main/java/com/wavefront/agent/PushAgent.java
+++ b/proxy/src/main/java/com/wavefront/agent/PushAgent.java
@@ -85,6 +85,26 @@ public class PushAgent extends AbstractAgent {
         }
       }
     }
+    if (writeHttpJsonPorts != null) {
+      for (String strPort : writeHttpJsonPorts.split(",")) {
+        if (strPort.trim().length() > 0) {
+          try {
+            int port = Integer.parseInt(strPort);
+            // will immediately start the server.
+            JettyHttpContainerFactory.createServer(
+                new URI("http://localhost:" + strPort + "/"),
+                new ResourceConfig(JacksonFeature.class).
+                    register(new WriteHttpJsonMetricsEndpoint(agentAPI, agentId, port, hostname, prefix,
+                        pushLogLevel, pushValidationLevel, pushFlushInterval, pushBlockedSamples
+                    )),
+                true);
+            logger.info("listening on port: " + strPort + " for Write HTTP JSON metrics");
+          } catch (URISyntaxException e) {
+            throw new RuntimeException("Unable to bind to: " + strPort + " for Write HTTP JSON metrics", e);
+          }
+        }
+      }
+    }
   }
 
   protected void startOpenTsdbListener(String strPort) {

--- a/proxy/src/main/java/com/wavefront/agent/WriteHttpJsonMetricsEndpoint.java
+++ b/proxy/src/main/java/com/wavefront/agent/WriteHttpJsonMetricsEndpoint.java
@@ -53,9 +53,10 @@ public class WriteHttpJsonMetricsEndpoint extends PointHandler {
   @Consumes(MediaType.APPLICATION_JSON)
   public Response reportMetrics(@Context UriInfo uriInfo,
                                 JsonNode metrics) {
+    final PostPushDataTimedTask randomPostTask = this.getRandomPostTask();
     if (!metrics.isArray()) {
       logger.warning("metrics is not an array!");
-      this.sendDataTask.incrementBlockedPoints();
+      randomPostTask.incrementBlockedPoints();
       throw new IllegalArgumentException("Metrics must be an array");
     }
 
@@ -79,7 +80,7 @@ public class WriteHttpJsonMetricsEndpoint extends PointHandler {
         }
         JsonNode values = metric.get("values");
         if (values == null) {
-          this.sendDataTask.incrementBlockedPoints();
+          randomPostTask.incrementBlockedPoints();
           logger.warning("Skipping.  Missing values.");
           continue;
         }
@@ -101,7 +102,7 @@ public class WriteHttpJsonMetricsEndpoint extends PointHandler {
           index++;
         }
       } catch (final Exception e) {
-        this.sendDataTask.incrementBlockedPoints();
+        randomPostTask.incrementBlockedPoints();
         logger.log(Level.WARNING, "Failed adding metric", e);
       }
     }

--- a/proxy/src/main/java/com/wavefront/agent/WriteHttpJsonMetricsEndpoint.java
+++ b/proxy/src/main/java/com/wavefront/agent/WriteHttpJsonMetricsEndpoint.java
@@ -1,0 +1,166 @@
+package com.wavefront.agent;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+import java.util.UUID;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import javax.annotation.Nullable;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriInfo;
+
+import sunnylabs.report.ReportPoint;
+
+/**
+ * Agent-side JSON metrics endpoint for parsing JSON from write_http collectd
+ * plugin.
+ * @see https://collectd.org/wiki/index.php/Plugin:Write_HTTP
+ */
+@Path("/")
+public class WriteHttpJsonMetricsEndpoint extends PointHandler {
+
+  protected static final Logger logger = Logger.getLogger("agent");
+  
+  @Nullable
+  private final String prefix;
+  private final String defaultHost;
+
+  public WriteHttpJsonMetricsEndpoint(final QueuedAgentService agentApi,
+                                      final UUID daemonId,
+                                      final int port,
+                                      final String host,
+                                      @Nullable
+                                      final String prefix,
+                                      final String logLevel,
+                                      final String validationLevel,
+                                      final long millisecondsPerBatch,
+                                      final int blockedPointsPerBatch) {
+    super(agentApi, daemonId, port, logLevel, validationLevel, millisecondsPerBatch,
+        blockedPointsPerBatch);
+    this.prefix = prefix;
+    this.defaultHost = host;
+  }
+
+  @POST
+  @Consumes(MediaType.APPLICATION_JSON)
+  public Response reportMetrics(@Context UriInfo uriInfo,
+                                JsonNode metrics) {
+    if (!metrics.isArray()) {
+      logger.warning("metrics is not an array!");
+      this.sendDataTask.incrementBlockedPoints();
+      throw new IllegalArgumentException("Metrics must be an array");
+    }
+
+    for (final JsonNode metric : metrics) {
+      try {
+        JsonNode host = metric.get("host");
+        String hostName;
+        if (host != null) {
+          hostName = host.textValue();
+          if (hostName == null || hostName.isEmpty()) {
+            hostName = defaultHost;
+          }
+        } else {
+          hostName = defaultHost;
+        }
+
+        JsonNode time = metric.get("time");
+        long ts = 0;
+        if (time != null) {
+          ts = time.asLong() * 1000;
+        }
+        JsonNode values = metric.get("values");
+        if (values == null) {
+          this.sendDataTask.incrementBlockedPoints();
+          logger.warning("Skipping.  Missing values.");
+          continue;
+        }
+        int index = 0;
+        for (final JsonNode value : values) {
+          String metricName = getMetricName(metric, index);
+          ReportPoint.Builder builder = ReportPoint.newBuilder()
+            .setMetric(metricName)
+            .setTable("dummy")
+            .setTimestamp(ts)
+            .setHost(hostName);
+          if (value.isDouble()) {
+            builder.setValue(value.asDouble());
+          } else {
+            builder.setValue(value.asLong());
+          }
+          ReportPoint point = builder.build();
+          reportPoint(point, "write_http json: " + pointToString(point));
+          index++;
+        }
+      } catch (final Exception e) {
+        this.sendDataTask.incrementBlockedPoints();
+        logger.log(Level.WARNING, "Failed adding metric", e);
+      }
+    }
+    return Response.accepted().build();
+  }
+
+  /**
+   * Generates a metric name from json format:
+     {
+     "values": [197141504, 175136768],
+     "dstypes": ["counter", "counter"],
+     "dsnames": ["read", "write"],
+     "time": 1251533299,
+     "interval": 10,
+     "host": "leeloo.lan.home.verplant.org",
+     "plugin": "disk",
+     "plugin_instance": "sda",
+     "type": "disk_octets",
+     "type_instance": ""
+    }
+
+    host "/" plugin ["-" plugin instance] "/" type ["-" type instance] =>
+    {plugin}[.{plugin_instance}].{type}[.{type_instance}]
+  */
+  private String getMetricName(final JsonNode metric, int index) {
+    JsonNode plugin = metric.get("plugin");
+    JsonNode plugin_instance = metric.get("plugin_instance");
+    JsonNode type = metric.get("type");
+    JsonNode type_instance = metric.get("type_instance");
+
+    if (plugin == null || type == null) {
+      throw new IllegalArgumentException("plugin or type is missing");
+    }
+
+    StringBuilder sb = new StringBuilder();
+    sb.append(plugin.textValue());
+    sb.append('.');
+    if (plugin_instance != null) {
+      String value = plugin_instance.textValue();
+      if (value != null && !value.isEmpty()) {
+        sb.append(value);
+        sb.append('.');
+      }
+    }
+    sb.append(type.textValue());
+    sb.append('.');
+    if (type_instance != null) {
+      String value = type_instance.textValue();
+      if (value != null && !value.isEmpty()) {
+        sb.append(value);
+        sb.append('.');
+      }
+    }
+
+    JsonNode dsnames = metric.get("dsnames");
+    if (dsnames == null || !dsnames.isArray() || dsnames.size() <= index) {
+      throw new IllegalArgumentException("dsnames is not set");
+    }
+    sb.append(dsnames.get(index).textValue());
+    return sb.toString();
+  }
+}

--- a/test/runner.py
+++ b/test/runner.py
@@ -1,0 +1,208 @@
+#!/usr/bin/env python
+"""
+This is a test runner with test suite for testing various proxy endpoints.
+"""
+
+import datetime
+import BaseHTTPServer
+import subprocess
+import threading
+import unittest
+import urllib2
+
+import dateutil
+import dateutil.tz
+
+EPOCH = (datetime.datetime.utcfromtimestamp(0)
+         .replace(tzinfo=dateutil.tz.tzutc()))
+def unix_time_seconds(date_in):
+    """
+    Convert a datetime into unix epoch seconds
+    Arguments:
+    date_in - the datetime object to convert. This must have a tz = UTC
+    """
+    return (date_in - EPOCH).total_seconds()
+
+
+class HttpServerRequests(object):
+    """
+    HTTP Requests object is used to store requests that have been sent to
+    the HTTP server.
+    """
+
+    def __init__(self):
+        """
+        Construct this class
+        """
+
+        self.lock = threading.Lock()
+        self.event = threading.Event()
+        self.config_processed_event = threading.Event()
+        self.pushdata_event = threading.Event()
+        self.commands = {}
+
+    def add_request(self, request_handler):
+        """
+        Add an incoming request
+
+        Arguments:
+        request_handler - the http request handler
+        """
+
+        self.lock.acquire()
+        try:
+            path = request_handler.path
+            headers = request_handler.headers
+            qsl = path.find('?')
+            if qsl >= 0:
+                path = path[0:qsl]
+            parts = path.split('/')
+            if len(parts) > 4:
+                length = int(headers.getheader('content-length'))
+                command = parts[4].lower()
+                if length > 0:
+                    content = request_handler.rfile.read(length)
+                else:
+                    content = ''
+                if command not in self.commands:
+                    self.commands[command] = [content]
+                else:
+                    self.commands[command].append(content)
+                #print('Adding %s request for |%s|\n%s' %
+                #      (command, path, content))
+                if command == 'config' and parts[5] == 'processed':
+                    self.config_processed_event.set()
+                elif command == 'pushdata':
+                    self.pushdata_event.set()
+
+            self.event.set()
+
+        finally:
+            self.lock.release()
+            self.config_processed_event.clear()
+            self.pushdata_event.clear()
+            self.event.clear()
+
+class AgentHttpEndpointHandler(BaseHTTPServer.BaseHTTPRequestHandler):
+    """
+    The RequestHandler class that handles requests from the agent (i.e., serves
+    as our fake HTTP WF endpoint).
+    """
+
+    def do_POST(self):
+        """
+        Handles the POST request.
+        """
+
+        self.server.requests.add_request(self)
+        self.send_response(200)
+        self.send_header('Content-type', 'application/json')
+        self.end_headers()
+        self.wfile.write("{}")
+
+class TestWriteHttpProxy(unittest.TestCase):
+    """
+    Tests the write_http plugin support (only JSON is supported/tested)
+    """
+
+    def setUp(self):
+        """
+        Unit Test setup function.  Sets up the fake wavefront endpoint
+        and connects to the proxy.
+        """
+
+        # cleanup function set in case setUp() fails
+        self.addCleanup(self.cleanup)
+
+        # create our fake metrics listener in a separate thread
+        self.server = BaseHTTPServer.HTTPServer(('127.0.0.1', 8080),
+                                                AgentHttpEndpointHandler)
+        self.server.requests = HttpServerRequests()
+        self.endpoint_thread = threading.Thread(
+            target=self.server.serve_forever)
+        self.endpoint_thread.start()
+
+        # start the agent
+        self.agent_stdout_fd = open('./test/proxy.out', 'w')
+        args = ['java', '-jar', '../proxy/target/wavefront-push-agent.jar',
+                '-f', './wavefront.conf', '--purgeBuffer']
+        self.agent_process = subprocess.Popen(args, stdout=self.agent_stdout_fd,
+                                              stderr=self.agent_stdout_fd,
+                                              cwd='./test')
+        print 'Waiting for /config/processed request ...'
+        self.server.requests.config_processed_event.wait(60)
+
+    def cleanup(self):
+        """
+        Unit Test cleanup function (called even if setUp() fails unlike
+        the tearDown()
+        """
+
+        if self.agent_process:
+            self.agent_process.kill()
+            self.agent_process.wait()
+            self.agent_process = None
+
+        if self.agent_stdout_fd:
+            self.agent_stdout_fd.close()
+            self.agent_stdout_fd = None
+
+        if self.server:
+            self.server.shutdown()
+            self.server = None
+
+        if self.endpoint_thread:
+            self.endpoint_thread.join()
+            self.endpoint_thread = None
+
+    def tearDown(self):
+        self.cleanup()
+
+    def test_simple_1(self):
+        """
+        Test that a simple JSON file is parsed and sent to WF correctly.
+        """
+
+        utcnow = unix_time_seconds(datetime.datetime.utcnow().replace(
+            tzinfo=dateutil.tz.tzutc()))
+        json = """
+[
+   {
+     "values": [197141504, 175136768],
+     "dstypes": ["counter", "counter"],
+     "dsnames": ["read", "write"],
+     "time": %d,
+     "interval": 10,
+     "host": "simple1.example.org",
+     "plugin": "disk",
+     "plugin_instance": "sda",
+     "type": "disk_octets",
+     "type_instance": ""
+   }
+]
+""" % utcnow
+
+        # this is the contents we expect to see in the POST to the WF servers
+        pushdata_expect = ("\"disk.sda.disk_octets.read\" 197141504 %d "
+                           "source=\"simple1.example.org\"\n"
+                           "\"disk.sda.disk_octets.write\" 175136768 %d "
+                           "source=\"simple1.example.org\"" % (utcnow, utcnow))
+
+        headers = {
+            'Content-Type': 'application/json'
+        }
+        #handler = urllib2.HTTPHandler(debuglevel=1)
+        #opener = urllib2.build_opener(handler)
+        #urllib2.install_opener(opener)
+        request = urllib2.Request('http://127.0.0.1:4878/',
+                                  headers=headers,
+                                  data=json)
+        conn = urllib2.urlopen(request)
+        #print conn.read()
+
+        self.server.requests.pushdata_event.wait(60)
+        self.assertEquals(pushdata_expect,
+                          self.server.requests.commands['pushdata'][0])
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/wavefront.conf
+++ b/test/wavefront.conf
@@ -1,0 +1,105 @@
+#
+# Wavefront proxy configuration file
+#
+#   Typically in /opt/wavefront/wavefront-proxy/conf/wavefront.conf
+#
+#   For help with your configuration, email support@wavefront.com
+#
+
+##############################################################################
+#
+# The prefix should either be left undefined, or can be any  prefix you want
+#    prepended to all data points coming from this agent (such as 'prod').
+#
+# Examples:
+#
+#    #prefix=
+#    prefix=prod.nyc
+#
+
+#prefix=production
+
+# The server should be either the primary Wavefront cloud server, or your custom VPC address.
+#   This will be provided to you by Wavefront.
+#
+server=http://127.0.0.1:8080/api/
+
+# The hostname will be used to identify the internal agent statistics around point rates, JVM info, etc.
+#  We strongly recommend setting this to a name that is unique among your entire infrastructure,
+#   possibly including the datacenter information, etc. This hostname does not need to correspond to
+#   any actual hostname or DNS entry; it's merely a string that we pass with the internal stats.
+#
+#hostname=my.agent.host.com
+
+# The Token is any valid API Token for your account, which can be generated from the gear icon
+#   at the top right of the Wavefront site, under 'Settings'. Paste that hexadecimal token
+#   after the '=' below, and the agent will automatically generate a machine-specific UUID and
+#   self-register.
+# If you don't set this token here, you can still register the agent through the normal web flow.
+#
+#token=XXX
+
+#Comma separated list of ports to listen on for Wavefront formatted data
+pushListenerPorts=2878
+#Comma separated list of ports to listen on for OpenTSDB formatted data
+opentsdbPorts=4242
+#Comma separated list of ports to listen on for HTTP JSON formatted data
+jsonListenerPorts=3878
+#Comma separated list of ports to listen on for write_http collectd formatted
+writeHttpListenerPorts=4878
+
+# Max points per flush. Typically 40000.
+pushFlushMaxPoints=40000
+
+# Milliseconds between flushes to the Wavefront servers. Typically 1000.
+pushFlushInterval=1000
+
+# If there are blocked points, how many lines to print to the log every 10 flushes. Typically 5.
+pushBlockedSamples=5
+
+# The push log level determines how much information will be printed to the log.
+#   Options: NONE, SUMMARY, DETAILED. Typically SUMMARY.
+pushLogLevel=SUMMARY
+
+# The validation level keeps certain data from being sent to Wavefront.
+#   We strongly recommend keeping this at NUMERIC_ONLY
+#   Options: NUMERIC_ONLY, NO_VALIDATION.
+pushValidationLevel=NUMERIC_ONLY
+
+# When using the Wavefront or TSDB data formats the Proxy will automatically look for a tag named
+# source= or host= (preferring source=) and treat that as the source/host within Wavefront.
+# customSourceTags is a comma separated, ordered list of additional tag keys to use if neither
+# source= or host= is present
+customSourceTags=fqdn, hostname
+
+## Which ports should listen for collectd/graphite-formatted data?
+## If you uncomment graphitePorts, make sure to uncomment and set 'graphiteFormat' and 'graphiteDelimiters' as well.
+#graphitePorts=2003
+
+## Which fields (1-based) should we extract and concatenate (with dots) as the hostname?
+#graphiteFormat=2
+
+## Which characters should be replaced by dots in the hostname, after extraction?
+#graphiteDelimiters=_
+
+## ID file for agent
+idFile=/opt/wavefront/wavefront-proxy/.wavefront_id
+
+## Number of threads retrying failed transmissions. Defaults to the number of processors (min. 4)
+## Buffer files are maxed out at 2G each so increasing the number of retry threads effectively governs
+## the maximum amount of space the agent will use to buffer points locally
+#retryThreads=4
+
+## Regex pattern (java.util.regex) that input lines must match to be accepted.
+## Input lines are checked against the pattern before the prefix is prepended.
+#whitelistRegex=^(production|stage).*
+
+## Regex pattern (java.util.regex) that input lines must NOT match to be accepted.
+## Input lines are checked against the pattern before the prefix is prepended.
+#blacklistRegex=^(qa|development|test).*
+
+## Whether to split the push batch size when the push is rejected by Wavefront due to rate limit.  Default false.
+#splitPushWhenRateLimited=false
+
+## For exponential backoff when retry threads are throttled, the base (a in a^b) in seconds.  Default 2.0
+#retryBackoffBaseSeconds=2.0


### PR DESCRIPTION
This was added to allow customers with older versions of collectd (without write_graphite or write_tsdb).  write_http was added in 4.8 and this allows customers who are on 4.8 or later to send stuff to our proxy via write_http.
See https://collectd.org/wiki/index.php/Plugin:Write_HTTP
Also added a test runner to make sure json is parsed correctly.  We'll need to add some more test case. It is currently testing a very simple case to catch the basics.