### PR TITLE
Graceful service shutdown and configure SO_LINGER

### DIFF
--- a/java-lib/src/main/java/com/wavefront/ingester/Ingester.java
+++ b/java-lib/src/main/java/com/wavefront/ingester/Ingester.java
@@ -4,6 +4,7 @@ import com.google.common.base.Charsets;
 import com.google.common.base.Function;
 
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Logger;
 
@@ -51,6 +52,11 @@ public abstract class Ingester implements Runnable {
    */
   protected ChannelInitializer initializer;
 
+  @Nullable
+  protected Map<ChannelOption<?>, ?> parentChannelOptions;
+  @Nullable
+  protected Map<ChannelOption<?>, ?> childChannelOptions;
+
   public Ingester(@Nullable List<Function<Channel, ChannelHandler>> decoders,
                   ChannelHandler commandHandler, int port) {
     this.listeningPort = port;
@@ -65,6 +71,16 @@ public abstract class Ingester implements Runnable {
   public Ingester(ChannelInitializer initializer, int port) {
     this.listeningPort = port;
     this.initializer = initializer;
+  }
+
+  public Ingester withParentChannelOptions(Map<ChannelOption<?>, ?> parentChannelOptions) {
+    this.parentChannelOptions = parentChannelOptions;
+    return this;
+  }
+
+  public Ingester withChildChannelOptions(Map<ChannelOption<?>, ?> childChannelOptions) {
+    this.childChannelOptions = childChannelOptions;
+    return this;
   }
 
   /**

--- a/java-lib/src/main/java/com/wavefront/ingester/StreamIngester.java
+++ b/java-lib/src/main/java/com/wavefront/ingester/StreamIngester.java
@@ -1,7 +1,10 @@
 package com.wavefront.ingester;
 
+import java.util.Map;
 import java.util.logging.Logger;
 import java.util.logging.Level;
+
+import javax.annotation.Nullable;
 
 import io.netty.bootstrap.ServerBootstrap;
 import io.netty.channel.ChannelFuture;
@@ -31,12 +34,28 @@ public class StreamIngester implements Runnable {
   private final int listeningPort;
   private final FrameDecoderFactory frameDecoderFactory;
 
+  @Nullable
+  protected Map<ChannelOption<?>, ?> parentChannelOptions;
+  @Nullable
+  protected Map<ChannelOption<?>, ?> childChannelOptions;
+
   public StreamIngester(FrameDecoderFactory frameDecoderFactory,
                         ChannelHandler commandHandler, int port) {
     this.listeningPort = port;
     this.commandHandler = commandHandler;
     this.frameDecoderFactory = frameDecoderFactory;
   }
+
+  public StreamIngester withParentChannelOptions(Map<ChannelOption<?>, ?> parentChannelOptions) {
+    this.parentChannelOptions = parentChannelOptions;
+    return this;
+  }
+
+  public StreamIngester withChildChannelOptions(Map<ChannelOption<?>, ?> childChannelOptions) {
+    this.childChannelOptions = childChannelOptions;
+    return this;
+  }
+
 
   public void run() {
     // Configure the server.

--- a/java-lib/src/main/java/com/wavefront/ingester/StreamIngester.java
+++ b/java-lib/src/main/java/com/wavefront/ingester/StreamIngester.java
@@ -77,6 +77,19 @@ public class StreamIngester implements Runnable {
             }
           });
 
+      if (parentChannelOptions != null) {
+        for (Map.Entry<ChannelOption<?>, ?> entry : parentChannelOptions.entrySet())
+        {
+          b.option((ChannelOption<Object>) entry.getKey(), entry.getValue());
+        }
+      }
+      if (childChannelOptions != null) {
+        for (Map.Entry<ChannelOption<?>, ?> entry : childChannelOptions.entrySet())
+        {
+          b.childOption((ChannelOption<Object>) entry.getKey(), entry.getValue());
+        }
+      }
+
       // Start the server.
       ChannelFuture f = b.bind().sync();
 

--- a/java-lib/src/main/java/com/wavefront/ingester/StreamIngester.java
+++ b/java-lib/src/main/java/com/wavefront/ingester/StreamIngester.java
@@ -41,8 +41,10 @@ public class StreamIngester implements Runnable {
   public void run() {
     // Configure the server.
     ServerBootstrap b = new ServerBootstrap();
+    NioEventLoopGroup parentGroup = new NioEventLoopGroup(1);
+    NioEventLoopGroup childGroup = new NioEventLoopGroup();
     try {
-      b.group(new NioEventLoopGroup(1), new NioEventLoopGroup())
+      b.group(parentGroup, childGroup)
           .channel(NioServerSocketChannel.class)
           .option(ChannelOption.SO_BACKLOG, 1024)
           .localAddress(listeningPort)
@@ -62,7 +64,10 @@ public class StreamIngester implements Runnable {
       // Wait until the server socket is closed.
       f.channel().closeFuture().sync();
     } catch (final InterruptedException e) {
-      logger.log(Level.WARNING, "Interrupted", e);
+      logger.log(Level.WARNING, "Interrupted");
+      parentGroup.shutdownGracefully();
+      childGroup.shutdownGracefully();
+      logger.info("Listener on port " + String.valueOf(listeningPort) + " shut down");
     }
   }
 }

--- a/java-lib/src/main/java/com/wavefront/ingester/TcpIngester.java
+++ b/java-lib/src/main/java/com/wavefront/ingester/TcpIngester.java
@@ -3,9 +3,12 @@ package com.wavefront.ingester;
 import com.google.common.base.Function;
 
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+
+import javax.annotation.Nullable;
 
 import io.netty.bootstrap.ServerBootstrap;
 import io.netty.channel.ChannelFuture;
@@ -44,6 +47,19 @@ public class TcpIngester extends Ingester {
         .option(ChannelOption.SO_BACKLOG, 1024)
         .localAddress(listeningPort)
         .childHandler(initializer);
+
+      if (parentChannelOptions != null) {
+        for (Map.Entry<ChannelOption<?>, ?> entry : parentChannelOptions.entrySet())
+        {
+          b.option((ChannelOption<Object>) entry.getKey(), entry.getValue());
+        }
+      }
+      if (childChannelOptions != null) {
+        for (Map.Entry<ChannelOption<?>, ?> entry : childChannelOptions.entrySet())
+        {
+          b.childOption((ChannelOption<Object>) entry.getKey(), entry.getValue());
+        }
+      }
 
       // Start the server.
       ChannelFuture f = b.bind().sync();

--- a/pkg/opt/wavefront/wavefront-proxy/conf/wavefront.conf
+++ b/pkg/opt/wavefront/wavefront-proxy/conf/wavefront.conf
@@ -131,3 +131,6 @@ buffer=/var/spool/wavefront-proxy/buffer
 ## Optional: if http proxy requires authentication
 #proxyUser=proxy_user
 #proxyPassword=proxy_password
+#
+## The following setting enables SO_LINGER with the specified linger time in seconds (SO_LINGER disabled by default)
+#soLingerTime=0

--- a/proxy/src/main/java/com/wavefront/agent/AbstractAgent.java
+++ b/proxy/src/main/java/com/wavefront/agent/AbstractAgent.java
@@ -213,6 +213,9 @@ public abstract class AbstractAgent {
   @Parameter(names = {"--javaNetConnection"}, description = "If true, use JRE's own http client when making connections instead of Apache HTTP Client")
   protected boolean javaNetConnection = false;
 
+  @Parameter(names = {"--soLingerTime"}, description = "If provided, enables SO_LINGER with the specified linger time in seconds (default: SO_LINGER disabled)")
+  protected int soLingerTime = -1;
+
   @Parameter(names = {"--proxyHost"}, description = "Proxy host for routing traffic through a http proxy")
   protected String proxyHost = null;
 
@@ -323,6 +326,7 @@ public abstract class AbstractAgent {
         proxyPassword = prop.getProperty("proxyPassword", proxyPassword);
         proxyUser = prop.getProperty("proxyUser", proxyUser);
         javaNetConnection = Boolean.valueOf(prop.getProperty("javaNetConnection", String.valueOf(javaNetConnection)));
+        soLingerTime = Integer.parseInt(prop.getProperty("soLingerTime", String.valueOf(soLingerTime)));
         splitPushWhenRateLimited = Boolean.parseBoolean(prop.getProperty("splitPushWhenRateLimited",
             String.valueOf(splitPushWhenRateLimited)));
         retryBackoffBaseSeconds = Double.parseDouble(prop.getProperty("retryBackoffBaseSeconds",

--- a/proxy/src/main/java/com/wavefront/agent/PostPushDataTimedTask.java
+++ b/proxy/src/main/java/com/wavefront/agent/PostPushDataTimedTask.java
@@ -180,7 +180,7 @@ public class PostPushDataTimedTask implements Runnable {
     }
   }
 
-  private void drainBuffersToQueue() {
+  public void drainBuffersToQueue() {
     try {
       isFlushingToQueue = true;
       while (points.size() > 0) {

--- a/proxy/src/main/java/com/wavefront/agent/PushAgentDaemon.java
+++ b/proxy/src/main/java/com/wavefront/agent/PushAgentDaemon.java
@@ -8,6 +8,7 @@ import org.apache.commons.daemon.DaemonInitException;
  * @author Mori Bellamy (mori@wavefront.com)
  */
 public class PushAgentDaemon implements Daemon {
+
     private PushAgent agent;
     private DaemonContext daemonContext;
 
@@ -24,7 +25,7 @@ public class PushAgentDaemon implements Daemon {
 
     @Override
     public void stop() throws Exception {
-
+        agent.shutdown();
     }
 
     @Override

--- a/proxy/src/main/java/com/wavefront/agent/QueuedAgentService.java
+++ b/proxy/src/main/java/com/wavefront/agent/QueuedAgentService.java
@@ -75,6 +75,7 @@ public class QueuedAgentService implements ForceQueueEnabledAgentAPI {
   private static int splitBatchSize = MAX_SPLIT_BATCH_SIZE;
   private static double retryBackoffBaseSeconds = 2.0;
   private boolean lastKnownQueueSizeIsPositive = true;
+  private final ExecutorService executorService;
   private MetricsRegistry metricsRegistry = new MetricsRegistry();
   private Meter resultPostingMeter = metricsRegistry.newMeter(QueuedAgentService.class, "post-result", "results",
       TimeUnit.MINUTES);
@@ -115,6 +116,7 @@ public class QueuedAgentService implements ForceQueueEnabledAgentAPI {
         registerTypeHierarchyAdapter(ResubmissionTask.class, new ResubmissionTaskDeserializer()).create();
     this.wrapped = service;
     this.taskQueues = Lists.newArrayListWithExpectedSize(retryThreads);
+    this.executorService = executorService;
     for (int i = 0; i < retryThreads; i++) {
       final int threadId = i;
       File buffer = new File(bufferFile + "." + i);
@@ -286,6 +288,10 @@ public class QueuedAgentService implements ForceQueueEnabledAgentAPI {
         return getQueuedTasksCount();
       }
     });
+  }
+
+  public void shutdown() {
+    executorService.shutdown();
   }
 
   public static void setRetryBackoffBaseSeconds(double newSecs) {


### PR DESCRIPTION
Prevent point loss during proxy shutdown/restart process - stop port listeners first and drain all in-memory buffers to retry queue