### PR TITLE
Clean up proxy build process.

### DIFF
--- a/pkg/stage.sh
+++ b/pkg/stage.sh
@@ -65,4 +65,4 @@ ln -s ../commons-daemon/src/native/unix/jsvc jsvc
 
 echo "Stage the agent jar..."
 cd $PROG_DIR
-cp $PUSH_AGENT_JAR $PROXY_DIR/bin
+cp $PUSH_AGENT_JAR $PROXY_DIR/bin/wavefront-push-agent.jar

--- a/pom.xml
+++ b/pom.xml
@@ -219,6 +219,7 @@
                   <goal>shade</goal>
                 </goals>
                 <configuration>
+                  <finalName>${project.artifactId}-${project.version}-uber</finalName>
                   <relocations>
                     <relocation>
                       <pattern>com.wavefront.patches</pattern>

--- a/proxy/pom.xml
+++ b/proxy/pom.xml
@@ -176,26 +176,6 @@
               </descriptors>
             </configuration>
           </execution>
-          <execution>
-            <configuration>
-              <finalName>wavefront-push-agent</finalName>
-              <appendAssemblyId>false</appendAssemblyId>
-              <attach>false</attach>
-              <descriptorRefs>
-                <descriptorRef>jar-with-dependencies</descriptorRef>
-              </descriptorRefs>
-              <archive>
-                <manifest>
-                  <mainClass>com.wavefront.agent.PushAgent</mainClass>
-                </manifest>
-              </archive>
-            </configuration>
-            <id>make-assembly</id>
-            <phase>package</phase>
-            <goals>
-              <goal>attached</goal>
-            </goals>
-          </execution>
         </executions>
       </plugin>
     </plugins>


### PR DESCRIPTION
Remove jar-with-dependencies prefab from assembly plugin in proxy. The
parent "shade" plugin takes care of that.

Configure the parent "shade" plugin to postfix all jars with "-uber".
This ensures that the deploy plugin (invoked later), uploads the
smaller, non-uber jar, while still keeping the uber jar in target/.