### PR TITLE
Make try the default server URL

### DIFF
--- a/pkg/opt/wavefront/wavefront-proxy/conf/wavefront.conf
+++ b/pkg/opt/wavefront/wavefront-proxy/conf/wavefront.conf
@@ -22,7 +22,7 @@
 # The server should be either the primary Wavefront cloud server, or your custom VPC address.
 #   This will be provided to you by Wavefront.
 #
-server=https://metrics.wavefront.com/api/
+server=https://try.wavefront.com/api/
 
 # The hostname will be used to identify the internal agent statistics around point rates, JVM info, etc.
 #  We strongly recommend setting this to a name that is unique among your entire infrastructure,


### PR DESCRIPTION
The most common "new" user of the proxy is using try.wavefront.com so we should use that as the default.