### PR TITLE
Add status exit code

### DIFF
--- a/pkg/etc/init.d/wavefront-proxy
+++ b/pkg/etc/init.d/wavefront-proxy
@@ -52,6 +52,7 @@ status)
 		echo "$DESC is running (PID $(cat $PID_FILE))"
 	else
 		echo "$DESC is not running."
+		exit 3
 	fi
 ;;
 stop)


### PR DESCRIPTION
Service status call should return code based on the state of the service. `0` is for running service while `3` is for not running service. This change will allow automation tools like Chef/Puppet/... to restart the service in case it crashes. Currently, if the service is not running, it will not get restarted as the exit code is `0`.