### PR TITLE
Reduce memory footprint

### DIFF
--- a/java-lib/src/main/java/com/wavefront/ingester/StringLineIngester.java
+++ b/java-lib/src/main/java/com/wavefront/ingester/StringLineIngester.java
@@ -70,4 +70,18 @@ public class StringLineIngester extends TcpIngester {
   public static String joinPushData(List<String> pushData) {
     return StringUtils.join(pushData, PUSH_DATA_DELIMETER);
   }
+
+  public static List<Integer> indexPushData(String pushData) {
+    List<Integer> index = new ArrayList<>();
+    index.add(0);
+    int lastIndex = pushData.indexOf(PUSH_DATA_DELIMETER);
+    final int delimiterLength = PUSH_DATA_DELIMETER.length();
+    while (lastIndex != -1) {
+      index.add(lastIndex);
+      index.add(lastIndex + delimiterLength);
+      lastIndex = pushData.indexOf(PUSH_DATA_DELIMETER, lastIndex + delimiterLength);
+    }
+    index.add(pushData.length());
+    return index;
+  }
 }

--- a/proxy/src/main/java/com/wavefront/agent/PointHandler.java
+++ b/proxy/src/main/java/com/wavefront/agent/PointHandler.java
@@ -2,6 +2,8 @@ package com.wavefront.agent;
 
 import java.util.List;
 
+import javax.annotation.Nullable;
+
 import sunnylabs.report.ReportPoint;
 
 /**
@@ -14,9 +16,9 @@ public interface PointHandler {
    * Send a point for reporting.
    *
    * @param point     Point to report.
-   * @param debugLine Debug information to print to console when the line is rejected.
+   * @param debugLine Debug information to print to console when the line is rejected. If null, then
    */
-  void reportPoint(ReportPoint point, String debugLine);
+  void reportPoint(ReportPoint point, @Nullable String debugLine);
 
   /**
    * Send a collection of points for reporting.

--- a/proxy/src/main/java/com/wavefront/agent/PointHandler.java
+++ b/proxy/src/main/java/com/wavefront/agent/PointHandler.java
@@ -16,7 +16,8 @@ public interface PointHandler {
    * Send a point for reporting.
    *
    * @param point     Point to report.
-   * @param debugLine Debug information to print to console when the line is rejected. If null, then
+   * @param debugLine Debug information to print to console when the line is rejected.
+   *                  If null, then use the entire point converted to string.
    */
   void reportPoint(ReportPoint point, @Nullable String debugLine);
 

--- a/proxy/src/main/java/com/wavefront/agent/QueuedAgentService.java
+++ b/proxy/src/main/java/com/wavefront/agent/QueuedAgentService.java
@@ -567,19 +567,18 @@ public class QueuedAgentService implements ForceQueueEnabledAgentAPI {
       // pull the pushdata back apart to split and put back together
       List<PostPushDataResultTask> splitTasks = Lists.newArrayList();
 
-      List<String> pushDatum = StringLineIngester.unjoinPushData(pushData);
+      List<Integer> dataIndex = StringLineIngester.indexPushData(pushData);
 
-      int numDatum = pushDatum.size();
+      int numDatum = dataIndex.size() / 2;
       if (numDatum > 1) {
         // in this case, at least split the strings in 2 batches.  batch size must be less
         // than splitBatchSize
         int stride = Math.min(splitBatchSize, (int) Math.ceil((float) numDatum / 2.0));
         int endingIndex = 0;
-        for (int startingIndex = 0; endingIndex < numDatum; startingIndex += stride) {
-          endingIndex = Math.min(numDatum, startingIndex + stride);
+        for (int startingIndex = 0; endingIndex < numDatum - 1; startingIndex += stride) {
+          endingIndex = Math.min(numDatum, startingIndex + stride) - 1;
           splitTasks.add(new PostPushDataResultTask(agentId, workUnitId, currentMillis, format,
-              StringLineIngester.joinPushData(new ArrayList<>(
-                  pushDatum.subList(startingIndex, endingIndex)))));
+              pushData.substring(dataIndex.get(startingIndex * 2), dataIndex.get(endingIndex * 2 + 1))));
         }
       } else {
         // 1 or 0


### PR DESCRIPTION
- No longer convert every single point to a string just in case it throws an exception
- When splitting a batch, use a string index instead of recreating all the strings