### PR TITLE
Create new "nodeps" jar as part of proxy release process.

### DIFF
--- a/proxy/pom.xml
+++ b/proxy/pom.xml
@@ -161,6 +161,23 @@
         </configuration>
       </plugin>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <version>2.3.2</version>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>jar</goal>
+            </goals>
+            <configuration>
+              <finalName>${project.artifactId}-${project.version}</finalName>
+              <classifier>nodeps</classifier>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
         <artifactId>maven-assembly-plugin</artifactId>
         <version>2.6</version>
         <executions>


### PR DESCRIPTION
Our maven-assembly-plugin replaces the common type of jar (no
dependencies) with an uber jar, since we have appendAssemblyId=false.
maven-assembly-plugin would support output naming like this:

        proxy-3.23.jar  // Small, no deps.
        proxy-3.23-with-deps.jar  // Large, uber.

Our current scheme is this:

        proxy-3.23.jar  // Large, uber.

This commit should bring us to this scheme:

        proxy-3.23.jar  // Large, uber.
        proxy-3.23-nodeps.jar  // Small, no deps.