### PR TITLE
Use a spool directory for buffer files, which is less surprising to Li…

### DIFF
--- a/pkg/before-remove.sh
+++ b/pkg/before-remove.sh
@@ -2,4 +2,9 @@
 
 service wavefront-proxy stop || true
 
+# If the proxy ID is in the default location, remove it.
+if [[ -f /opt/wavefront/wavefront-proxy/.wavefront_id ]]; then
+	rm /opt/wavefront/wavefront-proxy/.wavefront_id
+fi
+
 exit 0

--- a/pkg/opt/wavefront/wavefront-proxy/conf/wavefront.conf
+++ b/pkg/opt/wavefront/wavefront-proxy/conf/wavefront.conf
@@ -103,6 +103,9 @@ customSourceTags=fqdn, hostname
 ## ID file for agent
 idFile=/opt/wavefront/wavefront-proxy/.wavefront_id
 
+## Default location of buffer.* files for saving failed transmission for retry.
+buffer=/var/spool/wavefront-proxy/buffer
+
 ## Number of threads retrying failed transmissions. Defaults to the number of processors (min. 4)
 ## Buffer files are maxed out at 2G each so increasing the number of retry threads effectively governs
 ## the maximum amount of space the agent will use to buffer points locally

--- a/proxy/src/main/java/com/wavefront/agent/AbstractAgent.java
+++ b/proxy/src/main/java/com/wavefront/agent/AbstractAgent.java
@@ -286,6 +286,7 @@ public abstract class AbstractAgent {
         customSourceTagsProperty = prop.getProperty("customSourceTags", customSourceTagsProperty);
         ephemeral = Boolean.parseBoolean(prop.getProperty("ephemeral", String.valueOf(ephemeral)));
         picklePorts = prop.getProperty("picklePorts", picklePorts);
+        bufferFile = prop.getProperty("buffer", bufferFile);
         logger.warning("Loaded configuration file " + pushConfigFile);
       } catch (Throwable exception) {
         logger.severe("Could not load configuration file " + pushConfigFile);


### PR DESCRIPTION
…nux system maintainers.

Remove recursive chown. Root now owns everything in the deployed
package, except that the system user ("wavefront") may write new files
to /opt/wavefront/wavefront-proxy (so we can store the .wavefront_id
file somewhere)