### PR TITLE
Support OpenTSDB telnet and HTTP protocols on a single port

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ proxy/unitTest*
 
 test/buffer.*
 test/proxy*.out
+test/.wavefront_id

--- a/java-lib/src/main/java/com/wavefront/ingester/Ingester.java
+++ b/java-lib/src/main/java/com/wavefront/ingester/Ingester.java
@@ -37,8 +37,7 @@ public abstract class Ingester implements Runnable {
   private static final Logger logger = Logger.getLogger(Ingester.class.getCanonicalName());
 
   /**
-   * Default number of seconds before the channel idle timeout handler
-   * closes the connection.
+   * Default number of seconds before the channel idle timeout handler closes the connection.
    */
   private static final int CHANNEL_IDLE_TIMEOUT_IN_SECS_DEFAULT = (int) TimeUnit.DAYS.toSeconds(1);
 
@@ -80,36 +79,37 @@ public abstract class Ingester implements Runnable {
         addIdleTimeoutHandler(pipeline);
         pipeline.addLast(commandHandler);
       }
-      };
+    };
   }
 
   /**
    * Adds an idle timeout handler to the given pipeline
+   *
    * @param pipeline the pipeline to add the idle timeout handler
    */
   protected void addIdleTimeoutHandler(final ChannelPipeline pipeline) {
     // Shared across all reports for proper batching
     pipeline.addLast("idleStateHandler",
-                     new IdleStateHandler(CHANNEL_IDLE_TIMEOUT_IN_SECS_DEFAULT,
-                                          0, 0));
+        new IdleStateHandler(CHANNEL_IDLE_TIMEOUT_IN_SECS_DEFAULT,
+            0, 0));
     pipeline.addLast("idleChannelTerminator", new ChannelDuplexHandler() {
-        @Override
-        public void userEventTriggered(ChannelHandlerContext ctx,
-                                       Object evt) throws Exception {
-          if (evt instanceof IdleStateEvent) {
-            if (((IdleStateEvent) evt).state() == IdleState.READER_IDLE) {
-              logger.warning("terminating connection to graphite client due to inactivity after " + CHANNEL_IDLE_TIMEOUT_IN_SECS_DEFAULT + "s: " + ctx.channel());
-              ctx.close();
-            }
+      @Override
+      public void userEventTriggered(ChannelHandlerContext ctx,
+                                     Object evt) throws Exception {
+        if (evt instanceof IdleStateEvent) {
+          if (((IdleStateEvent) evt).state() == IdleState.READER_IDLE) {
+            logger.warning("terminating connection to graphite client due to inactivity after " + CHANNEL_IDLE_TIMEOUT_IN_SECS_DEFAULT + "s: " + ctx.channel());
+            ctx.close();
           }
         }
-      });
+      }
+    });
   }
 
   /**
-   * Adds additional decoders passed in during construction of this object
-   * (if not null).
-   * @param ch the channel and pipeline to add these decoders to
+   * Adds additional decoders passed in during construction of this object (if not null).
+   *
+   * @param ch       the channel and pipeline to add these decoders to
    * @param decoders the list of decoders to add to the channel
    */
   protected void addDecoders(final Channel ch, @Nullable List<Function<Channel, ChannelHandler>> decoders) {

--- a/java-lib/src/main/java/com/wavefront/ingester/Ingester.java
+++ b/java-lib/src/main/java/com/wavefront/ingester/Ingester.java
@@ -9,7 +9,10 @@ import java.util.logging.Logger;
 
 import javax.annotation.Nullable;
 
+import io.netty.bootstrap.AbstractBootstrap;
 import io.netty.bootstrap.ServerBootstrap;
+
+import io.netty.channel.Channel;
 import io.netty.channel.ChannelDuplexHandler;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelHandler;
@@ -19,7 +22,6 @@ import io.netty.channel.ChannelOption;
 import io.netty.channel.ChannelPipeline;
 import io.netty.channel.nio.NioEventLoopGroup;
 import io.netty.channel.socket.SocketChannel;
-import io.netty.channel.socket.nio.NioServerSocketChannel;
 import io.netty.handler.codec.LineBasedFrameDecoder;
 import io.netty.handler.codec.string.StringDecoder;
 import io.netty.handler.timeout.IdleState;
@@ -31,76 +33,92 @@ import io.netty.handler.timeout.IdleStateHandler;
  *
  * @author Clement Pang (clement@wavefront.com).
  */
-public class Ingester implements Runnable {
-
+public abstract class Ingester implements Runnable {
   private static final Logger logger = Logger.getLogger(Ingester.class.getCanonicalName());
 
-  private static final int CHANNEL_IDLE_TIMEOUT_IN_SECS = (int) TimeUnit.DAYS.toSeconds(1);
+  /**
+   * Default number of seconds before the channel idle timeout handler
+   * closes the connection.
+   */
+  private static final int CHANNEL_IDLE_TIMEOUT_IN_SECS_DEFAULT = (int) TimeUnit.DAYS.toSeconds(1);
 
-  @Nullable
-  private final List<Function<SocketChannel, ChannelHandler>> decoders;
-  private final ChannelHandler commandHandler;
-  private final int listeningPort;
+  /**
+   * The port that this ingester should be listening on
+   */
+  protected final int listeningPort;
 
-  public Ingester(List<Function<SocketChannel, ChannelHandler>> decoders,
+  /**
+   * The channel initializer object for the netty channel
+   */
+  protected ChannelInitializer initializer;
+
+  public Ingester(@Nullable List<Function<Channel, ChannelHandler>> decoders,
                   ChannelHandler commandHandler, int port) {
     this.listeningPort = port;
-    this.commandHandler = commandHandler;
-    this.decoders = decoders;
+    this.createInitializer(decoders, commandHandler);
   }
 
   public Ingester(ChannelHandler commandHandler, int port) {
     this.listeningPort = port;
-    this.commandHandler = commandHandler;
-    this.decoders = null;
+    this.createInitializer(null, commandHandler);
   }
 
-  public void run() {
-    // Configure the server.
-    ServerBootstrap b = new ServerBootstrap();
-    try {
-      b.group(new NioEventLoopGroup(1), new NioEventLoopGroup())
-          .channel(NioServerSocketChannel.class)
-          .option(ChannelOption.SO_BACKLOG, 1024)
-          .localAddress(listeningPort)
-          .childHandler(new ChannelInitializer<SocketChannel>() {
-            @Override
-            public void initChannel(SocketChannel ch) throws Exception {
-              ChannelPipeline pipeline = ch.pipeline();
-              pipeline.addLast(new LineBasedFrameDecoder(4096, true, true));
-              pipeline.addLast(new StringDecoder(Charsets.UTF_8));
-              if (decoders != null) {
-                for (Function<SocketChannel, ChannelHandler> handler : decoders) {
-                  pipeline.addLast(handler.apply(ch));
-                }
-              }
-              // Shared across all reports for proper batching
-              pipeline.addLast("idleStateHandler", new IdleStateHandler(CHANNEL_IDLE_TIMEOUT_IN_SECS,
-                  0, 0));
-              pipeline.addLast("idleChannelTerminator", new ChannelDuplexHandler() {
-                @Override
-                public void userEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
-                  if (evt instanceof IdleStateEvent) {
-                    if (((IdleStateEvent) evt).state() == IdleState.READER_IDLE) {
-                      logger.warning("terminating connection to graphite client due to inactivity after " +
-                          CHANNEL_IDLE_TIMEOUT_IN_SECS + "s: " + ctx.channel());
-                      ctx.close();
-                    }
-                  }
-                }
-              });
-              pipeline.addLast(commandHandler);
+  public Ingester(ChannelInitializer initializer, int port) {
+    this.listeningPort = port;
+    this.initializer = initializer;
+  }
+
+  /**
+   * Creates the ChannelInitializer for this ingester
+   */
+  private void createInitializer(@Nullable final List<Function<Channel, ChannelHandler>> decoders, final ChannelHandler commandHandler) {
+    this.initializer = new ChannelInitializer<SocketChannel>() {
+      @Override
+      public void initChannel(SocketChannel ch) throws Exception {
+        ChannelPipeline pipeline = ch.pipeline();
+        addDecoders(ch, decoders);
+        addIdleTimeoutHandler(pipeline);
+        pipeline.addLast(commandHandler);
+      }
+      };
+  }
+
+  /**
+   * Adds an idle timeout handler to the given pipeline
+   * @param pipeline the pipeline to add the idle timeout handler
+   */
+  protected void addIdleTimeoutHandler(final ChannelPipeline pipeline) {
+    // Shared across all reports for proper batching
+    pipeline.addLast("idleStateHandler",
+                     new IdleStateHandler(CHANNEL_IDLE_TIMEOUT_IN_SECS_DEFAULT,
+                                          0, 0));
+    pipeline.addLast("idleChannelTerminator", new ChannelDuplexHandler() {
+        @Override
+        public void userEventTriggered(ChannelHandlerContext ctx,
+                                       Object evt) throws Exception {
+          if (evt instanceof IdleStateEvent) {
+            if (((IdleStateEvent) evt).state() == IdleState.READER_IDLE) {
+              logger.warning("terminating connection to graphite client due to inactivity after " + CHANNEL_IDLE_TIMEOUT_IN_SECS_DEFAULT + "s: " + ctx.channel());
+              ctx.close();
             }
-          });
+          }
+        }
+      });
+  }
 
-      // Start the server.
-      ChannelFuture f = b.bind().sync();
-
-      // Wait until the server socket is closed.
-      f.channel().closeFuture().sync();
-    } catch (InterruptedException e) {
-      // Server was interrupted
-      e.printStackTrace();
+  /**
+   * Adds additional decoders passed in during construction of this object
+   * (if not null).
+   * @param ch the channel and pipeline to add these decoders to
+   * @param decoders the list of decoders to add to the channel
+   */
+  protected void addDecoders(final Channel ch, @Nullable List<Function<Channel, ChannelHandler>> decoders) {
+    if (decoders != null) {
+      ChannelPipeline pipeline = ch.pipeline();
+      for (Function<Channel, ChannelHandler> handler : decoders) {
+        pipeline.addLast(handler.apply(ch));
+      }
     }
   }
+
 }

--- a/java-lib/src/main/java/com/wavefront/ingester/OpenTSDBDecoder.java
+++ b/java-lib/src/main/java/com/wavefront/ingester/OpenTSDBDecoder.java
@@ -52,4 +52,8 @@ public class OpenTSDBDecoder implements Decoder<String> {
       out.add(point);
     }
   }
+
+  public String getDefaultHostName() {
+    return this.hostName;
+  }
 }

--- a/java-lib/src/main/java/com/wavefront/ingester/PickleProtocolDecoder.java
+++ b/java-lib/src/main/java/com/wavefront/ingester/PickleProtocolDecoder.java
@@ -110,10 +110,10 @@ public class PickleProtocolDecoder implements Decoder<byte[]> {
           this.metricMangler.extractComponents(o[0].toString());
       point.setMetric(components.metric);
       String host = components.source;
-      if (host == null) {
-        final Map<String, String> annotations = point.getAnnotations();
+      final Map<String, String> annotations = point.getAnnotations();
+      if (host == null && annotations != null) {
         // iterate over the set of custom tags, breaking when one is found
-        for (String tag : customSourceTags) {
+        for (final String tag : customSourceTags) {
           host = annotations.remove(tag);
           if (host != null) {
             break;

--- a/java-lib/src/main/java/com/wavefront/ingester/StringLineIngester.java
+++ b/java-lib/src/main/java/com/wavefront/ingester/StringLineIngester.java
@@ -9,6 +9,8 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+import javax.annotation.Nullable;
+
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandler;
 import io.netty.handler.codec.LineBasedFrameDecoder;
@@ -38,7 +40,7 @@ public class StringLineIngester extends TcpIngester {
    * @param decoders the starting list
    * @return copy of the provided list with additional decodiers prepended
    */
-  private static List<Function<Channel, ChannelHandler>> createDecoderList(final List<Function<Channel, ChannelHandler>> decoders) {
+  private static List<Function<Channel, ChannelHandler>> createDecoderList(@Nullable final List<Function<Channel, ChannelHandler>> decoders) {
     final List<Function<Channel, ChannelHandler>> copy;
     if (decoders == null) {
       copy = new ArrayList<>();

--- a/java-lib/src/main/java/com/wavefront/ingester/StringLineIngester.java
+++ b/java-lib/src/main/java/com/wavefront/ingester/StringLineIngester.java
@@ -1,0 +1,71 @@
+package com.wavefront.ingester;
+
+import com.google.common.base.Charsets;
+import com.google.common.base.Function;
+
+import org.apache.commons.lang.StringUtils;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelHandler;
+import io.netty.handler.codec.LineBasedFrameDecoder;
+import io.netty.handler.codec.string.StringDecoder;
+
+/**
+ * Default Ingester thread that sets up decoders and a command handler to listen for metrics that
+ * are string formatted lines on a port.
+ */
+public class StringLineIngester extends TcpIngester {
+
+  private static final String PUSH_DATA_DELIMETER = "\n";
+
+  public StringLineIngester(List<Function<Channel, ChannelHandler>> decoders,
+                            ChannelHandler commandHandler, int port) {
+    super(createDecoderList(decoders), commandHandler, port);
+  }
+
+  public StringLineIngester(ChannelHandler commandHandler, int port) {
+    super(createDecoderList(null), commandHandler, port);
+  }
+
+  /**
+   * Returns a copy of the given list plus inserts the 2 decoders needed for this specific ingester
+   * (LineBasedFrameDecoder and StringDecoder)
+   *
+   * @param decoders the starting list
+   * @return copy of the provided list with additional decodiers prepended
+   */
+  private static List<Function<Channel, ChannelHandler>> createDecoderList(final List<Function<Channel, ChannelHandler>> decoders) {
+    final List<Function<Channel, ChannelHandler>> copy;
+    if (decoders == null) {
+      copy = new ArrayList<>();
+    } else {
+      copy = new ArrayList<>(decoders);
+    }
+    copy.add(0, new Function<Channel, ChannelHandler>() {
+      @Override
+      public ChannelHandler apply(Channel input) {
+        return new LineBasedFrameDecoder(4096, true, true);
+      }
+    });
+    copy.add(1, new Function<Channel, ChannelHandler>() {
+      @Override
+      public ChannelHandler apply(Channel input) {
+        return new StringDecoder(Charsets.UTF_8);
+      }
+    });
+
+    return copy;
+  }
+
+  public static List<String> unjoinPushData(String pushData) {
+    return Arrays.asList(StringUtils.split(pushData, PUSH_DATA_DELIMETER));
+  }
+
+  public static String joinPushData(List<String> pushData) {
+    return StringUtils.join(pushData, PUSH_DATA_DELIMETER);
+  }
+}

--- a/java-lib/src/main/java/com/wavefront/ingester/TcpIngester.java
+++ b/java-lib/src/main/java/com/wavefront/ingester/TcpIngester.java
@@ -1,0 +1,54 @@
+package com.wavefront.ingester;
+
+import com.google.common.base.Function;
+
+import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import io.netty.bootstrap.ServerBootstrap;
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelHandler;
+import io.netty.channel.ChannelInitializer;
+import io.netty.channel.ChannelOption;
+import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.channel.Channel;
+import io.netty.channel.socket.nio.NioServerSocketChannel;
+
+/**
+ * Ingester thread that sets up decoders and a command handler to listen for metrics on a port.
+ * @author Mike McLaughlin (mike@wavefront.com)
+ */
+public class TcpIngester extends Ingester {
+
+  private static final Logger logger =
+    Logger.getLogger(TcpIngester.class.getCanonicalName());
+
+  public TcpIngester(List<Function<Channel, ChannelHandler>> decoders,
+                     ChannelHandler commandHandler, int port) {
+    super(decoders, commandHandler, port);
+  }
+
+  public TcpIngester(ChannelInitializer initializer, int port) {
+    super(initializer, port);
+  }
+
+  public void run() {
+    ServerBootstrap b = new ServerBootstrap();
+    try {
+      b.group(new NioEventLoopGroup(1), new NioEventLoopGroup())
+        .channel(NioServerSocketChannel.class)
+        .option(ChannelOption.SO_BACKLOG, 1024)
+        .localAddress(listeningPort)
+        .childHandler(initializer);
+
+      // Start the server.
+      ChannelFuture f = b.bind().sync();
+
+      // Wait until the server socket is closed.
+      f.channel().closeFuture().sync();
+    } catch (final InterruptedException e) {
+      logger.log(Level.WARNING, "Interrupted", e);
+    }
+  }
+}

--- a/proxy/src/main/java/com/wavefront/agent/ChannelByteArrayHandler.java
+++ b/proxy/src/main/java/com/wavefront/agent/ChannelByteArrayHandler.java
@@ -1,20 +1,16 @@
 package com.wavefront.agent;
 
-import com.google.common.base.Function;
 import com.google.common.base.Throwables;
 import com.google.common.collect.Lists;
 
-import com.wavefront.agent.api.ForceQueueEnabledAgentAPI;
 import com.wavefront.common.MetricWhiteBlackList;
 import com.wavefront.ingester.Decoder;
 
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.SimpleChannelInboundHandler;
-import org.apache.commons.lang.StringUtils;
 import sunnylabs.report.ReportPoint;
 
-import java.util.Arrays;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -27,12 +23,11 @@ import javax.annotation.Nullable;
  * @author Mike McLaughlin (mike@wavefront.com)
  */
 @ChannelHandler.Sharable
-public class ChannelByteArrayHandler extends SimpleChannelInboundHandler<byte[]> {
+class ChannelByteArrayHandler extends SimpleChannelInboundHandler<byte[]> {
   private static final Logger logger = Logger.getLogger(
       ChannelByteArrayHandler.class.getCanonicalName());
 
   private final Decoder<byte[]> decoder;
-  private final String prefix;
   private final PointHandler pointHandler;
 
   private MetricWhiteBlackList whiteBlackList;
@@ -40,19 +35,16 @@ public class ChannelByteArrayHandler extends SimpleChannelInboundHandler<byte[]>
   /**
    * Constructor.
    */
-  public ChannelByteArrayHandler(Decoder<byte[]> decoder,
+  ChannelByteArrayHandler(Decoder<byte[]> decoder,
                                  final int port,
                                  final String prefix,
-                                 final String logLevel,
                                  final String validationLevel,
-                                 final long millisecondsPerBatch,
                                  final int blockedPointsPerBatch,
                                  final PostPushDataTimedTask[] postPushDataTimedTasks,
                                  @Nullable final String pointLineWhiteListRegex,
                                  @Nullable final String pointLineBlackListRegex) {
     this.decoder = decoder;
-    this.pointHandler = new PointHandler(port, validationLevel, blockedPointsPerBatch, postPushDataTimedTasks);
-    this.prefix = prefix;
+    this.pointHandler = new PointHandler(port, validationLevel, blockedPointsPerBatch, prefix, postPushDataTimedTasks);
     this.whiteBlackList = new MetricWhiteBlackList(
       pointLineWhiteListRegex, pointLineBlackListRegex, String.valueOf(port));
   }
@@ -72,38 +64,28 @@ public class ChannelByteArrayHandler extends SimpleChannelInboundHandler<byte[]>
           pointHandler.handleBlockedPoint(point.getMetric());
           continue;
         }
-        if (prefix != null) {
-          point.setMetric(prefix + "." + point.getMetric());
-        }
         pointHandler.reportPoint(point, point.getMetric());
       }
-    } catch (final Exception any) {
-      logger.log(Level.WARNING, "Failed to read:\n" + new String(msg), any);
-      final Throwable rootCause = Throwables.getRootCause(any);
-      if (rootCause == null || rootCause.getMessage() == null) {
-        final String message = "WF-300 Cannot parse: \"" + new String(msg)
-            + "\", reason: \"" + any.getMessage() + "\"";
-        pointHandler.handleBlockedPoint(message);
-      } else {
-        final String message = "WF-300 Cannot parse: \"" + new String(msg)
-            + "\", reason: \"" + any.getMessage()
-            + "\", root cause: \"" + rootCause.getMessage() + "\"";
-        pointHandler.handleBlockedPoint(message);
+    } catch (final Exception e) {
+      final Throwable rootCause = Throwables.getRootCause(e);
+      String errMsg = "WF-300 Cannot parse: \"" +
+          "\", reason: \"" + e.getMessage() + "\"";
+      if (rootCause != null && rootCause.getMessage() != null) {
+        errMsg = errMsg + ", root cause: \"" + rootCause.getMessage() + "\"";
       }
+      logger.log(Level.WARNING, errMsg, e);
+      pointHandler.handleBlockedPoint(errMsg);
     }
   }
 
   @Override
   public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
     final Throwable rootCause = Throwables.getRootCause(cause);
-    if (rootCause == null || rootCause.getMessage() == null) {
-      final String message = "WF-301 Channel Handler Failed, reason: \""
-          + cause.getMessage() + "\"";
-      pointHandler.handleBlockedPoint(message);
-    } else {
-      final String message = "WF-301 Channel Handler Failed, reason: \""
-          + cause.getMessage() + "\", root cause: \"" + rootCause.getMessage() + "\"";
-      pointHandler.handleBlockedPoint(message);
+    String message = "WF-301 Channel Handler Failed, reason: \""
+        + cause.getMessage() + "\"";
+    if (rootCause != null && rootCause.getMessage() != null) {
+      message += ", root cause: \"" + rootCause.getMessage() + "\"";
     }
+    pointHandler.handleBlockedPoint(message);
   }
 }

--- a/proxy/src/main/java/com/wavefront/agent/ChannelStringHandler.java
+++ b/proxy/src/main/java/com/wavefront/agent/ChannelStringHandler.java
@@ -17,6 +17,7 @@ import java.util.UUID;
 import java.util.logging.Logger;
 
 import javax.annotation.Nullable;
+import javax.validation.constraints.Null;
 
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
@@ -34,7 +35,7 @@ public class ChannelStringHandler extends SimpleChannelInboundHandler<String> {
   private static final Logger logger = Logger.getLogger(ChannelStringHandler.class.getCanonicalName());
 
   private final Decoder<String> decoder;
-  private final String prefix;
+
   /**
    * Transformer to transform each line.
    */
@@ -54,93 +55,67 @@ public class ChannelStringHandler extends SimpleChannelInboundHandler<String> {
                               @Nullable final String pointLineWhiteListRegex,
                               @Nullable final String pointLineBlackListRegex) {
     this.decoder = decoder;
-    this.pointHandler = new PointHandler(port, validationLevel, blockedPointsPerBatch, postPushDataTimedTasks);
-    this.prefix = prefix;
+    this.pointHandler = new PointHandler(port, validationLevel, blockedPointsPerBatch, prefix, postPushDataTimedTasks);
     this.transformer = transformer;
     this.whiteBlackList = new MetricWhiteBlackList(pointLineWhiteListRegex,
                                                    pointLineBlackListRegex,
                                                    String.valueOf(port));
   }
 
-  public static final String PUSH_DATA_DELIMETER = "\n";
-
-  public static List<String> unjoinPushData(String pushData) {
-    return Arrays.asList(StringUtils.split(pushData, PUSH_DATA_DELIMETER));
-  }
-
-  public static String joinPushData(List<String> pushData) {
-    return StringUtils.join(pushData, PUSH_DATA_DELIMETER);
-  }
-
-  /**
-   * Verify the given point is valid to send to WF.
-   * @param point The point to verify.
-   * @return A human readable error message regarding the point, or empty string if the point is OK.
-   */
-  private String verifyPoint(ReportPoint point) {
-    StringBuilder sb = new StringBuilder();
-    if (point.getHost().length() >= 1024) {
-      sb.append(" Host too long: ").append(point.getHost()).append(".");
-    }
-    if (point.getMetric().length() >= 1024) {
-      sb.append(" Metric too long: ").append(point.getMetric()).append(".");
-    }
-    // Each tag of the form "k=v" must be < 256
-    for (Map.Entry<String, String> tag : point.getAnnotations().entrySet()) {
-      if (tag.getKey().length() + tag.getValue().length() >= 255) {
-        sb.append(" Tag too long: ").append(tag.getKey()).append("=").append(tag.getValue())
-            .append(".");
-      }
-    }
-    if (sb.length() > 0) {
-      sb.insert(0, "WF-301: Point is malformed.");
-      return sb.toString();
-    }
-    return "";
+  protected ChannelStringHandler(Decoder<String> decoder,
+                                 final PointHandler pointhandler,
+                                 final MetricWhiteBlackList whiteBlackList,
+                                 @Nullable final Function<String, String> transformer) {
+    this.decoder = decoder;
+    this.pointHandler = pointhandler;
+    this.transformer = transformer;
+    this.whiteBlackList = whiteBlackList;
   }
 
   @Override
   protected void channelRead0(ChannelHandlerContext ctx, String msg) throws Exception {
+    processPointLine(msg, decoder, pointHandler, whiteBlackList, transformer);
+  }
+
+  /**
+   * This probably belongs in a base class.  It's only done like this so it can be easily re-used.
+   * This should be refactored when it's clear where it belongs.
+   */
+  public static void processPointLine(final String message,
+                                      Decoder<String> decoder,
+                                      final PointHandler pointHandler,
+                                      final MetricWhiteBlackList whiteBlackList,
+                                      @Nullable final Function<String, String> transformer) {
     // ignore empty lines.
+    String msg = message;
     if (msg == null || msg.trim().length() == 0) return;
+
+    // transform the line if needed
     if (transformer != null) {
       msg = transformer.apply(msg);
     }
     String pointLine = msg.trim();
 
-    // apply white/black lists after formatting, but before prefixing
-    if (!this.whiteBlackList.passes(pointLine)) {
+    // apply white/black lists after formatting
+    if (!whiteBlackList.passes(pointLine)) {
       pointHandler.handleBlockedPoint(pointLine);
       return;
     }
-    if (prefix != null) {
-      pointLine = prefix + "." + msg;
-    }
+
+    // decode the line into report points
     List<ReportPoint> points = Lists.newArrayListWithExpectedSize(1);
     try {
       decoder.decodeReportPoints(pointLine, points, "dummy");
     } catch (Exception e) {
       final Throwable rootCause = Throwables.getRootCause(e);
-      if (rootCause == null || rootCause.getMessage() == null) {
-        final String message = "WF-300 Cannot parse: \"" + pointLine +
+      String errMsg = "WF-300 Cannot parse: \"" + pointLine +
             "\", reason: \"" + e.getMessage() + "\"";
-        pointHandler.handleBlockedPoint(message);
-      } else {
-        final String message = "WF-300 Cannot parse: \"" + pointLine +
-            "\", reason: \"" + e.getMessage() +
-            "\", root cause: \"" + rootCause.getMessage() + "\"";
-        pointHandler.handleBlockedPoint(message);
+      if (rootCause != null && rootCause.getMessage() != null) {
+        errMsg = errMsg + ", root cause: \"" + rootCause.getMessage() + "\"";
       }
+      pointHandler.handleBlockedPoint(errMsg);
     }
-    if (!points.isEmpty()) {
-      ReportPoint point = points.get(0);
-      String errorMessage = verifyPoint(point);
-      if (!errorMessage.equals("")) {
-        pointHandler.handleBlockedPoint(errorMessage);
-      } else {
-        pointHandler.reportPoint(point, pointLine);
-      }
-    }
+    pointHandler.reportPoints(points);
   }
 
   @Override

--- a/proxy/src/main/java/com/wavefront/agent/OpenTSDBPortUnificationHandler.java
+++ b/proxy/src/main/java/com/wavefront/agent/OpenTSDBPortUnificationHandler.java
@@ -1,0 +1,310 @@
+package com.wavefront.agent;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.util.logging.Logger;
+import java.util.logging.Level;
+import java.util.HashMap;
+import java.util.Map;
+import java.net.URI;
+
+import javax.annotation.Nullable;
+
+import io.netty.buffer.Unpooled;
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelFutureListener;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.SimpleChannelInboundHandler;
+import io.netty.handler.codec.http.DefaultFullHttpResponse;
+import io.netty.handler.codec.http.FullHttpRequest;
+import io.netty.handler.codec.http.FullHttpResponse;
+import io.netty.handler.codec.http.HttpHeaders;
+import io.netty.handler.codec.http.HttpRequest;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.util.CharsetUtil;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import com.google.common.base.Throwables;
+
+import com.wavefront.ingester.OpenTSDBDecoder;
+import com.wavefront.common.MetricWhiteBlackList;
+import com.wavefront.metrics.JsonMetricsParser;
+
+import sunnylabs.report.ReportPoint;
+
+import static io.netty.handler.codec.http.HttpHeaders.Names.*;
+import static io.netty.handler.codec.http.HttpVersion.*;
+
+/**
+ * This class handles an incoming message of either String or FullHttpRequest type.  All other types
+ * are ignored. This will likely be passed to the PlainTextOrHttpFrameDecoder as the handler for
+ * messages.
+ * @author Mike McLaughlin (mike@wavefront.com)
+ */
+class OpenTSDBPortUnificationHandler extends SimpleChannelInboundHandler<Object> {
+  private static final Logger logger = Logger.getLogger(
+      OpenTSDBPortUnificationHandler.class.getCanonicalName());
+
+  /**
+   * The point handler that takes report metrics one data point at a time and handles batching and
+   * retries, etc
+   */
+  private final PointHandler pointHandler;
+
+  /**
+   * OpenTSDB decoder object
+   */
+  private final OpenTSDBDecoder decoder;
+
+  /**
+   * white list/ black list handler
+   */
+  private final MetricWhiteBlackList whiteBlackList;
+
+  OpenTSDBPortUnificationHandler(final OpenTSDBDecoder decoder,
+                                 final int port,
+                                 final String prefix,
+                                 final String validationLevel,
+                                 final int blockedPointsPerBatch,
+                                 final PostPushDataTimedTask[] postPushDataTimedTasks,
+                                 @Nullable final String pointLineWhiteListRegex,
+                                 @Nullable final String pointLineBlackListRegex) {
+    this.decoder = decoder;
+    this.pointHandler = new PointHandler(
+        port, validationLevel, blockedPointsPerBatch, prefix, postPushDataTimedTasks);
+    this.whiteBlackList = new MetricWhiteBlackList(
+        pointLineWhiteListRegex, pointLineBlackListRegex, String.valueOf(port));
+  }
+
+  @Override
+  public void channelReadComplete(ChannelHandlerContext ctx) {
+    ctx.flush();
+  }
+
+  @Override
+  public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
+    blockMessage("WF-301", "Handler failed", cause);
+  }
+
+  @Override
+  protected void channelRead0(final ChannelHandlerContext ctx,
+                              final Object message) {
+    try {
+      if (message != null) {
+        if (message instanceof String) {
+          handlePlainTextMessage(ctx, message);
+        } else if (message instanceof FullHttpRequest) {
+          handleHttpMessage(ctx, message);
+        } else {
+          blockMessage("WF-300", "Unexpected message type " + message.getClass().getName(), null);
+        }
+      }
+    } catch (final Exception e) {
+      blockMessage("WF-300", "Failed to handle message", e);
+    }
+  }
+
+  /**
+   * Handles an incoming HTTP message.  The currently supported paths are:
+   *   {@link <a href="http://opentsdb.net/docs/build/html/api_http/put.html">/api/put</a>}
+   *   {@link <a href="http://opentsdb.net/docs/build/html/api_http/version.html">/api/version</a>},
+   *
+   * @throws IOException        when reading contents of HTTP body fails
+   * @throws URISyntaxException when the request URI cannot be parsed
+   */
+  private void handleHttpMessage(final ChannelHandlerContext ctx,
+                                 final Object message) throws IOException, URISyntaxException {
+    final FullHttpRequest request = (FullHttpRequest) message;
+    final URI uri = new URI(request.getUri());
+    if (uri.getPath().equals("/api/put")) {
+      final ObjectMapper jsonTree = new ObjectMapper();
+      HttpResponseStatus status;
+      // from the docs:
+      // The put endpoint will respond with a 204 HTTP status code and no content if all data points
+      // were stored successfully. If one or more data points had an error, the API will return a 400.
+      if (reportMetrics(jsonTree.readTree(request.content().toString(CharsetUtil.UTF_8)))) {
+        status = HttpResponseStatus.NO_CONTENT;
+      } else {
+        status = HttpResponseStatus.BAD_REQUEST;
+      }
+      writeHttpResponse(request, ctx, status, "");
+    } else if (uri.getPath().equals("/api/version")) {
+      writeHttpResponse(request, ctx, HttpResponseStatus.OK,
+          "Wavefront OpenTSDB Endpoint"); // TODO: should be a JSON response object (see docs)
+      // http://opentsdb.net/docs/build/html/api_http/version.html
+    } else {
+      writeHttpResponse(request, ctx, HttpResponseStatus.BAD_REQUEST, "Unsupported path");
+      blockMessage("WF-300", "Unexpected path '" + request.getUri() + "'", null);
+    }
+  }
+
+  /**
+   * Handles an incoming plain text (string) message.
+   * Handles :
+   *   
+   */
+  private void handlePlainTextMessage(final ChannelHandlerContext ctx,
+                                      final Object message) throws Exception {
+    final String messageStr = (String) message;
+    if (message == null) {
+      throw new IllegalArgumentException("Message cannot be null");
+    }
+    if (logger.isLoggable(Level.FINE)) {
+      logger.fine("Handling plain text message: " + messageStr);
+    }
+    if (messageStr.substring(0, 7).equals("version")) {
+      ChannelFuture f = ctx.writeAndFlush("Wavefront OpenTSDB Endpoint\n");
+      if (!f.isSuccess()) {
+        throw new Exception("Failed to write version response", f.cause());
+      }
+    } else {
+      ChannelStringHandler.processPointLine(messageStr, decoder, pointHandler, whiteBlackList, null);
+    }
+  }
+
+  /**
+   * Parse the metrics JSON and report the metrics found.  There are 2 formats supported: - array of
+   * points - single point
+   *
+   * @param metrics an array of objects or a single object representing a metric
+   * @return true if all metrics added successfully; false o/w
+   * @see #reportMetric(JsonNode)
+   */
+  private boolean reportMetrics(final JsonNode metrics) {
+    if (!metrics.isArray()) {
+      return reportMetric(metrics);
+    } else {
+      boolean successful = true;
+      for (final JsonNode metric : metrics) {
+        if (!reportMetric(metric)) {
+          successful = false;
+        }
+      }
+      return successful;
+    }
+  }
+
+  /**
+   * Parse the individual metric object and send the metric to on to the point handler.
+   *
+   * @param metric the JSON object representing a single metric
+   * @return True if the metric was reported successfully; False o/w
+   * @see <a href="http://opentsdb.net/docs/build/html/api_http/put.html">OpenTSDB /api/put documentation</a>
+   */
+  private boolean reportMetric(final JsonNode metric) {
+    final PostPushDataTimedTask randomPostTask = this.pointHandler.getRandomPostTask();
+    try {
+      String metricName = metric.get("metric").textValue();
+      JsonNode tags = metric.get("tags");
+      Map<String, String> wftags = JsonMetricsParser.makeTags(tags);
+
+      String hostName;
+      if (wftags.containsKey("host")) {
+        hostName = wftags.get("host");
+      } else if (wftags.containsKey("source")) {
+        hostName = wftags.get("source");
+      } else {
+        hostName = decoder.getDefaultHostName();
+      }
+      // remove source/host from the tags list
+      Map<String, String> wftags2 = new HashMap<>();
+      for (Map.Entry<String, String> wftag : wftags.entrySet()) {
+        if (wftag.getKey().equalsIgnoreCase("host") ||
+            wftag.getKey().equalsIgnoreCase("source")) {
+          continue;
+        }
+        wftags2.put(wftag.getKey(), wftag.getValue());
+      }
+
+      ReportPoint.Builder builder = ReportPoint.newBuilder();
+      builder.setMetric(metricName);
+      JsonNode time = metric.get("timestamp");
+      long ts = 0;
+      if (time != null) {
+        if (Long.toString(ts).length() == 10) {
+          ts = time.asLong() * 1000;
+        } else {
+          ts = time.asLong();
+        }
+      }
+      builder.setTimestamp(ts);
+      JsonNode value = metric.get("value");
+      if (value == null) {
+        randomPostTask.incrementBlockedPoints();
+        logger.warning("Skipping.  Missing 'value' in JSON node.");
+        return false;
+      }
+      if (value.isDouble()) {
+        builder.setValue(value.asDouble());
+      } else {
+        builder.setValue(value.asLong());
+      }
+      builder.setAnnotations(wftags2);
+      builder.setTable("dummy");
+      builder.setHost(hostName);
+      ReportPoint point = builder.build();
+      pointHandler.reportPoint(point, "OpenTSDB http json: " + PointHandler.pointToString(point));
+      return true;
+    } catch (final Exception e) {
+      blockMessage("WF-300", "Failed to add metric", e);
+      return false;
+    }
+  }
+
+  /**
+   * Writes an HTTP response
+   */
+  private void writeHttpResponse(HttpRequest request,
+                                 ChannelHandlerContext ctx,
+                                 HttpResponseStatus status,
+                                 String contents) {
+    // Decide whether to close the connection or not.
+    boolean keepAlive = HttpHeaders.isKeepAlive(request);
+    // Build the response object.
+    FullHttpResponse response = new DefaultFullHttpResponse(
+        HTTP_1_1, status, Unpooled.copiedBuffer(contents, CharsetUtil.UTF_8));
+    response.headers().set(CONTENT_TYPE, "text/plain; charset=UTF-8");
+
+    if (keepAlive) {
+      // Add 'Content-Length' header only for a keep-alive connection.
+      response.headers().set(CONTENT_LENGTH, response.content().readableBytes());
+      // Add keep alive header as per:
+      // - http://www.w3.org/Protocols/HTTP/1.1/draft-ietf-http-v11-spec-01.html#Connection
+      response.headers().set(CONNECTION, HttpHeaders.Values.KEEP_ALIVE);
+    }
+
+    // Write the response.
+    ctx.write(response);
+
+    if (!keepAlive) {
+      ctx.writeAndFlush(Unpooled.EMPTY_BUFFER)
+          .addListener(ChannelFutureListener.CLOSE);
+    }
+  }
+
+  /**
+   * Logs and handles a blocked metric
+   *
+   * @param messageId the error message ID
+   * @param message   the error message
+   * @param e         the exception (optional) that caused the message to be blocked
+   */
+  private void blockMessage(final String messageId, final String message, @Nullable final Throwable e) {
+    String errMsg = messageId + ": OpenTSDB: " + message;
+    if (e != null) {
+      final Throwable rootCause = Throwables.getRootCause(e);
+      errMsg = errMsg + "; reason: \"" + e.getMessage() + "\"";
+      if (rootCause != null && rootCause.getMessage() != null) {
+        errMsg = errMsg + ", root cause: \"" + rootCause.getMessage() + "\"";
+      }
+      logger.log(Level.WARNING, errMsg, e);
+    } else {
+      logger.warning(errMsg);
+    }
+
+    pointHandler.handleBlockedPoint(errMsg);
+  }
+}
+

--- a/proxy/src/main/java/com/wavefront/agent/PlainTextOrHttpFrameDecoder.java
+++ b/proxy/src/main/java/com/wavefront/agent/PlainTextOrHttpFrameDecoder.java
@@ -19,7 +19,7 @@ import java.util.List;
 import java.util.logging.Logger;
 
 /**
- * This class handles 2 d ifferent protocols on a single port.  Supported protocols include HTTP and
+ * This class handles 2 different protocols on a single port.  Supported protocols include HTTP and
  * a plain text protocol.  It dynamically adds the appropriate encoder/decoder based on the detected
  * protocol. This class was largely adapted from the example provided with netty v4.0
  *

--- a/proxy/src/main/java/com/wavefront/agent/PlainTextOrHttpFrameDecoder.java
+++ b/proxy/src/main/java/com/wavefront/agent/PlainTextOrHttpFrameDecoder.java
@@ -1,0 +1,108 @@
+package com.wavefront.agent;
+
+import com.google.common.base.Charsets;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.ChannelHandler;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelPipeline;
+import io.netty.handler.codec.ByteToMessageDecoder;
+import io.netty.handler.codec.LineBasedFrameDecoder;
+import io.netty.handler.codec.string.StringDecoder;
+import io.netty.handler.codec.string.StringEncoder;
+import io.netty.handler.codec.http.HttpContentCompressor;
+import io.netty.handler.codec.http.HttpObjectAggregator;
+import io.netty.handler.codec.http.HttpRequestDecoder;
+import io.netty.handler.codec.http.HttpResponseEncoder;
+
+import java.util.List;
+import java.util.logging.Logger;
+
+/**
+ * This class handles 2 d ifferent protocols on a single port.  Supported protocols include HTTP and
+ * a plain text protocol.  It dynamically adds the appropriate encoder/decoder based on the detected
+ * protocol. This class was largely adapted from the example provided with netty v4.0
+ *
+ * @see <a href="http://netty.io/4.0/xref/io/netty/example/portunification/PortUnificationServerHandler.html">Netty
+ * Port Unification Example</a>
+ * @author Mike McLaughlin (mike@wavefront.com)
+ */
+final class PlainTextOrHttpFrameDecoder extends ByteToMessageDecoder {
+
+  protected static final Logger logger = Logger.getLogger(PlainTextOrHttpFrameDecoder.class.getName());
+
+  /**
+   * The object for handling requests of either protocol
+   */
+  private final ChannelHandler handler;
+
+  private static final HttpRequestDecoder HTTP_REQUEST_DECODER = new HttpRequestDecoder();
+  private static final HttpResponseEncoder HTTP_RESPONSE_ENCODER = new HttpResponseEncoder();
+  private static final HttpObjectAggregator HTTP_OBJECT_AGGREGATOR = new HttpObjectAggregator(1048576);
+  private static final HttpContentCompressor HTTP_CONTENT_COMPRESSOR = new HttpContentCompressor();
+  private static final StringDecoder STRING_DECODER = new StringDecoder(Charsets.UTF_8);
+  private static final StringEncoder STRING_ENCODER = new StringEncoder(Charsets.UTF_8);
+
+  /**
+   * Constructor.
+   *
+   * @param handler the object responsible for handling the incoming messages or either protocol
+   */
+  PlainTextOrHttpFrameDecoder(final ChannelHandler handler) {
+    this.handler = handler;
+  }
+
+  /**
+   * Dynamically adds the appropriate encoder/decoder(s) to the pipeline based on the detected
+   * protocol.
+   */
+  @Override
+  protected void decode(final ChannelHandlerContext ctx,
+                        final ByteBuf buffer,
+                        List<Object> out) throws Exception {
+    // read the first 2 bytes to use for protocol detection
+    if (buffer.readableBytes() < 2) {
+      logger.warning("buffer has less that 2 readable bytes");
+      return;
+    }
+    final int firstByte = buffer.getUnsignedByte(buffer.readerIndex());
+    final int secondByte = buffer.getUnsignedByte(buffer.readerIndex() + 1);
+
+    // determine the protocol and add the encoder/decoder
+    final ChannelPipeline pipeline = ctx.pipeline();
+    if (isHttp(firstByte, secondByte)) {
+      pipeline.addLast("decoder", HTTP_REQUEST_DECODER);
+      pipeline.addLast("encoder", HTTP_RESPONSE_ENCODER);
+      pipeline.addLast("aggregator", HTTP_OBJECT_AGGREGATOR);
+      pipeline.addLast("deflate", HTTP_CONTENT_COMPRESSOR);
+      pipeline.addLast("handler", this.handler);
+    } else {
+      pipeline.addLast("line", new LineBasedFrameDecoder(4096));
+      pipeline.addLast("decoder", STRING_DECODER);
+      pipeline.addLast("encoder", STRING_ENCODER);
+      pipeline.addLast("handler", this.handler);
+    }
+
+    pipeline.remove(this);
+  }
+
+  /**
+   * @param magic1 the first byte of the incoming message
+   * @param magic2 the second byte of the incoming message
+   * @return true if this is an HTTP message; false o/w
+   * @see <a href="http://netty.io/4.0/xref/io/netty/example/portunification/PortUnificationServerHandler.html">Netty
+   * Port Unification Example</a>
+   */
+  private static boolean isHttp(int magic1, int magic2) {
+    return
+        ((magic1 == 'G' && magic2 == 'E') || // GET
+            (magic1 == 'P' && magic2 == 'O') || // POST
+            (magic1 == 'P' && magic2 == 'U') || // PUT
+            (magic1 == 'H' && magic2 == 'E') || // HEAD
+            (magic1 == 'O' && magic2 == 'P') || // OPTIONS
+            (magic1 == 'P' && magic2 == 'A') || // PATCH
+            (magic1 == 'D' && magic2 == 'E') || // DELETE
+            (magic1 == 'T' && magic2 == 'R') || // TRACE
+            (magic1 == 'C' && magic2 == 'O'));  // CONNECT
+  }
+}

--- a/proxy/src/main/java/com/wavefront/agent/PostPushDataTimedTask.java
+++ b/proxy/src/main/java/com/wavefront/agent/PostPushDataTimedTask.java
@@ -4,6 +4,7 @@ import com.google.common.util.concurrent.RateLimiter;
 
 import com.wavefront.agent.api.ForceQueueEnabledAgentAPI;
 import com.wavefront.api.agent.Constants;
+import com.wavefront.ingester.StringLineIngester;
 import com.yammer.metrics.Metrics;
 import com.yammer.metrics.core.Counter;
 import com.yammer.metrics.core.MetricName;
@@ -134,7 +135,7 @@ public class PostPushDataTimedTask implements Runnable {
         try {
           response = agentAPI.postPushData(daemonId, Constants.GRAPHITE_BLOCK_WORK_UNIT,
               System.currentTimeMillis(), Constants.PUSH_FORMAT_GRAPHITE_V2,
-              ChannelStringHandler.joinPushData(current));
+              StringLineIngester.joinPushData(current));
           int pointsInList = current.size();
           this.pointsAttempted.inc(pointsInList);
           if (response.getStatus() == Response.Status.NOT_ACCEPTABLE.getStatusCode()) {
@@ -161,7 +162,7 @@ public class PostPushDataTimedTask implements Runnable {
             if (pushDataPointCount > 0) {
               agentAPI.postPushData(daemonId, Constants.GRAPHITE_BLOCK_WORK_UNIT,
                   System.currentTimeMillis(), Constants.PUSH_FORMAT_GRAPHITE_V2,
-                  ChannelStringHandler.joinPushData(pushData), true);
+                  StringLineIngester.joinPushData(pushData), true);
 
               // update the counters as if this was a failed call to the API
               this.pointsAttempted.inc(pushDataPointCount);

--- a/proxy/src/main/java/com/wavefront/agent/QueuedAgentService.java
+++ b/proxy/src/main/java/com/wavefront/agent/QueuedAgentService.java
@@ -19,6 +19,7 @@ import com.wavefront.agent.api.ForceQueueEnabledAgentAPI;
 import com.wavefront.api.AgentAPI;
 import com.wavefront.api.agent.AgentConfiguration;
 import com.wavefront.api.agent.ShellOutputDTO;
+import com.wavefront.ingester.StringLineIngester;
 import com.wavefront.metrics.ExpectedAgentMetric;
 import com.yammer.metrics.Metrics;
 import com.yammer.metrics.core.Gauge;
@@ -562,7 +563,7 @@ public class QueuedAgentService implements ForceQueueEnabledAgentAPI {
       // pull the pushdata back apart to split and put back together
       List<PostPushDataResultTask> splitTasks = Lists.newArrayList();
 
-      List<String> pushDatum = ChannelStringHandler.unjoinPushData(pushData);
+      List<String> pushDatum = StringLineIngester.unjoinPushData(pushData);
 
       int numDatum = pushDatum.size();
       if (numDatum > 1) {
@@ -573,7 +574,7 @@ public class QueuedAgentService implements ForceQueueEnabledAgentAPI {
         for (int startingIndex = 0; endingIndex < numDatum; startingIndex += stride) {
           endingIndex = Math.min(numDatum, startingIndex + stride);
           splitTasks.add(new PostPushDataResultTask(agentId, workUnitId, currentMillis, format,
-              ChannelStringHandler.joinPushData(new ArrayList<>(
+              StringLineIngester.joinPushData(new ArrayList<>(
                   pushDatum.subList(startingIndex, endingIndex)))));
         }
       } else {

--- a/proxy/src/test/java/com/wavefront/agent/QueuedAgentServiceTest.java
+++ b/proxy/src/test/java/com/wavefront/agent/QueuedAgentServiceTest.java
@@ -6,6 +6,7 @@ import com.squareup.tape.TaskInjector;
 import com.wavefront.agent.QueuedAgentService.PostPushDataResultTask;
 import com.wavefront.api.AgentAPI;
 import com.wavefront.api.agent.ShellOutputDTO;
+import com.wavefront.ingester.StringLineIngester;
 
 import net.jcip.annotations.NotThreadSafe;
 
@@ -135,7 +136,7 @@ public class QueuedAgentServiceTest {
     pretendPushDataList.add("string line 1");
     pretendPushDataList.add("string line 2");
 
-    String pretendPushData = ChannelStringHandler.joinPushData(pretendPushDataList);
+    String pretendPushData = StringLineIngester.joinPushData(pretendPushDataList);
 
     EasyMock.expect(mockAgentAPI.postPushData(agentId, workUnitId, now, format, pretendPushData)).
         andReturn(Response.ok().build()).once();
@@ -159,7 +160,7 @@ public class QueuedAgentServiceTest {
     pretendPushDataList.add("string line 1");
     pretendPushDataList.add("string line 2");
 
-    String pretendPushData = ChannelStringHandler.joinPushData(pretendPushDataList);
+    String pretendPushData = StringLineIngester.joinPushData(pretendPushDataList);
 
     EasyMock.expect(mockAgentAPI.postPushData(agentId, workUnitId, now, format, pretendPushData)).
         andReturn(Response.status(Response.Status.NOT_ACCEPTABLE).build()).once();
@@ -188,7 +189,7 @@ public class QueuedAgentServiceTest {
     pretendPushDataList.add(str1);
     pretendPushDataList.add(str2);
 
-    String pretendPushData = ChannelStringHandler.joinPushData(pretendPushDataList);
+    String pretendPushData = StringLineIngester.joinPushData(pretendPushDataList);
 
     EasyMock.expect(mockAgentAPI.postPushData(agentId, workUnitId, now, format, pretendPushData)).
         andReturn(Response.status(Response.Status.REQUEST_ENTITY_TOO_LARGE).build()).once();
@@ -224,7 +225,7 @@ public class QueuedAgentServiceTest {
     pretendPushDataList.add(str1);
     pretendPushDataList.add(str2);
 
-    String pretendPushData = ChannelStringHandler.joinPushData(pretendPushDataList);
+    String pretendPushData = StringLineIngester.joinPushData(pretendPushDataList);
 
     EasyMock.expect(mockAgentAPI.postPushData(agentId, workUnitId, now, format, pretendPushData)).andReturn(Response
         .status(Response.Status.REQUEST_ENTITY_TOO_LARGE).build()).once();
@@ -393,7 +394,7 @@ public class QueuedAgentServiceTest {
     pretendPushDataList.add("string line 1");
     pretendPushDataList.add("string line 2");
 
-    String pretendPushData = ChannelStringHandler.joinPushData(pretendPushDataList);
+    String pretendPushData = StringLineIngester.joinPushData(pretendPushDataList);
 
     QueuedAgentService.PostPushDataResultTask task = new QueuedAgentService.PostPushDataResultTask(
         agentId,
@@ -428,7 +429,7 @@ public class QueuedAgentServiceTest {
     pretendPushDataList.add("string line 1");
     pretendPushDataList.add("string line 2");
 
-    String pretendPushData = ChannelStringHandler.joinPushData(pretendPushDataList);
+    String pretendPushData = StringLineIngester.joinPushData(pretendPushDataList);
 
     QueuedAgentService.PostPushDataResultTask task = new QueuedAgentService.PostPushDataResultTask(
         agentId,
@@ -470,7 +471,7 @@ public class QueuedAgentServiceTest {
     pretendPushDataList.add("string line 1");
     pretendPushDataList.add("string line 2");
 
-    String pretendPushData = ChannelStringHandler.joinPushData(pretendPushDataList);
+    String pretendPushData = StringLineIngester.joinPushData(pretendPushDataList);
 
     QueuedAgentService.PostPushDataResultTask task = new QueuedAgentService.PostPushDataResultTask(
         agentId,
@@ -513,7 +514,7 @@ public class QueuedAgentServiceTest {
     List<String> pretendPushDataList = new ArrayList<String>();
     pretendPushDataList.add(str1);
 
-    String pretendPushData = ChannelStringHandler.joinPushData(pretendPushDataList);
+    String pretendPushData = StringLineIngester.joinPushData(pretendPushDataList);
 
     QueuedAgentService.PostPushDataResultTask task = new QueuedAgentService.PostPushDataResultTask(
         agentId,
@@ -527,7 +528,7 @@ public class QueuedAgentServiceTest {
     assertEquals(1, splitTasks.size());
 
     String firstSplitDataString = splitTasks.get(0).getPushData();
-    List<String> firstSplitData = ChannelStringHandler.unjoinPushData(firstSplitDataString);
+    List<String> firstSplitData = StringLineIngester.unjoinPushData(firstSplitDataString);
 
     assertEquals(1, firstSplitData.size());
   }
@@ -552,7 +553,7 @@ public class QueuedAgentServiceTest {
     pretendPushDataList.add(str3);
     pretendPushDataList.add(str4);
 
-    String pretendPushData = ChannelStringHandler.joinPushData(pretendPushDataList);
+    String pretendPushData = StringLineIngester.joinPushData(pretendPushDataList);
 
     PostPushDataResultTask task = new PostPushDataResultTask(
         agentId,
@@ -566,11 +567,11 @@ public class QueuedAgentServiceTest {
     assertEquals(2, splitTasks.size());
 
     String firstSplitDataString = splitTasks.get(0).getPushData();
-    List<String> firstSplitData = ChannelStringHandler.unjoinPushData(firstSplitDataString);
+    List<String> firstSplitData = StringLineIngester.unjoinPushData(firstSplitDataString);
     assertEquals(2, firstSplitData.size());
 
     String secondSplitDataString = splitTasks.get(1).getPushData();
-    List<String> secondSplitData = ChannelStringHandler.unjoinPushData(secondSplitDataString);
+    List<String> secondSplitData = StringLineIngester.unjoinPushData(secondSplitDataString);
     assertEquals(2, secondSplitData.size());
 
     // and all the data is the same...
@@ -583,9 +584,9 @@ public class QueuedAgentServiceTest {
     }
 
     // first list should have the first 2 strings
-    assertEquals(ChannelStringHandler.joinPushData(Arrays.asList(str1, str2)), firstSplitDataString);
+    assertEquals(StringLineIngester.joinPushData(Arrays.asList(str1, str2)), firstSplitDataString);
     // second list should have the last 2
-    assertEquals(ChannelStringHandler.joinPushData(Arrays.asList(str3, str4)), secondSplitDataString);
+    assertEquals(StringLineIngester.joinPushData(Arrays.asList(str3, str4)), secondSplitDataString);
 
   }
 
@@ -614,7 +615,7 @@ public class QueuedAgentServiceTest {
     pretendPushDataList.add(str4);
     pretendPushDataList.add(str5);
 
-    String pretendPushData = ChannelStringHandler.joinPushData(pretendPushDataList);
+    String pretendPushData = StringLineIngester.joinPushData(pretendPushDataList);
 
     PostPushDataResultTask task = new PostPushDataResultTask(
         agentId,
@@ -628,12 +629,12 @@ public class QueuedAgentServiceTest {
     assertEquals(2, splitTasks.size());
 
     String firstSplitDataString = splitTasks.get(0).getPushData();
-    List<String> firstSplitData = ChannelStringHandler.unjoinPushData(firstSplitDataString);
+    List<String> firstSplitData = StringLineIngester.unjoinPushData(firstSplitDataString);
 
     assertEquals(3, firstSplitData.size());
 
     String secondSplitDataString = splitTasks.get(1).getPushData();
-    List<String> secondSplitData = ChannelStringHandler.unjoinPushData(secondSplitDataString);
+    List<String> secondSplitData = StringLineIngester.unjoinPushData(secondSplitDataString);
 
     assertEquals(2, secondSplitData.size());
   }
@@ -656,7 +657,7 @@ public class QueuedAgentServiceTest {
           pretendPushDataList.add(RandomStringUtils.randomAlphabetic(6));
         }
 
-        String pretendPushData = ChannelStringHandler.joinPushData(pretendPushDataList);
+        String pretendPushData = StringLineIngester.joinPushData(pretendPushDataList);
 
         PostPushDataResultTask task = new PostPushDataResultTask(
             agentId,
@@ -669,7 +670,7 @@ public class QueuedAgentServiceTest {
         List<PostPushDataResultTask> splitTasks = task.splitTask();
         Set<String> splitData = Sets.newHashSet();
         for (PostPushDataResultTask taskN : splitTasks) {
-          List<String> dataStrings = ChannelStringHandler.unjoinPushData(taskN.getPushData());
+          List<String> dataStrings = StringLineIngester.unjoinPushData(taskN.getPushData());
           splitData.addAll(dataStrings);
           assertTrue(dataStrings.size() <= targetBatchSize + 1);
         }
@@ -695,7 +696,7 @@ public class QueuedAgentServiceTest {
         pretendPushDataList.add(RandomStringUtils.randomAlphabetic(6));
       }
 
-      String pretendPushData = ChannelStringHandler.joinPushData(pretendPushDataList);
+      String pretendPushData = StringLineIngester.joinPushData(pretendPushDataList);
 
       PostPushDataResultTask task = new PostPushDataResultTask(
           agentId,
@@ -709,7 +710,7 @@ public class QueuedAgentServiceTest {
       assertEquals(2, splitTasks.size());
       Set<String> splitData = Sets.newHashSet();
       for (PostPushDataResultTask taskN : splitTasks) {
-        List<String> dataStrings = ChannelStringHandler.unjoinPushData(taskN.getPushData());
+        List<String> dataStrings = StringLineIngester.unjoinPushData(taskN.getPushData());
         splitData.addAll(dataStrings);
         assertTrue(dataStrings.size() <= numTestStrings / 2 + 1);
       }

--- a/test/runner.py
+++ b/test/runner.py
@@ -6,15 +6,16 @@ This is a test runner with test suite for testing various proxy endpoints.
 import datetime
 import BaseHTTPServer
 import pickle
+import re
+import requests
 import socket
 import struct
 import subprocess
-import StringIO
 import threading
-import tokenize
+import time
 import unittest
 import urllib2
-
+import Queue
 import dateutil
 import dateutil.tz
 
@@ -28,7 +29,7 @@ def unix_time_seconds(date_in):
     """
     return (date_in - EPOCH).total_seconds()
 
-
+#pylint: disable=too-few-public-methods
 class HttpServerRequests(object):
     """
     HTTP Requests object is used to store requests that have been sent to
@@ -42,8 +43,11 @@ class HttpServerRequests(object):
 
         self.lock = threading.Lock()
         self.event = threading.Event()
-        self.config_processed_event = threading.Event()
-        self.pushdata_event = threading.Event()
+        self.events = {
+            'main': threading.Event(),
+            'pushdata': threading.Event(),
+            'config_processed': threading.Event()
+        }
         self.commands = {}
 
     def add_request(self, request_handler):
@@ -70,24 +74,25 @@ class HttpServerRequests(object):
                 else:
                     content = ''
                 if command not in self.commands:
-                    self.commands[command] = [content]
-                else:
-                    self.commands[command].append(content)
+                    self.commands[command] = Queue.Queue()
+                self.commands[command].put(content)
+
                 # use this for debugging if needed
                 # print('Adding %s request for |%s|\n%s' %
                 #       (command, path, content))
                 if command == 'config' and parts[5] == 'processed':
-                    self.config_processed_event.set()
-                elif command == 'pushdata':
-                    self.pushdata_event.set()
+                    self.events['config_processed'].set()
 
-            self.event.set()
+                elif command == 'pushdata':
+                    self.events['pushdata'].set()
+                    print '%s body:\n|%s|\n' % (command, content)
+
+            self.events['main'].set()
 
         finally:
             self.lock.release()
-            self.config_processed_event.clear()
-            self.pushdata_event.clear()
-            self.event.clear()
+            for command, event in self.events.iteritems():
+                event.clear()
 
 class AgentHttpEndpointHandler(BaseHTTPServer.BaseHTTPRequestHandler):
     """
@@ -95,6 +100,7 @@ class AgentHttpEndpointHandler(BaseHTTPServer.BaseHTTPRequestHandler):
     as our fake HTTP WF endpoint).
     """
 
+    #pylint: disable=invalid-name
     def do_POST(self):
         """
         Handles the POST request.
@@ -106,7 +112,8 @@ class AgentHttpEndpointHandler(BaseHTTPServer.BaseHTTPRequestHandler):
         self.end_headers()
         self.wfile.write("{}")
 
-class TestAgentProxyBase(object):
+#pylint: disable=too-many-public-methods
+class TestAgentProxyBase(unittest.TestCase):
     """
     Base class for all test cases that are testing the agent.  This class
     will startup (and shutdown) a fake "metrics.wavefront.com" end point
@@ -119,15 +126,24 @@ class TestAgentProxyBase(object):
         self.endpoint_thread = None
         self.agent_stdout_fd = None
         self.agent_process = None
+        self.current_test_name = None
 
-    def setUpCommon(self, test_name):
+    def setup_common(self, test_name, port, additional_args=None,
+                         conf_file=None):
         """
         Unit Test setup function.  Sets up the fake wavefront endpoint
         and starts the agent.
 
         Arguments:
         test_name - name of the test being run
+        port - port being tested (will wait for it to be up)
+        additional_args - additional proxy arguments (should be a list)
+        conf_file - configuration file (if different than './wavefront.conf')
         """
+
+        self.current_test_name = test_name
+        print ('\n----------------------------\n%s'
+               '\n----------------------------') % (test_name, )
 
         # cleanup function set in case setUp() fails
         self.addCleanup(self.cleanup)
@@ -140,15 +156,46 @@ class TestAgentProxyBase(object):
             target=self.server.serve_forever)
         self.endpoint_thread.start()
 
+        if not conf_file:
+            conf_file = './wavefront.conf'
+
         # start the agent
+        print 'Starting proxy [%s] ...' % (test_name)
         self.agent_stdout_fd = open('./test/proxy' + test_name + '.out', 'w')
-        args = ['java', '-jar', '../proxy/target/wavefront-push-agent.jar',
-                '-f', './wavefront.conf', '--purgeBuffer']
+        args = ['java', '-jar',
+                '-Dcom.sun.management.jmxremote.port=3000',
+                '-Dcom.sun.management.jmxremote',
+                '-Dcom.sun.management.jmxremote.local.only=false',
+                '-Dcom.sun.management.jmxremote.authenticate=false',
+                '-Dcom.sun.management.jmxremote.ssl=false',
+                '-Djava.rmi.server.hostname=192.168.56.101',
+                '../proxy/target/wavefront-push-agent.jar',
+                '-f', conf_file, '--purgeBuffer'
+                    ]
+        if additional_args:
+            args.extend(additional_args)
         self.agent_process = subprocess.Popen(args, stdout=self.agent_stdout_fd,
                                               stderr=self.agent_stdout_fd,
                                               cwd='./test')
         print 'Waiting for /config/processed request ...'
-        self.server.requests.config_processed_event.wait(60)
+        self.server.requests.events['config_processed'].wait(60)
+        self.wait_for_port(port, 60)
+
+    def wait_for_server_command(self, command, timeout):
+        """
+        Waits for the given command to arrive
+        """
+
+        if (command not in self.server.requests.commands or
+                self.server.requests.commands[command].empty()):
+            print 'Waiting for %s' % (command, )
+            self.server.requests.events[command].wait(timeout)
+
+        if command in self.server.requests.commands:
+            return self.server.requests.commands[command]
+        else:
+            print '%s not in commands list' % (command)
+            return Queue.Queue()
 
     def cleanup(self):
         """
@@ -157,6 +204,7 @@ class TestAgentProxyBase(object):
         """
 
         if self.agent_process:
+            print 'Killing proxy ...'
             self.agent_process.kill()
             self.agent_process.wait()
             self.agent_process = None
@@ -173,11 +221,176 @@ class TestAgentProxyBase(object):
             self.endpoint_thread.join()
             self.endpoint_thread = None
 
-    def tearDownCommon(self):
+    def teardown_common(self):
+        """
+        Common teardown code
+        """
+
         self.cleanup()
 
+    @staticmethod
+    def is_port_available(port):
+        """
+        Checks to see if the given port on localhost is listening.
+        Arguments:
+        port - the port to check
+        """
 
-class TestWriteHttpProxy(unittest.TestCase, TestAgentProxyBase):
+        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        result = sock.connect_ex(('127.0.0.1', port))
+        if result == 0:
+            sock.shutdown(socket.SHUT_WR)
+            sock.close()
+        return result == 0
+
+    def wait_for_port(self, port, timeout):
+        """
+        Waits for the given amount of time for the port to be listening
+        Arguments:
+        port - the port to check
+        timeout - the maximum number of seconds to wait
+        """
+
+        timeleft = timeout
+        sleep_time = 1
+        while timeleft and not self.is_port_available(port):
+            time.sleep(sleep_time)
+            timeleft = timeleft - sleep_time
+
+        self.assertTrue(self.is_port_available(port))
+
+    @staticmethod
+    def send_messages_and_close(port, message):
+        """
+        Sends the cmd(s) to the WF proxy on the given port and close the
+        socket when done.  Will not close until all messages have been sent.
+        Arguments:
+        port - the port to connect to
+        message - the message to send (string or list or strings)
+        """
+
+        # connect to the proxy on port
+        sock = socket.socket()
+        sock.connect(('127.0.0.1', port))
+
+        # send
+        if isinstance(message, list):
+            for msg in message:
+                sock.sendall(msg)
+        else:
+            sock.sendall(message)
+
+        # all done.  close the socket
+        sock.shutdown(socket.SHUT_WR)
+        sock.close()
+
+    @staticmethod
+    def send_message_and_close(port, message):
+        """
+        Sends message to the given port (assumes localhost) and closes the
+        socket once message has been sent.
+        Arguments:
+        port - the port to send the message to (localhost assumed)
+        message - the message to send
+        """
+
+        sock = socket.socket()
+        sock.connect(('127.0.0.1', port))
+        sock.sendall(message)
+        sock.shutdown(socket.SHUT_WR)
+        sock.close()
+
+    @staticmethod
+    def send_message_parallel(port, cmds):
+        """
+        Sends the messages to the WF proxy in parallel (each message in its
+        own thread)
+        Arguments:
+        port - the port on the localhost host to send message to
+        cmds - the list of messages to send
+        """
+
+        threads = []
+        for cmd in cmds:
+            thread = threading.Thread(
+                target=TestAgentProxyBase.send_message_and_close,
+                args=(port, cmd))
+            thread.daemon = True
+            thread.start()
+            threads.append(thread)
+
+        for thread in threads:
+            thread.join()
+        print '%d threads complete' % (len(cmds), )
+
+    def wait_for_push_data(self, pushdata_expect):
+        """
+        Wait for the proxy to send all of the expected metric lines.  This will
+        wait up to 5 minutes
+        Arguments:
+        pushdata_expect - an array of expected push data lines (not including
+                      the end of line character)
+        """
+
+        now = unix_time_seconds(datetime.datetime.utcnow().replace(
+            tzinfo=dateutil.tz.tzutc()))
+        start = now
+        while len(pushdata_expect) > 0 and (now - start) < 120:
+            now = unix_time_seconds(datetime.datetime.utcnow().replace(
+                tzinfo=dateutil.tz.tzutc()))
+            pushdata = self.wait_for_server_command('pushdata', 60)
+            if pushdata.empty():
+                print 'pushdata queue is empty'
+                continue
+
+            # there could be multiple metric lines in the body
+            data = pushdata.get().split('\n')
+            for line in data:
+                foundline = line in pushdata_expect
+                if foundline:
+                    #print 'Found |%s|' % (line, )
+                    pushdata_expect.remove(line)
+
+                else:
+                    self.fail('Line |%s| NOT expected' % (line))
+
+        self.assertEquals(0, len(pushdata_expect))
+
+    def assert_blocked_point_in_log(self, message, replace_special):
+        """
+        Asserts that this test's log file has a blocked point in with
+        at least part of the given message in it.
+        Arguments:
+        message - the message to look for
+        replace_special - true to replace RE special characters in message
+        """
+
+        message_re = message
+        if replace_special:
+            re_special_chars = ['^', '.', '$', '*', ')', '(']
+            for char in re_special_chars:
+                message_re = message_re.replace(char, '\\' + char)
+
+        logfile_path = './test/proxy' + self.current_test_name + '.out'
+        with open(logfile_path, 'r') as proxylog_fd:
+            print ('Checking |%s| has blocked message |%s|'
+                       % (logfile_path, message_re))
+            found = False
+            iterations = 0
+            while not found and iterations < 6:
+                for line in proxylog_fd:
+                    if re.match('.*blocked input:.*' + message_re + '.*', line):
+                        found = True
+                        break
+                iterations = iterations + 1
+                if not found and iterations < 6:
+                    time.sleep(10)
+
+            if not found:
+                self.fail('Blocked line NOT found')
+
+#pylint: disable=too-many-public-methods
+class TestWriteHttpProxy(TestAgentProxyBase):
     """
     Tests the write_http plugin support (only JSON is supported/tested)
     """
@@ -186,10 +399,11 @@ class TestWriteHttpProxy(unittest.TestCase, TestAgentProxyBase):
         super(TestWriteHttpProxy, self).__init__(*args, **kwargs)
 
     def setUp(self):
-        self.setUpCommon(self.__class__.__name__)
+        self.setup_common(self.__class__.__name__ + '__' +
+                          self._testMethodName, 4878)
 
     def tearDown(self):
-        self.tearDownCommon()
+        self.teardown_common()
 
     def test_simple_1(self):
         """
@@ -216,10 +430,10 @@ class TestWriteHttpProxy(unittest.TestCase, TestAgentProxyBase):
 """ % utcnow
 
         # this is the contents we expect to see in the POST to the WF servers
-        pushdata_expect = ("\"disk.sda.disk_octets.read\" 197141504 %d "
-                           "source=\"simple1.example.org\"\n"
+        pushdata_expect = ["\"disk.sda.disk_octets.read\" 197141504 %d "
+                               "source=\"simple1.example.org\"" % (utcnow),
                            "\"disk.sda.disk_octets.write\" 175136768 %d "
-                           "source=\"simple1.example.org\"" % (utcnow, utcnow))
+                               "source=\"simple1.example.org\"" % (utcnow)]
 
         headers = {
             'Content-Type': 'application/json'
@@ -231,36 +445,551 @@ class TestWriteHttpProxy(unittest.TestCase, TestAgentProxyBase):
         request = urllib2.Request('http://127.0.0.1:4878/',
                                   headers=headers,
                                   data=json)
-        conn = urllib2.urlopen(request)
+        #conn =
+        urllib2.urlopen(request)
         #print conn.read()
 
-        self.server.requests.pushdata_event.wait(60)
-        self.assertEquals(pushdata_expect,
-                          self.server.requests.commands['pushdata'][0])
+        self.wait_for_push_data(pushdata_expect)
 
-
-class TestPickleProtocolProxy(unittest.TestCase, TestAgentProxyBase):
+class TestOpenTSDBProtocol(TestAgentProxyBase):
     """
-    Tests the opentsdb pickle protocol support
+    Tests the opentsdb telnet & http protocol support
+    """
+
+    def __init__(self, *args, **kwargs):
+        super(TestOpenTSDBProtocol, self).__init__(*args, **kwargs)
+
+    def setUp(self):
+        if self._testMethodName[0:12] == 'test_prefix_':
+            args = ['-p', self._testMethodName]
+        elif self._testMethodName == 'test_metric_invalid_characters':
+            args = ['--pushBlockedSamples', '0']
+        else:
+            args = None
+        self.setup_common(self.__class__.__name__ + '__' + self._testMethodName,
+                         4242,
+                         args)
+
+    def tearDown(self):
+        self.teardown_common()
+
+    def test_telnet_1(self):
+        """
+        Test of a single PUT command
+        """
+
+        # send PUT
+        utcnow = unix_time_seconds(datetime.datetime.utcnow().replace(
+            tzinfo=dateutil.tz.tzutc()))
+        putcmd = ('put test.test1.t1 %d 0.14 host=localhost\n' % (utcnow,))
+        self.send_message_and_close(4242, putcmd)
+
+        # check that it was sent on to the WF server
+        pushdata_expect = [("\"test.test1.t1\" 0.14 %d source=\"localhost\"" %
+                                (utcnow))]
+        self.wait_for_push_data(pushdata_expect)
+
+    def test_telnet_2(self):
+        """
+        Test of a multiple PUT commands
+        """
+
+        # send PUTs
+        utcnow = unix_time_seconds(datetime.datetime.utcnow().replace(
+            tzinfo=dateutil.tz.tzutc()))
+        putcmd = [('put test.test1.t1 %d 0.14 host=localhost\n' % (utcnow,)),
+                  ('put test.test1.t2 %d 0.15 host=localhost\n' %
+                       (utcnow + 1000,))]
+        self.send_messages_and_close(4242, putcmd)
+
+        # check that it was sent on to the WF server
+        pushdata_expect = [("\"test.test1.t1\" 0.14 %d source=\"localhost\"" %
+                                (utcnow)),
+                           ("\"test.test1.t2\" 0.15 %d source=\"localhost\"" %
+                                (utcnow + 1000))]
+        self.wait_for_push_data(pushdata_expect)
+
+    def test_telnet_parallel_1(self):
+        """
+        Test of a multiple PUT commands in parallel
+        """
+
+        # send PUTs
+        utcnow = unix_time_seconds(datetime.datetime.utcnow().replace(
+            tzinfo=dateutil.tz.tzutc()))
+        putcmd = [('put test.test1.t1 %d 0.14 host=localhost\n' % (utcnow,)),
+                  ('put test.test1.t2 %d 0.15 host=localhost\n' %
+                       (utcnow + 1000,))]
+        self.send_message_parallel(4242, putcmd)
+
+        # check that it was sent on to the WF server
+        pushdata_expect = [("\"test.test1.t1\" 0.14 %d source=\"localhost\"" %
+                                (utcnow)),
+                           ("\"test.test1.t2\" 0.15 %d source=\"localhost\"" %
+                                (utcnow + 1000))]
+        self.wait_for_push_data(pushdata_expect)
+
+    def test_telnet_parallel_2(self):
+        """
+        Test of a multiple PUT commands in parallel
+        """
+
+        # send PUTs
+        utcnow = unix_time_seconds(datetime.datetime.utcnow().replace(
+            tzinfo=dateutil.tz.tzutc()))
+
+        expected_putcmds = []
+        for j in range(100):
+            putcmds = []
+            for i in range(1000):
+                putcmds.append('put test.test1.%d.t%d %d %d.0 '
+                                   'host=localhost\n' % (j, i, utcnow, i))
+                expected_putcmds.append('"test.test1.%d.t%d" %d.0 %d '
+                                            'source="localhost"' %
+                                            (j, i, i, utcnow))
+            # add on a version command every 1000
+            putcmds.append('version\n')
+
+            self.send_message_parallel(4242, putcmds)
+        self.wait_for_push_data(expected_putcmds)
+
+    def test_telnet_version(self):
+        """
+        Tests that version command returns something via telnet
+        """
+
+        sock = socket.socket()
+        sock.settimeout(5.0)
+        sock.connect(('127.0.0.1', 4242))
+
+        # send
+        print 'sending version command'
+        sock.sendall('version\n')
+
+        # recv
+        print 'waiting for response ...'
+        data = sock.recv(4096)
+        self.assertEquals('Wavefront OpenTSDB Endpoint\n', data)
+
+        # all done.  close the socket
+        sock.shutdown(socket.SHUT_WR)
+        sock.close()
+
+    def test_http_with_array(self):
+        """
+        Test of a single HTTP command with an array of data points
+        """
+
+        utcnow = unix_time_seconds(datetime.datetime.utcnow().replace(
+            tzinfo=dateutil.tz.tzutc())) * 1000
+        body = """[
+    {
+        "metric": "sys.cpu.nice",
+        "timestamp": %d,
+        "value": 18,
+        "tags": {
+           "host": "web01",
+           "dc": "lga"
+        }
+    },
+    {
+        "metric": "sys.cpu.nice",
+        "timestamp": %d,
+        "value": 9,
+        "tags": {
+           "host": "web02",
+           "dc": "lga"
+        }
+    }
+]""" % (utcnow - 3000, utcnow)
+
+        headers = {'content-type': 'application/json'}
+        requests.post('http://localhost:4242/api/put',
+                      data=body,
+                      headers=headers)
+
+        pushdata_expect = ['"sys.cpu.nice" 18 %d source="web01"'
+                               ' "dc"="lga"' % ((utcnow - 3000) / 1000),
+                           '"sys.cpu.nice" 9 %d source="web02"'
+                               ' "dc"="lga"' % (utcnow / 1000)]
+        self.wait_for_push_data(pushdata_expect)
+
+    def test_http_with_single_element(self):
+        """
+        Test of a single HTTP command with only a single data point
+        """
+
+        utcnow = unix_time_seconds(datetime.datetime.utcnow().replace(
+            tzinfo=dateutil.tz.tzutc())) * 1000
+        body = """
+    {
+        "metric": "sys.cpu.nice",
+        "timestamp": %d,
+        "value": 18,
+        "tags": {
+           "host": "web01",
+           "dc": "lga"
+        }
+    }""" % (utcnow)
+
+        headers = {'content-type': 'application/json'}
+        requests.post('http://localhost:4242/api/put',
+                        data=body, headers=headers)
+
+        pushdata_expect = [('"sys.cpu.nice" 18 %d source="web01"'
+                                ' "dc"="lga"') % (utcnow / 1000)]
+        self.wait_for_push_data(pushdata_expect)
+
+    def test_http_with_version(self):
+        """
+        Test HTTP /api/version endpoint
+        """
+
+        request = requests.post('http://localhost:4242/api/version')
+        self.assertEquals("Wavefront OpenTSDB Endpoint", request.text)
+
+    def test_http_unsupported_endpoint(self):
+        """
+        Test HTTP /api/blah endpoint
+        """
+
+        request = requests.post('http://localhost:4242/api/blah')
+        self.assertEquals(400, request.status_code)
+
+    def test_prefix_1(self):
+        """
+        Test of a single PUT command with a configured prefix
+        """
+
+        # send PUT
+        utcnow = unix_time_seconds(datetime.datetime.utcnow().replace(
+            tzinfo=dateutil.tz.tzutc()))
+        putcmd = ('put test.test1.t1 %d 0.14 host=localhost\n' % (utcnow,))
+        self.send_message_and_close(4242, putcmd)
+
+        # check that it was sent on to the WF server
+        pushdata_expect = [('"test_prefix_1.test.test1.t1" 0.14 %d '
+                                'source="localhost"' % (utcnow))]
+        self.wait_for_push_data(pushdata_expect)
+
+    def test_host_name_too_long(self):
+        """
+        Tests that a host name that is longer than 1024 characters will be
+        blocked.
+        """
+
+        # create hostname
+        hostname = []
+        for _ in range(1024):
+            hostname.append('h')
+        hostname = ''.join(hostname)
+
+        # send PUT
+        utcnow = unix_time_seconds(datetime.datetime.utcnow().replace(
+            tzinfo=dateutil.tz.tzutc()))
+        putcmd = ('put test.test1.t1 %d 0.14 host=%s\n' % (utcnow, hostname))
+        self.send_message_and_close(4242, putcmd)
+
+        # check that message was not sent
+        pushdata = self.wait_for_server_command('pushdata', 60)
+        self.assertTrue(pushdata.empty())
+
+        # check log file for blocked point
+        self.assert_blocked_point_in_log('WF-301:.*Host.*too long.*' +
+                                              hostname, False)
+
+    def test_metric_name_too_long(self):
+        """
+        Tests that a metric name that is longer than 1024 characters will be
+        blocked.
+        """
+
+        # create metric name
+        metric_name = []
+        for _ in range(1024):
+            metric_name.append('m')
+        metric_name = ''.join(metric_name)
+
+        # send PUT
+        utcnow = unix_time_seconds(datetime.datetime.utcnow().replace(
+            tzinfo=dateutil.tz.tzutc()))
+        putcmd = ('put %s %d 0.14 host=localhost\n' % (metric_name, utcnow))
+        self.send_message_and_close(4242, putcmd)
+
+        # check that message was not sent
+        pushdata = self.wait_for_server_command('pushdata', 60)
+        self.assertTrue(pushdata.empty())
+
+        # check log file for blocked point
+        self.assert_blocked_point_in_log('WF-301: Metric name is too long.*' +
+                                              metric_name, False)
+
+    def test_metric_invalid_characters(self):
+        """
+        Tests that lines are blocked when the metric names contain invalid
+        characters.
+        """
+
+        # create metric names to test
+        metric_names = {
+            ('foo-./0123456789.ABCDEFGHIJKLMNOPQRSTUVWXYZ.'
+                 'abcdefghijklmnopqrstuvwxyz_'): True,
+            ('~abc-./0123456789.ABCDEFGHIJKLMNOPQRSTUVWXYZ.'
+                 'abcdefghijklmnopqrstuvwxyz_'): True,
+            '01234.ABCD.~abc': False,
+            'A=BC.123': False,
+            'abc7*.123': False,
+            'abc(.123)': False
+        }
+
+        utcnow = unix_time_seconds(datetime.datetime.utcnow().replace(
+            tzinfo=dateutil.tz.tzutc()))
+        for metric, expected in metric_names.iteritems():
+            print '\n*** Testing metric |%s| ***' % (metric)
+
+            # send PUT
+            putcmd = ('put %s %d 0.14 host=localhost\n' % (metric, utcnow,))
+            self.send_message_and_close(4242, putcmd)
+
+            if expected:
+                # check that it was sent on to the WF server
+                pushdata_expect = [("\"%s\" 0.14 %d source=\"localhost\"" %
+                                (metric, utcnow))]
+                self.wait_for_push_data(pushdata_expect)
+
+            else:
+                pushdata = self.wait_for_server_command('pushdata', 60)
+                self.assertTrue(pushdata.empty())
+                self.assert_blocked_point_in_log(metric, True)
+
+class TestProxyWavefrontFormat(TestAgentProxyBase):
+    """
+    Tests the wavefront format protocol support
+    """
+
+    def __init__(self, *args, **kwargs):
+        super(TestProxyWavefrontFormat, self).__init__(*args, **kwargs)
+
+    def setUp(self):
+        self.setup_common(self.__class__.__name__ + '__' +
+                          self._testMethodName, 2878)
+
+    def tearDown(self):
+        self.teardown_common()
+
+    def test_simple_1(self):
+        """
+        Simple test of a single metric using wavefront format
+        """
+
+        # send metric
+        utcnow = unix_time_seconds(datetime.datetime.utcnow().replace(
+            tzinfo=dateutil.tz.tzutc()))
+        putcmd = ('test.test2.t1 0.214 %d source=%s\n' % (utcnow, 'localhost'))
+        self.send_message_and_close(2878, putcmd)
+
+        # check that it was sent on to the WF server
+        pushdata_expect = [("\"test.test2.t1\" 0.214 %d source=\"%s\"" %
+                                (utcnow, 'localhost'))]
+        self.wait_for_push_data(pushdata_expect)
+
+    def test_simple_no_ts_1(self):
+        """
+        Simple test of a single metric using wavefront format without timestamp
+        """
+
+        # send metric
+        utcnow = unix_time_seconds(datetime.datetime.utcnow().replace(
+            tzinfo=dateutil.tz.tzutc()))
+        putcmd = ('test.test2.t1 0.214 source=%s\n' % ('localhost', ))
+        self.send_message_and_close(2878, putcmd)
+
+        # check that it was sent on to the WF server
+        pushdata_expect = [("\"test.test2.t1\" 0.214 %d source=\"%s\"" %
+                                (utcnow, 'localhost'))]
+        self.wait_for_push_data(pushdata_expect)
+
+    def test_parallel_1(self):
+        """
+        Test of multiple commands in parallel
+        """
+
+        # send commands
+        utcnow = unix_time_seconds(datetime.datetime.utcnow().replace(
+            tzinfo=dateutil.tz.tzutc()))
+
+        expected_cmds = []
+        for j in range(100):
+            cmds = []
+            for i in range(1000):
+                cmds.append('test.test2.t%d %d.0 %d source=%s\n' %
+                                (j, i, utcnow, 'localhost'))
+                expected_cmds.append('"test.test2.t%d" %d.0 %d '
+                                         'source="localhost"' % (j, i, utcnow))
+
+            self.send_message_parallel(2878, cmds)
+        self.wait_for_push_data(expected_cmds)
+
+class TestProxyGraphiteFormat(TestAgentProxyBase):
+    """
+    Tests the regular graphite protocol support
+    """
+
+    def __init__(self, *args, **kwargs):
+        super(TestProxyGraphiteFormat, self).__init__(*args, **kwargs)
+
+    def setUp(self):
+        args = [
+            '--graphitePorts', '2003',
+            '--graphiteFormat', '2',
+        ]
+        self.setup_common(self.__class__.__name__ + '__' +
+                          self._testMethodName, 2003, args)
+
+    def tearDown(self):
+        self.teardown_common()
+
+    def test_simple_1(self):
+        """
+        Simple test of a single metric using graphite protocol
+        """
+
+        # send metric
+        utcnow = unix_time_seconds(datetime.datetime.utcnow().replace(
+            tzinfo=dateutil.tz.tzutc()))
+        putcmd = ('test.%s.test1.t1 0.204 %d\n' % ('localhost', utcnow))
+        self.send_message_and_close(2003, putcmd)
+
+        # check that it was sent on to the WF server
+        pushdata_expect = [("\"test.test1.t1\" 0.204 %d source=\"%s\"" %
+                                (utcnow, 'localhost'))]
+        self.wait_for_push_data(pushdata_expect)
+
+    def test_parallel_1(self):
+        """
+        Test of multiple commands in parallel
+        """
+
+        # send commands
+        utcnow = unix_time_seconds(datetime.datetime.utcnow().replace(
+            tzinfo=dateutil.tz.tzutc()))
+
+        expected_cmds = []
+        for j in range(100):
+            cmds = []
+            for i in range(1000):
+                cmds.append('test.%s.test1.t%d %d.0 %d\n' %
+                                ('localhost', j, i, utcnow))
+                expected_cmds.append('"test.test1.t%d" %d.0 %d '
+                                         'source="localhost"' % (j, i, utcnow))
+
+            self.send_message_parallel(2003, cmds)
+        self.wait_for_push_data(expected_cmds)
+
+class TestProxyGraphiteFormatWithOptionsSet(TestAgentProxyBase):
+    """
+    Tests the regular graphite protocol support with updated graphiteFormat
+    option and a graphiteDelimters configuration option.
+    """
+
+    def __init__(self, *args, **kwargs):
+        super(TestProxyGraphiteFormatWithOptionsSet, self).__init__(
+            *args, **kwargs)
+
+    def setUp(self):
+        args = [
+            '--graphitePorts', '2003',
+            '--graphiteFormat', '3',
+            '--graphiteDelimiters', '-',
+        ]
+        self.setup_common(self.__class__.__name__ + '__' +
+                          self._testMethodName, 2003, args)
+
+    def tearDown(self):
+        self.teardown_common()
+
+    def test_host_with_delimiters(self):
+        """
+        Simple test of a single metric using graphite protocol
+        """
+
+        # send metric
+        utcnow = unix_time_seconds(datetime.datetime.utcnow().replace(
+            tzinfo=dateutil.tz.tzutc()))
+        putcmd = ('test.test1.%s.t1 0.204 %d\n' % ('localhost-foo-bar', utcnow))
+        self.send_message_and_close(2003, putcmd)
+
+        # check that it was sent on to the WF server
+        pushdata_expect = [("\"test.test1.t1\" 0.204 %d source=\"%s\"" %
+                                (utcnow, 'localhost.foo.bar'))]
+        self.wait_for_push_data(pushdata_expect)
+
+class TestProxyGraphiteFormatWithOptionsSet2(TestAgentProxyBase):
+    """
+    Tests the regular graphite protocol support with updated graphiteFormat
+    option and graphiteFieldsToRemove
+    """
+
+    def __init__(self, *args, **kwargs):
+        super(TestProxyGraphiteFormatWithOptionsSet2, self).__init__(
+            *args, **kwargs)
+
+    def setUp(self):
+        args = [
+            '--graphitePorts', '2003',
+            '--graphiteFormat', '2',
+            '--graphiteFieldsToRemove', '1'
+        ]
+        self.setup_common(self.__class__.__name__ + '__' +
+                          self._testMethodName, 2003, args)
+
+    def tearDown(self):
+        self.teardown_common()
+
+    def test_metric_with_fields_removed(self):
+        """
+        Simple test of a single metric using graphite protocol
+        """
+
+        # send metric
+        utcnow = unix_time_seconds(datetime.datetime.utcnow().replace(
+            tzinfo=dateutil.tz.tzutc()))
+        putcmd = ('test.%s.test1.t1 0.204 %d\n' % ('localhost-foo-bar', utcnow))
+        self.send_message_and_close(2003, putcmd)
+
+        # check that it was sent on to the WF server
+        pushdata_expect = [("\"test1.t1\" 0.204 %d source=\"%s\"" %
+                                (utcnow, 'localhost-foo-bar'))]
+        self.wait_for_push_data(pushdata_expect)
+
+class TestPickleProtocolProxy(TestAgentProxyBase):
+    """
+    Tests the graphite pickle protocol support
     """
 
     def __init__(self, *args, **kwargs):
         super(TestPickleProtocolProxy, self).__init__(*args, **kwargs)
 
     def setUp(self):
-        self.setUpCommon(self.__class__.__name__)
+        args = [
+            '--graphiteFormat', '2',
+            '--graphiteFieldsToRemove', '1',
+        ]
+        self.setup_common(self.__class__.__name__ + '__' +
+                          self._testMethodName, 5878, args)
 
     def tearDown(self):
-        self.tearDownCommon()
+        self.teardown_common()
 
+    #pylint: disable=too-many-locals
     def test_example_capture_1(self):
         """
         Test of a capture sent to us by Rocket Fuel.
         """
 
         # connect to the proxy on port 5878 - the pickle protocol port
-        s = socket.socket()
-        s.connect(('127.0.0.1', 5878))
+        sock = socket.socket()
+        sock.connect(('127.0.0.1', 5878))
 
         # open the sample file and send to proxy on open socket
         # the file is graphite pickle format which has a format that looks like:
@@ -290,34 +1019,13 @@ class TestPickleProtocolProxy(unittest.TestCase, TestAgentProxyBase):
                 orig_length = sample_fd.read(4)
 
             # send the entire file on the socket using the expected format
-            s.sendall(''.join(all_data))
+            sock.sendall(''.join(all_data))
 
         # all done.  close the socket
-        s.shutdown(socket.SHUT_WR)
-        s.close()
+        sock.shutdown(socket.SHUT_WR)
+        sock.close()
 
-        # wait for pushdata events to send all data to our fake metrics endpoint
-        lines = []
-        for i in range(5):
-            print 'Waiting for pushdata (' + str(i) + ') event ...'
-            self.server.requests.pushdata_event.wait(60)
-            self.server.requests.pushdata_event.clear()
-            self.assertTrue('pushdata' in self.server.requests.commands)
-
-            # get the contents of the pushdata event and add it to our current
-            # list of events
-            if i < len(self.server.requests.commands['pushdata']):
-                pushdata = self.server.requests.commands['pushdata'][i]
-                pushdata_lines = pushdata.splitlines()
-                for tmp in pushdata_lines:
-                    lines.append(tmp)
-
-            else:
-                # assumption: if that last .wait() timed out, then there are
-                # no more pushdata events
-                break
-
-        current = 0
+        expected = []
         for pickled_data in all_pickled:
             # walk through each record in the pickled segment and make sure
             # it matches what the proxy sent to WF.
@@ -335,44 +1043,45 @@ class TestPickleProtocolProxy(unittest.TestCase, TestAgentProxyBase):
                 if '#' in metric_name:
                     continue
                 host_name = parts[1]
-                ts = int(metric[1][0]) # remove .0 with int()
+                tstamp = int(metric[1][0]) # remove .0 with int()
                 value = metric[1][1]
 
-                # now grab the line from the pushdata content that should match
-                line = lines[current]
-                # tokenize the line
-                tokens = tokenize.generate_tokens(
-                    StringIO.StringIO(line).readline)
+                orig_value = value
+                precision = get_precision(orig_value)
+                value_len = len(str(int(value)))
+                if value_len > 7:
+                    value = (('%.' + str(precision) + 'E') %
+                                 (value)).replace('+', '').replace('E0', 'E')
 
                 # "metric name" value ts source=hostname
-                token_number = 0
-                for token in tokens:
-                    tmp = token[4][token[2][1]:token[3][1]]
-                    # strip off the quotes
-                    if len(tmp) > 0 and tmp[0] == '"':
-                        tmp = tmp[1:-1]
+                expected.append('"%s" %s %d source="%s"' %
+                                    (metric_name, value, tstamp, host_name))
 
-                    # metric name
-                    if token_number == 0:
-                        self.assertEquals(tmp, metric_name)
+        self.wait_for_push_data(expected)
 
-                    # value
-                    elif token_number == 1:
-                        if tmp == '-': # negative numbers in 2 tokens
-                            tmp = tmp + tokens.next()[1]
-                        self.assertEquals(float(tmp), value)
+def get_precision(value):
+    """
+    This is a hacky function for getting the precision to use when comparing
+    the value sent to WF via the proxy with a double value passed to it.
+    Arguments:
+    value - the value to return the precision to use with a %.E format string
+    """
 
-                    # timestamp
-                    elif token_number == 2:
-                        self.assertEquals(long(tmp), ts)
+    sval = '%.2f' % (float(value))
+    last_index = len(sval)
+    found_decimal = False
+    for index in range(len(sval) - 1, 0, -1):
+        char = sval[index]
+        last_index = index
+        if char == '.':
+            found_decimal = True
+        if char != '0' and char != '.':
+            break
 
-                    # host name (skip source, =)
-                    elif token_number == 5:
-                        self.assertEquals(tmp, host_name)
-
-                    token_number = token_number + 1
-
-                current = current + 1
+    if not found_decimal:
+        return last_index - 1
+    else:
+        return last_index
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/wavefront.conf
+++ b/test/wavefront.conf
@@ -77,11 +77,11 @@ customSourceTags=fqdn, hostname
 #graphitePorts=2003
 
 ## Which fields (1-based) should we extract and concatenate (with dots) as the hostname?
-graphiteFormat=2
+#graphiteFormat=2
 
 ## Which characters should be replaced by dots in the hostname, after extraction?
 #graphiteDelimiters=_
-graphiteFieldsToRemove=1
+#graphiteFieldsToRemove=1
 
 # Which ports to listen for Graphite pickle formatted data (from carbon-relay)
 # This is expecting streaming data formatted as:
@@ -92,7 +92,7 @@ picklePorts=5878
 writeHttpJsonListenerPorts=4878
 
 ## ID file for agent
-idFile=/opt/wavefront/wavefront-proxy/.wavefront_id
+idFile=./.wavefront_id
 
 ## Number of threads retrying failed transmissions. Defaults to the number of processors (min. 4)
 ## Buffer files are maxed out at 2G each so increasing the number of retry threads effectively governs


### PR DESCRIPTION
## Background Information
OpenTSDB actually listens for the "telnet" protocol and the HTTP protocol on a single port (4242).  It detects the data type and handles the command based on the request.
See [OpenTSDB documentation](http://opentsdb.net/docs/build/html/user_guide/writing.html#input-methods) for more details.

## Overview of Changes
- This pull request adds a netty decoder similar to the one implemented in the tsd code [https://github.com/OpenTSDB/opentsdb/blob/master/src/tsd/PipelineFactory.java].  It uses the first 2 bytes to detect if the request is HTTP or telnet.  The paths for the HTTP request are checked manually instead of with JAX-RS because the [connector](https://github.com/caskdata/netty-http) to netty does not seem not very pluggable.

- The previously unsupported OpenTSDB "version" command is now supported on both HTTP and telnet.  tcollector requires this command to work properly with the proxy.  Without this command, the proxy will get [blacklisted](https://github.com/OpenTSDB/tcollector/blob/master/tcollector.py#L533) by tcollector.

## Major changes in this pull request:
- Ingester was split into multiple classes: TcpIngester, StringLineIngester
- Moved common code for metrics to PointHandler from ChannelStringHandler (including prefix management and metric/host/annotation validation) so it could be re-used
- added PlainTextOrHttpFrameDecoder class to facilitate switching between plain text and HTTP protocols
- PushAgent.startOpenTsdbListener() now uses the OpenTSDBPortUnificationHandler class
- pylint run on test/runner.py and more tests added to automate testing most OpenTSDB code

## Tests
See test/runner.py to run automated tests.  This script starts up a fake HTTP endpoint for API calls and then runs tests against most of the supported protocols/ports.  It then confirms that the HTTP endpoint received metrics as expected.
