### PR TITLE
Attach the fully assembled jar to the maven project.

### DIFF
--- a/proxy/pom.xml
+++ b/proxy/pom.xml
@@ -180,7 +180,7 @@
             <configuration>
               <finalName>wavefront-push-agent</finalName>
               <appendAssemblyId>false</appendAssemblyId>
-              <attach>false</attach>
+              <attach>true</attach>
               <descriptorRefs>
                 <descriptorRef>jar-with-dependencies</descriptorRef>
               </descriptorRefs>


### PR DESCRIPTION
This should make the standalone "wavefront-push-agent.jar" downloadable
from Maven repo.