### PR TITLE
Faster recovery after heavy queueing

### DIFF
--- a/proxy/src/main/java/com/wavefront/agent/AbstractAgent.java
+++ b/proxy/src/main/java/com/wavefront/agent/AbstractAgent.java
@@ -688,7 +688,8 @@ public abstract class AbstractAgent {
     }
     logger.info("Shutting down: Flushing pending points...");
     for (PostPushDataTimedTask task : managedTasks) {
-      task.drainBuffersToQueue();
+      while (task.getNumPointsToSend() > 0)
+        task.drainBuffersToQueue();
     }
     logger.info("Shutdown complete");
   }


### PR DESCRIPTION
Limit queue draining per cycle to give threads a chance to snap out of endless queueing loop