### PR TITLE
Do remove a custom tag when treating it as source

### DIFF
--- a/java-lib/src/main/java/com/wavefront/ingester/IngesterFormatter.java
+++ b/java-lib/src/main/java/com/wavefront/ingester/IngesterFormatter.java
@@ -120,7 +120,7 @@ public class IngesterFormatter {
       if (host == null) {
         // iterate over the set of custom tags, breaking when one is found
         for (String tag : customSourceTags) {
-          host = annotations.remove(tag);
+          host = annotations.get(tag);
           if (host != null) {
             break;
           }

--- a/java-lib/src/test/java/com/wavefront/ingester/GraphiteDecoderTest.java
+++ b/java-lib/src/test/java/com/wavefront/ingester/GraphiteDecoderTest.java
@@ -335,7 +335,7 @@ public class GraphiteDecoderTest {
     assertEquals("customer", point.getTable());
     assertEquals("test", point.getMetric());
     assertEquals("machine.company.com", point.getHost());
-    assertEquals(null, point.getAnnotations().get("fqdn"));
+    assertEquals("machine.company.com", point.getAnnotations().get("fqdn"));
     assertEquals("machine", point.getAnnotations().get("hostname"));
     assertEquals(1.0, point.getValue());
   }
@@ -352,7 +352,7 @@ public class GraphiteDecoderTest {
     assertEquals("customer", point.getTable());
     assertEquals("test", point.getMetric());
     assertEquals("machine.company.com", point.getHost());
-    assertEquals(null, point.getAnnotations().get("fqdn"));
+    assertEquals("machine.company.com", point.getAnnotations().get("fqdn"));
     assertEquals(1.0, point.getValue());
   }
 


### PR DESCRIPTION
Previously with a wavefront.conf setting of `customSourceTags=fqdn` data like this:

`metric.measure 1 fqdn=hostname.company.com` would have been transformed into: `metric.measure 1 source=hostname.company.com`

With this change that would be: `metric.measure 1 source=hostname.company.com fqdn=hostname.company.com`

That has the advantage of allowing any existing queries which relied on fqdn= to continue to work.
