### PR TITLE
Clean up version conflicts and redundant dependencies

### DIFF
--- a/java-lib/pom.xml
+++ b/java-lib/pom.xml
@@ -104,6 +104,7 @@
       <plugin>
         <groupId>org.apache.avro</groupId>
         <artifactId>avro-maven-plugin</artifactId>
+        <version>1.7.7</version>
         <configuration>
           <stringType>String</stringType>
           <templateDirectory>${project.basedir}/src/main/resources/wavefront/templates/</templateDirectory>

--- a/pom.xml
+++ b/pom.xml
@@ -69,6 +69,13 @@
         </configuration>
       </plugin>
       <plugin>
+        <artifactId>maven-assembly-plugin</artifactId>
+        <version>2.6</version>
+        <configuration>
+          <tarLongFileMode>gnu</tarLongFileMode>
+        </configuration>
+      </plugin>
+      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-release-plugin</artifactId>
         <version>2.5</version>

--- a/proxy/pom.xml
+++ b/proxy/pom.xml
@@ -68,11 +68,6 @@
       <version>${jetty.version}</version>
     </dependency>
     <dependency>
-      <groupId>org.glassfish.jersey.bundles</groupId>
-      <artifactId>jaxrs-ri</artifactId>
-      <version>2.22.1</version>
-    </dependency>
-    <dependency>
       <groupId>org.glassfish.jersey.containers</groupId>
       <artifactId>jersey-container-jetty-http</artifactId>
       <version>2.22.1</version>
@@ -103,8 +98,8 @@
     </dependency>
     <dependency>
       <groupId>io.netty</groupId>
-      <artifactId>netty-all</artifactId>
-      <version>4.0.33.Final</version>
+      <artifactId>netty-codec-http</artifactId>
+      <version>4.0.35.Final</version>
     </dependency>
     <dependency>
       <groupId>commons-daemon</groupId>
@@ -137,12 +132,18 @@
             <configuration>
               <finalName>${project.artifactId}-${project.version}-uber</finalName>
               <!--Relocation is required until HTTPCLIENT-1747 is fixed.-->
-              <relocations>
-                <relocation>
-                  <pattern>com.wavefront.patches</pattern>
-                  <shadedPattern />
-                </relocation>
-              </relocations>
+              <filters>
+                <filter>
+                  <artifact>org.apache.httpcomponents:httpclient</artifact>
+                  <includes>
+                    <include>org/apache/**</include>
+                  </includes>
+                  <excludes>
+                    <exclude>org/apache/http/client/params/HttpClientParamConfig</exclude>
+                    <exclude>org/apache/http/impl/client/InternalHttpClient</exclude>
+                  </excludes>
+                </filter>
+              </filters>
               <transformers>
                 <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
                 <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">

--- a/proxy/pom.xml
+++ b/proxy/pom.xml
@@ -131,7 +131,9 @@
             </goals>
             <configuration>
               <finalName>${project.artifactId}-${project.version}-uber</finalName>
-              <!--Relocation is required until HTTPCLIENT-1747 is fixed.-->
+              <!--Filters section is required until HTTPCLIENT-1747 is fixed - to make sure that patched
+              versions of HttpClientParamConfig and InternalHttpClient classes end up in the uber jar and
+              not what's in 4.5.2 -->
               <filters>
                 <filter>
                   <artifact>org.apache.httpcomponents:httpclient</artifact>


### PR DESCRIPTION
Reduce the number of warnings during project build