### PR TITLE
Support ephemeral agents in java-lib.

### DIFF
--- a/java-lib/src/main/java/com/wavefront/api/AgentAPI.java
+++ b/java-lib/src/main/java/com/wavefront/api/AgentAPI.java
@@ -52,7 +52,8 @@ public interface AgentAPI {
                              @QueryParam("currentMillis") final Long currentMillis,
                              @QueryParam("local") Boolean localAgent,
                              @GZIP JsonNode agentMetrics,
-                             @QueryParam("push") Boolean pushAgent);
+                             @QueryParam("push") Boolean pushAgent,
+                             @QueryParam("ephemeral") Boolean ephemeral);
 
 
   /**

--- a/proxy/src/main/java/com/wavefront/agent/AbstractAgent.java
+++ b/proxy/src/main/java/com/wavefront/agent/AbstractAgent.java
@@ -176,6 +176,9 @@ public abstract class AbstractAgent {
   @Parameter(names = {"--customSourceTags"}, description = "Comma separated list of point tag keys that should be treated as the source in Wavefront in the absence of a tag named source or host")
   protected String customSourceTagsProperty = "fqdn";
 
+  @Parameter(names = {"--ephemeral"}, description = "If true, this agent is removed from Wavefront after 24 hours of inactivity.")
+  protected boolean ephemeral = false;
+
   @Parameter(description = "Unparsed parameters")
   protected List<String> unparsed_params;
 
@@ -500,7 +503,7 @@ public abstract class AbstractAgent {
 
       JsonNode agentMetrics = JsonMetricsGenerator.generateJsonMetrics(Metrics.defaultRegistry(), true, true, true);
       newConfig = agentAPI.checkin(agentId, hostname, token, props.getString("build.version"),
-          System.currentTimeMillis(), localAgent, agentMetrics, pushAgent);
+          System.currentTimeMillis(), localAgent, agentMetrics, pushAgent, ephemeral);
     } catch (Exception ex) {
       logger.warning("cannot fetch proxy agent configuration from remote server: " + Throwables.getRootCause(ex));
       return null;

--- a/proxy/src/main/java/com/wavefront/agent/AbstractAgent.java
+++ b/proxy/src/main/java/com/wavefront/agent/AbstractAgent.java
@@ -270,6 +270,7 @@ public abstract class AbstractAgent {
         retryBackoffBaseSeconds = Double.parseDouble(prop.getProperty("retryBackoffBaseSeconds",
             String.valueOf(retryBackoffBaseSeconds)));
         customSourceTagsProperty = prop.getProperty("customSourceTags", customSourceTagsProperty);
+        ephemeral = Boolean.parseBoolean(prop.getProperty("ephemeral", String.valueOf(ephemeral)));
         logger.warning("Loaded configuration file " + pushConfigFile);
       } catch (Throwable exception) {
         logger.severe("Could not load configuration file " + pushConfigFile);

--- a/proxy/src/main/java/com/wavefront/agent/QueuedAgentService.java
+++ b/proxy/src/main/java/com/wavefront/agent/QueuedAgentService.java
@@ -359,8 +359,8 @@ public class QueuedAgentService implements ForceQueueEnabledAgentAPI {
 
   @Override
   public AgentConfiguration checkin(UUID agentId, String hostname, String token, String version, Long currentMillis,
-                                    Boolean localAgent, JsonNode agentMetrics, Boolean pushAgent) {
-    return wrapped.checkin(agentId, hostname, token, version, currentMillis, localAgent, agentMetrics, pushAgent);
+                                    Boolean localAgent, JsonNode agentMetrics, Boolean pushAgent, Boolean ephemeral) {
+    return wrapped.checkin(agentId, hostname, token, version, currentMillis, localAgent, agentMetrics, pushAgent, ephemeral);
   }
 
   @Override


### PR DESCRIPTION
Backwards-compatible to older WF versions -- the "ephemeral" field is
ignored in that case.