### PR TITLE
Prevent OoM in a tight retry loop 

### DIFF
--- a/proxy/src/main/java/com/wavefront/agent/QueuedAgentService.java
+++ b/proxy/src/main/java/com/wavefront/agent/QueuedAgentService.java
@@ -221,6 +221,7 @@ public class QueuedAgentService implements ForceQueueEnabledAgentAPI {
                 } finally {
                   if (removeTask) taskQueue.remove();
                 }
+                taskQueue.wait(50); // release lock for 50ms  
               }
             }
           } catch (Throwable ex) {

--- a/proxy/src/main/java/com/wavefront/agent/QueuedAgentService.java
+++ b/proxy/src/main/java/com/wavefront/agent/QueuedAgentService.java
@@ -169,8 +169,8 @@ public class QueuedAgentService implements ForceQueueEnabledAgentAPI {
               logger.warning("[RETRY THREAD " + threadId + "] TASK STARTING");
             }
             while (taskQueue.size() > 0 && taskQueue.size() > failures) {
+              taskQueue.getLockObject().lock();
               try {
-                taskQueue.getLockObject().lock();
                 ResubmissionTask task = taskQueue.peek();
                 boolean removeTask = true;
                 try {
@@ -456,14 +456,12 @@ public class QueuedAgentService implements ForceQueueEnabledAgentAPI {
   private void addTaskToSmallestQueue(ResubmissionTask taskToRetry) {
     ResubmissionTaskQueue queue = getSmallestQueue();
     if (queue != null) {
+      queue.getLockObject().lock();
       try {
-        queue.getLockObject().lock();
-        try {
-          queue.add(taskToRetry);
-        } catch (FileException e) {
-          logger.log(Level.WARNING,
-              "CRITICAL (Losing points!): WF-1: Submission queue is full.", e);
-        }
+        queue.add(taskToRetry);
+      } catch (FileException e) {
+        logger.log(Level.WARNING,
+            "CRITICAL (Losing points!): WF-1: Submission queue is full.", e);
       } finally {
         queue.getLockObject().unlock();
       }

--- a/proxy/src/main/java/com/wavefront/agent/ResubmissionTaskQueue.java
+++ b/proxy/src/main/java/com/wavefront/agent/ResubmissionTaskQueue.java
@@ -1,0 +1,26 @@
+package com.wavefront.agent;
+
+import com.squareup.tape.ObjectQueue;
+import com.squareup.tape.TaskInjector;
+import com.squareup.tape.TaskQueue;
+
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+
+/**
+ * Created by Vasily on 8/18/16.
+ */
+public class ResubmissionTaskQueue extends TaskQueue<ResubmissionTask> {
+
+  // maintain a fair lock on the queue
+  private ReentrantLock lock = new ReentrantLock(true);
+
+  public ResubmissionTaskQueue(ObjectQueue<ResubmissionTask> objectQueue, TaskInjector<ResubmissionTask> taskInjector) {
+    super(objectQueue, taskInjector);
+  }
+
+  public Lock getLockObject() {
+    return lock;
+  }
+
+}


### PR DESCRIPTION
on a machine with very limited resources. 
When the number of push threads is low and there are a lot of items in the retry queue; when a  new batch is also forced to be queued, the retry loop is very likely to immediately acquire back the just released lock, not giving the push thread a chance to write to the queue - and this could last for several minutes, quickly eating up heap memory as points are accumulating in a push thread's buffers.