### PR TITLE
Improve default configuration

### DIFF
--- a/pkg/opt/wavefront/wavefront-proxy/conf/wavefront.conf
+++ b/pkg/opt/wavefront/wavefront-proxy/conf/wavefront.conf
@@ -44,7 +44,9 @@ pushListenerPorts=2878
 #Comma separated list of ports to listen on for OpenTSDB formatted data
 opentsdbPorts=4242
 #Comma separated list of ports to listen on for HTTP JSON formatted data
-jsonListenerPorts=3878
+#jsonListenerPorts=3878
+#Comma separate list of ports to listen on for HTTP collectd write_http data
+#writeHttpJsonListenerPorts=4878
 
 # Number of threads that flush data to the server. If not defined in wavefront.conf it defaults to the
 # number of processors (min 4). Setting this value too large will result in sending batches that are

--- a/pkg/opt/wavefront/wavefront-proxy/conf/wavefront.conf
+++ b/pkg/opt/wavefront/wavefront-proxy/conf/wavefront.conf
@@ -46,6 +46,11 @@ opentsdbPorts=4242
 #Comma separated list of ports to listen on for HTTP JSON formatted data
 jsonListenerPorts=3878
 
+# Number of threads that flush data to the server. If not defined in wavefront.conf it defaults to the
+# number of processors (min 4). Setting this value too large will result in sending batches that are
+# too small to the server and wasting connections. This setting is per listening port.
+flushThreads=4
+
 # Max points per flush. Typically 40000.
 pushFlushMaxPoints=40000
 

--- a/proxy/src/main/java/com/wavefront/agent/AbstractAgent.java
+++ b/proxy/src/main/java/com/wavefront/agent/AbstractAgent.java
@@ -61,8 +61,6 @@ public abstract class AbstractAgent {
   private static final Gson GSON = new Gson();
   private static final int GRAPHITE_LISTENING_PORT = 2878;
   private static final int OPENTSDB_LISTENING_PORT = 4242;
-  private static final int HTTP_JSON_LISTENING_PORT = 3878;
-  private static final int WRITE_HTTP_JSON_LISTENING_PORT = 4878;
 
   @Parameter(names = {"-f", "--file"}, description =
       "Proxy configuration file")
@@ -137,12 +135,12 @@ public abstract class AbstractAgent {
   protected String graphiteDelimiters = "_";
 
   @Parameter(names = {"--httpJsonPorts"}, description = "Comma-separated list of ports to listen on for json metrics " +
-      "data. Binds, by default, to " + HTTP_JSON_LISTENING_PORT)
-  protected String httpJsonPorts = "" + HTTP_JSON_LISTENING_PORT;
+      "data. Binds, by default, to none.")
+  protected String httpJsonPorts = "";
 
   @Parameter(names = {"--writeHttpJsonPorts"}, description = "Comma-separated list of ports to listen on for json metrics from collectd write_http json format " +
-      "data. Binds, by default, to " + WRITE_HTTP_JSON_LISTENING_PORT)
-  protected String writeHttpJsonPorts = "" + WRITE_HTTP_JSON_LISTENING_PORT;
+      "data. Binds, by default, to none.")
+  protected String writeHttpJsonPorts = "";
 
   @Parameter(names = {"--hostname"}, description = "Hostname for the agent. Defaults to FQDN of machine.")
   protected String hostname;


### PR DESCRIPTION
This pull changes the default configuration in 2 aspects:

1. Adds the new flushThreads property to the default configuration. It seems like it may be safer to explicitly set it to 4 here by default, rather than allowing the code to set it to a very large number like 32 in the case of a large machine. 

2. Disables ports 3878 and 4878 by default, but with a commented out property in wavefront.conf making it very easy to turn them on as needed.