### PR TITLE
Support for direct logs ingestion from filebeat -> WF proxy.

### DIFF
--- a/.idea/codeStyleSettings.xml
+++ b/.idea/codeStyleSettings.xml
@@ -276,6 +276,9 @@
         <option name="DOWHILE_BRACE_FORCE" value="3" />
         <option name="WHILE_BRACE_FORCE" value="3" />
         <option name="FOR_BRACE_FORCE" value="3" />
+        <MarkdownNavigatorCodeStyleSettings>
+          <option name="RIGHT_MARGIN" value="72" />
+        </MarkdownNavigatorCodeStyleSettings>
         <XML>
           <option name="XML_LEGACY_SETTINGS_IMPORTED" value="true" />
         </XML>
@@ -300,23 +303,16 @@
           <option name="INDENT_SIZE" value="2" />
         </ADDITIONAL_INDENT_OPTIONS>
         <codeStyleSettings language="ECMA Script Level 4">
-          <option name="KEEP_CONTROL_STATEMENT_IN_ONE_LINE" value="false" />
           <option name="KEEP_BLANK_LINES_IN_CODE" value="1" />
-          <option name="BLANK_LINES_AFTER_CLASS_HEADER" value="1" />
           <option name="ALIGN_MULTILINE_PARAMETERS_IN_CALLS" value="true" />
           <option name="ALIGN_MULTILINE_BINARY_OPERATION" value="true" />
-          <option name="ALIGN_MULTILINE_ASSIGNMENT" value="true" />
           <option name="ALIGN_MULTILINE_TERNARY_OPERATION" value="true" />
-          <option name="ALIGN_MULTILINE_THROWS_LIST" value="true" />
           <option name="ALIGN_MULTILINE_EXTENDS_LIST" value="true" />
-          <option name="ALIGN_MULTILINE_PARENTHESIZED_EXPRESSION" value="true" />
           <option name="ALIGN_MULTILINE_ARRAY_INITIALIZER_EXPRESSION" value="true" />
           <option name="CALL_PARAMETERS_WRAP" value="1" />
           <option name="METHOD_PARAMETERS_WRAP" value="1" />
           <option name="EXTENDS_LIST_WRAP" value="1" />
-          <option name="THROWS_LIST_WRAP" value="1" />
           <option name="EXTENDS_KEYWORD_WRAP" value="1" />
-          <option name="THROWS_KEYWORD_WRAP" value="1" />
           <option name="METHOD_CALL_CHAIN_WRAP" value="1" />
           <option name="BINARY_OPERATION_WRAP" value="1" />
           <option name="BINARY_OPERATION_SIGN_ON_NEXT_LINE" value="true" />

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,1 +1,3 @@
 language: java
+jdk:
+  - oraclejdk8

--- a/java-lib/src/main/avro/Reporting.avdl
+++ b/java-lib/src/main/avro/Reporting.avdl
@@ -16,6 +16,14 @@ protocol Reporting {
     map<string> annotations = {};
   }
 
+  // The parts of a ReportPoint that uniquely identify a timeseries to wavefront.
+  record TimeSeries {
+    string metric;
+    string host = "unknown";
+    string table = "tsdb";
+    @java-class("java.util.TreeMap") map<string> annotations = {};
+  }
+
   record IndexUpdate {
     string table;
     bytes metricKey;

--- a/pkg/opt/wavefront/wavefront-proxy/conf/wavefront.conf
+++ b/pkg/opt/wavefront/wavefront-proxy/conf/wavefront.conf
@@ -111,12 +111,12 @@ buffer=/var/spool/wavefront-proxy/buffer
 ## the maximum amount of space the agent will use to buffer points locally
 #retryThreads=4
 
-## Regex pattern (java.util.regex) that input lines must match to be accepted.
-## Input lines are checked against the pattern before the prefix is prepended.
+## Regex metricMatcher (java.util.regex) that input lines must match to be accepted.
+## Input lines are checked against the metricMatcher before the prefix is prepended.
 #whitelistRegex=^(production|stage).*
 
-## Regex pattern (java.util.regex) that input lines must NOT match to be accepted.
-## Input lines are checked against the pattern before the prefix is prepended.
+## Regex metricMatcher (java.util.regex) that input lines must NOT match to be accepted.
+## Input lines are checked against the metricMatcher before the prefix is prepended.
 #blacklistRegex=^(qa|development|test).*
 
 ## Whether to split the push batch size when the push is rejected by Wavefront due to rate limit.  Default false.

--- a/pkg/opt/wavefront/wavefront-proxy/conf/wavefront.conf
+++ b/pkg/opt/wavefront/wavefront-proxy/conf/wavefront.conf
@@ -111,12 +111,12 @@ buffer=/var/spool/wavefront-proxy/buffer
 ## the maximum amount of space the agent will use to buffer points locally
 #retryThreads=4
 
-## Regex metricMatcher (java.util.regex) that input lines must match to be accepted.
-## Input lines are checked against the metricMatcher before the prefix is prepended.
+## Regex pattern (java.util.regex) that input lines must match to be accepted.
+## Input lines are checked against the pattern before the prefix is prepended.
 #whitelistRegex=^(production|stage).*
 
-## Regex metricMatcher (java.util.regex) that input lines must NOT match to be accepted.
-## Input lines are checked against the metricMatcher before the prefix is prepended.
+## Regex pattern (java.util.regex) that input lines must NOT match to be accepted.
+## Input lines are checked against the pattern before the prefix is prepended.
 #blacklistRegex=^(qa|development|test).*
 
 ## Whether to split the push batch size when the push is rejected by Wavefront due to rate limit.  Default false.

--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
 
     <java.version>1.7</java.version>
     <jetty.version>9.2.10.v20150310</jetty.version>
-    <jackson.version>2.5.3</jackson.version>
+    <jackson.version>2.7.4</jackson.version>
     <public.project.version>3.26-SNAPSHOT</public.project.version>
   </properties>
 
@@ -187,7 +187,7 @@
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-handler</artifactId>
-        <version>4.0.35.Final</version>
+        <version>4.1.5.Final</version>
       </dependency>
       <dependency>
         <groupId>com.google.code.findbugs</groupId>

--- a/proxy/README.md
+++ b/proxy/README.md
@@ -2,6 +2,9 @@
 
 The Wavefront proxy is a light-weight Java application that you send your metrics to. It handles authentication and the transmission of your metrics to your Wavefront instance.
 
+Source code under org.logstash.* is used from
+ [logstash-input-beats](https://github.com/logstash-plugins/logstash-input-beats) via the Apache 2.0 license.
+
 ## Installation
 
 ### Using The Wavefront Installer
@@ -25,4 +28,3 @@ mvn install
 ## Configuration
 
 For the detailed list of configuration options, please refer to [Wavefront Production Proxy Configuration Guide](https://community.wavefront.com/docs/DOC-1034) on our Community site.
-

--- a/proxy/config.ini
+++ b/proxy/config.ini
@@ -1,14 +1,17 @@
 retryThreads=0
-server=http://127.0.0.1:5000/post
+server=http://localhost:8080/api
 hostname=myHost
-token=TOKEN_HERE
+token=23f9d3c5-1fb5-4330-a111-c2d3feda355d
 pushListenerPorts=2878
 
 pushFlushMaxPoints=40000
 pushFlushInterval=1000
 pushBlockedSamples=5
+filebeatPort=5044
+prefix=development
 
 pushLogLevel=SUMMARY
 pushValidationLevel=NUMERIC_ONLY
 
 idFile=wavefront_test_id
+logsIngestionConfigFile=proxy/logsIngestion.yaml

--- a/proxy/config.ini
+++ b/proxy/config.ini
@@ -1,17 +1,14 @@
 retryThreads=0
-server=http://localhost:8080/api
+server=http://127.0.0.1:5000/post
 hostname=myHost
-token=23f9d3c5-1fb5-4330-a111-c2d3feda355d
+token=TOKEN_HERE
 pushListenerPorts=2878
 
 pushFlushMaxPoints=40000
 pushFlushInterval=1000
 pushBlockedSamples=5
-filebeatPort=5044
-prefix=development
 
 pushLogLevel=SUMMARY
 pushValidationLevel=NUMERIC_ONLY
 
 idFile=wavefront_test_id
-logsIngestionConfigFile=proxy/logsIngestion.yaml

--- a/proxy/logsIngestion.yaml
+++ b/proxy/logsIngestion.yaml
@@ -1,0 +1,4 @@
+aggregationIntervalSeconds: 4
+counters:
+  - pattern: "%{COMBINEDAPACHELOG}%{GREEDYDATA:extra_fields}"
+    metricName: "development.combined_apache_log_lines"

--- a/proxy/pom.xml
+++ b/proxy/pom.xml
@@ -8,6 +8,10 @@
     <version>3.26-SNAPSHOT</version>
   </parent>
 
+  <properties>
+    <java.version>1.8</java.version>
+  </properties>
+
   <artifactId>proxy</artifactId>
 
   <name>Wavefront Proxy Agent</name>
@@ -86,7 +90,13 @@
       <groupId>org.easymock</groupId>
       <artifactId>easymock</artifactId>
       <scope>test</scope>
-      <version>3.2</version>
+      <version>3.4</version>
+    </dependency>
+    <!-- https://mvnrepository.com/artifact/org.hamcrest/hamcrest-all -->
+    <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest-all</artifactId>
+      <version>1.3</version>
     </dependency>
     <dependency>
       <groupId>joda-time</groupId>
@@ -99,7 +109,7 @@
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-codec-http</artifactId>
-      <version>4.0.35.Final</version>
+      <version>4.1.5.Final</version>
     </dependency>
     <dependency>
       <groupId>commons-daemon</groupId>
@@ -110,6 +120,44 @@
       <groupId>org.yaml</groupId>
       <artifactId>snakeyaml</artifactId>
       <version>1.17</version>
+    </dependency>
+    <!-- https://mvnrepository.com/artifact/log4j/log4j -->
+    <dependency>
+      <groupId>log4j</groupId>
+      <artifactId>log4j</artifactId>
+      <version>1.2.17</version>
+    </dependency>
+    <!-- https://mvnrepository.com/artifact/com.fasterxml.jackson.module/jackson-module-afterburner -->
+    <dependency>
+      <groupId>com.fasterxml.jackson.module</groupId>
+      <artifactId>jackson-module-afterburner</artifactId>
+      <version>${jackson.version}</version>
+    </dependency>
+    <!--&lt;!&ndash; https://mvnrepository.com/artifact/com.fasterxml.jackson.core/jackson-databind &ndash;&gt;-->
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <version>${jackson.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-annotations</artifactId>
+      <version>${jackson.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.dataformat</groupId>
+      <artifactId>jackson-dataformat-yaml</artifactId>
+      <version>${jackson.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.github.ben-manes.caffeine</groupId>
+      <artifactId>caffeine</artifactId>
+      <version>2.3.3</version>
+    </dependency>
+    <dependency>
+      <groupId>io.thekraken</groupId>
+      <artifactId>grok</artifactId>
+      <version>0.1.4</version>
     </dependency>
   </dependencies>
 

--- a/proxy/src/main/java/com/wavefront/agent/AbstractAgent.java
+++ b/proxy/src/main/java/com/wavefront/agent/AbstractAgent.java
@@ -176,7 +176,7 @@ public abstract class AbstractAgent {
   protected String writeHttpJsonPorts = "";
 
   @Parameter(names = {"--filebeatPort"}, description = "Port on which to listen for filebeat data.")
-  protected Integer filebeatPort = null;
+  protected Integer filebeatPort = 0;
 
   @Parameter(names = {"--hostname"}, description = "Hostname for the agent. Defaults to FQDN of machine.")
   protected String hostname;

--- a/proxy/src/main/java/com/wavefront/agent/AbstractAgent.java
+++ b/proxy/src/main/java/com/wavefront/agent/AbstractAgent.java
@@ -11,6 +11,9 @@ import com.google.gson.Gson;
 import com.beust.jcommander.JCommander;
 import com.beust.jcommander.Parameter;
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import com.wavefront.agent.config.LogsIngestionConfig;
 import com.wavefront.agent.preprocessor.AgentPreprocessorConfiguration;
 import com.wavefront.agent.preprocessor.PointLineBlacklistRegexFilter;
 import com.wavefront.agent.preprocessor.PointLineWhitelistRegexFilter;
@@ -161,7 +164,7 @@ public abstract class AbstractAgent {
       "extracted hostname with dots. Defaults to underscores (_).")
   protected String graphiteDelimiters = "_";
 
-  @Parameter(names = {"--graphiteFieldsToRemove"}, description="Comma-separated list of metric segments to remove (1-based)")
+  @Parameter(names = {"--graphiteFieldsToRemove"}, description = "Comma-separated list of metric segments to remove (1-based)")
   protected String graphiteFieldsToRemove;
 
   @Parameter(names = {"--httpJsonPorts"}, description = "Comma-separated list of ports to listen on for json metrics " +
@@ -171,6 +174,9 @@ public abstract class AbstractAgent {
   @Parameter(names = {"--writeHttpJsonPorts"}, description = "Comma-separated list of ports to listen on for json metrics from collectd write_http json format " +
       "data. Binds, by default, to none.")
   protected String writeHttpJsonPorts = "";
+
+  @Parameter(names = {"--filebeatPort"}, description = "Port on which to listen for filebeat data.")
+  protected Integer filebeatPort = null;
 
   @Parameter(names = {"--hostname"}, description = "Hostname for the agent. Defaults to FQDN of machine.")
   protected String hostname;
@@ -243,6 +249,9 @@ public abstract class AbstractAgent {
   @Parameter(names = {"--dataBackfillCutoffHours"}, description = "The cut-off point for what is considered a valid timestamp for back-dated points. Default is 8760 (1 year)")
   protected int dataBackfillCutoffHours = 8760;
 
+  @Parameter(names = {"--logsIngestionConfigFile"}, description = "Location of logs ingestions config yaml file.")
+  protected String logsIngestionConfigFile = null;
+
   @Parameter(description = "Unparsed parameters")
   protected List<String> unparsed_params;
 
@@ -256,6 +265,8 @@ public abstract class AbstractAgent {
 
   protected final boolean localAgent;
   protected final boolean pushAgent;
+
+  protected LogsIngestionConfig logsIngestionConfig;
 
   /**
    * Executors for support tasks.
@@ -302,7 +313,7 @@ public abstract class AbstractAgent {
     // convert blacklist/whitelist fields to filters for full backwards compatibility
     // blacklistRegex and whitelistRegex are applied to pushListenerPorts, graphitePorts and picklePorts
     if (whitelistRegex != null || blacklistRegex != null) {
-      String allPorts = StringUtils.join(new String[] {
+      String allPorts = StringUtils.join(new String[]{
           pushListenerPorts == null ? "" : pushListenerPorts,
           graphitePorts == null ? "" : graphitePorts,
           picklePorts == null ? "" : picklePorts
@@ -348,6 +359,14 @@ public abstract class AbstractAgent {
       preprocessors.loadFromStream(stream);
       logger.info("Preprocessor configuration loaded from " + preprocessorConfigFile);
     }
+  }
+
+  private void loadLogsIngestionConfig() throws IOException {
+    if (logsIngestionConfigFile == null) {
+      return;
+    }
+    ObjectMapper objectMapper = new ObjectMapper(new YAMLFactory());
+    logsIngestionConfig = objectMapper.readValue(new File(logsIngestionConfigFile), LogsIngestionConfig.class);
   }
 
   private void loadListenerConfigurationFile() throws IOException {
@@ -403,6 +422,8 @@ public abstract class AbstractAgent {
         preprocessorConfigFile = prop.getProperty("preprocessorConfigFile", preprocessorConfigFile);
         dataBackfillCutoffHours = Integer.parseInt(prop.getProperty("dataBackfillCutoffHours",
             String.valueOf(dataBackfillCutoffHours)));
+        filebeatPort = Integer.parseInt(prop.getProperty("filebeatPort", String.valueOf(filebeatPort)));
+        logsIngestionConfigFile = prop.getProperty("logsIngestionConfigFile", logsIngestionConfigFile);
         logger.warning("Loaded configuration file " + pushConfigFile);
       } catch (Throwable exception) {
         logger.severe("Could not load configuration file " + pushConfigFile);
@@ -443,8 +464,9 @@ public abstract class AbstractAgent {
        * Configuration Setup.
        * ------------------------------------------------------------------------------------ */
 
-      // 1. Load the listener configuration, if it exists
+      // 1. Load the listener configurations.
       loadListenerConfigurationFile();
+      loadLogsIngestionConfig();
 
       // 2. Read or create the unique Id for the daemon running on this machine.
       readOrCreateDaemonId();
@@ -764,18 +786,18 @@ public abstract class AbstractAgent {
     logger.info("Shutdown complete");
   }
 
-  private String getLocalHostName() {
+  private static String getLocalHostName() {
     try {
       return InetAddress.getLocalHost().getCanonicalHostName();
     } catch (UnknownHostException e) {
       try {
         // if can't resolve local server name, use a real IPv4 address from the first available network interface
         for (Enumeration<NetworkInterface> nics = NetworkInterface.getNetworkInterfaces();
-             nics.hasMoreElements();) {
+             nics.hasMoreElements(); ) {
           NetworkInterface network = nics.nextElement();
           if (!network.isUp() || network.isLoopback())
             continue;
-          for (Enumeration<InetAddress> addresses = network.getInetAddresses(); addresses.hasMoreElements();) {
+          for (Enumeration<InetAddress> addresses = network.getInetAddresses(); addresses.hasMoreElements(); ) {
             InetAddress address = addresses.nextElement();
             if (address.isAnyLocalAddress() || address.isLoopbackAddress() ||
                 address.isMulticastAddress() || !(address instanceof Inet4Address))

--- a/proxy/src/main/java/com/wavefront/agent/PushAgent.java
+++ b/proxy/src/main/java/com/wavefront/agent/PushAgent.java
@@ -6,6 +6,7 @@ import com.google.common.base.Splitter;
 
 import com.beust.jcommander.internal.Lists;
 import com.wavefront.agent.formatter.GraphiteFormatter;
+import com.wavefront.agent.logsharvesting.FilebeatListener;
 import com.wavefront.agent.preprocessor.PointPreprocessor;
 import com.wavefront.agent.preprocessor.ReportPointAddPrefixTransformer;
 import com.wavefront.agent.preprocessor.ReportPointTimestampInRangeFilter;
@@ -22,6 +23,7 @@ import com.wavefront.ingester.TcpIngester;
 import org.glassfish.jersey.jackson.JacksonFeature;
 import org.glassfish.jersey.jetty.JettyHttpContainerFactory;
 import org.glassfish.jersey.server.ResourceConfig;
+import org.logstash.beats.Server;
 
 import java.io.IOException;
 import java.net.URI;
@@ -152,6 +154,20 @@ public class PushAgent extends AbstractAgent {
         }
       }
     }
+
+    if (filebeatPort != null) {
+      final Server filebeatServer = new Server(filebeatPort);
+      filebeatServer.setMessageListener(new FilebeatListener(
+          new PointHandlerImpl(filebeatPort, pushValidationLevel, pushBlockedSamples, getFlushTasks(filebeatPort)),
+          logsIngestionConfig, hostname, prefix, true));
+      startAsManagedThread(() -> {
+        try {
+          filebeatServer.listen();
+        } catch (InterruptedException e) {
+          e.printStackTrace();
+        }
+      });
+    }
   }
 
   protected void startOpenTsdbListener(final String strPort) {
@@ -213,10 +229,10 @@ public class PushAgent extends AbstractAgent {
   /**
    * Registers a custom point handler on a particular port.
    *
-   * @param strPort       The port to listen on.
-   * @param decoder       The decoder to use.
-   * @param pointHandler  The handler to handle parsed ReportPoints.
-   * @param preprocessor  Pre-processor (predicates and transform functions) for every point
+   * @param strPort      The port to listen on.
+   * @param decoder      The decoder to use.
+   * @param pointHandler The handler to handle parsed ReportPoints.
+   * @param preprocessor Pre-processor (predicates and transform functions) for every point
    */
   protected void startCustomListener(String strPort, Decoder<String> decoder, PointHandler pointHandler,
                                      @Nullable PointPreprocessor preprocessor) {

--- a/proxy/src/main/java/com/wavefront/agent/PushAgent.java
+++ b/proxy/src/main/java/com/wavefront/agent/PushAgent.java
@@ -155,11 +155,11 @@ public class PushAgent extends AbstractAgent {
       }
     }
 
-    if (filebeatPort != null) {
+    if (filebeatPort > 0) {
       final Server filebeatServer = new Server(filebeatPort);
       filebeatServer.setMessageListener(new FilebeatListener(
           new PointHandlerImpl(filebeatPort, pushValidationLevel, pushBlockedSamples, getFlushTasks(filebeatPort)),
-          logsIngestionConfig, hostname, prefix, true));
+          logsIngestionConfig, hostname, prefix));
       startAsManagedThread(() -> {
         try {
           filebeatServer.listen();

--- a/proxy/src/main/java/com/wavefront/agent/PushAgent.java
+++ b/proxy/src/main/java/com/wavefront/agent/PushAgent.java
@@ -323,7 +323,7 @@ public class PushAgent extends AbstractAgent {
       }
     }
 
-    if (filebeatPort > 0) {
+    if (filebeatPort > 0 && logsIngestionConfig != null) {
       final Server filebeatServer = new Server(filebeatPort);
       final String filebeatPortStr = String.valueOf(filebeatPort);
       filebeatServer.setMessageListener(new FilebeatListener(

--- a/proxy/src/main/java/com/wavefront/agent/PushAgent.java
+++ b/proxy/src/main/java/com/wavefront/agent/PushAgent.java
@@ -325,8 +325,10 @@ public class PushAgent extends AbstractAgent {
 
     if (filebeatPort > 0) {
       final Server filebeatServer = new Server(filebeatPort);
+      final String filebeatPortStr = String.valueOf(filebeatPort);
       filebeatServer.setMessageListener(new FilebeatListener(
-          new PointHandlerImpl(filebeatPort, pushValidationLevel, pushBlockedSamples, getFlushTasks(filebeatPort)),
+          new PointHandlerImpl(
+              filebeatPortStr, pushValidationLevel, pushBlockedSamples, getFlushTasks(filebeatPortStr)),
           logsIngestionConfig, hostname, prefix));
       startAsManagedThread(() -> {
         try {

--- a/proxy/src/main/java/com/wavefront/agent/config/Configuration.java
+++ b/proxy/src/main/java/com/wavefront/agent/config/Configuration.java
@@ -1,0 +1,14 @@
+package com.wavefront.agent.config;
+
+/**
+ * @author Mori Bellamy (mori@wavefront.com)
+ */
+public abstract class Configuration {
+  protected void ensure(boolean b, String message) throws ConfigurationException {
+    if (!b) {
+      throw new ConfigurationException(message);
+    }
+  }
+
+  public abstract void verify() throws ConfigurationException;
+}

--- a/proxy/src/main/java/com/wavefront/agent/config/ConfigurationException.java
+++ b/proxy/src/main/java/com/wavefront/agent/config/ConfigurationException.java
@@ -1,0 +1,10 @@
+package com.wavefront.agent.config;
+
+/**
+ * @author Mori Bellamy (mori@wavefront.com)
+ */
+public class ConfigurationException extends Exception {
+  public ConfigurationException(String message) {
+    super(message);
+  }
+}

--- a/proxy/src/main/java/com/wavefront/agent/config/LogsIngestionConfig.java
+++ b/proxy/src/main/java/com/wavefront/agent/config/LogsIngestionConfig.java
@@ -1,0 +1,85 @@
+package com.wavefront.agent.config;
+
+import com.google.common.base.Throwables;
+import com.google.common.collect.ImmutableList;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import org.apache.commons.io.IOUtils;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.PrintWriter;
+import java.util.Arrays;
+import java.util.List;
+
+import oi.thekraken.grok.api.Grok;
+import oi.thekraken.grok.api.exception.GrokException;
+
+/**
+ * @author Mori Bellamy (mori@wavefront.com)
+ */
+public class LogsIngestionConfig extends Configuration {
+  @JsonProperty
+  public Integer aggregationIntervalSeconds = 5;
+  @JsonProperty
+  public List<MetricMatcher> counters = ImmutableList.of();
+  @JsonProperty
+  public List<MetricMatcher> gauges = ImmutableList.of();
+  @JsonProperty
+  public List<String> additionalPatterns = ImmutableList.of();
+
+  private String patternsFile = null;
+  private Object patternsFileLock = new Object();
+
+  public String patternsFile() {
+    if (patternsFile != null) return patternsFile;
+    synchronized (patternsFileLock) {
+      if (patternsFile != null) return patternsFile;
+      try {
+        File temp = File.createTempFile("patterns", ".tmp");
+        InputStream patternInputStream = getClass().getClassLoader().getResourceAsStream("patterns/patterns");
+        FileOutputStream fileOutputStream = new FileOutputStream(temp);
+        IOUtils.copy(patternInputStream, fileOutputStream);
+        PrintWriter printWriter = new PrintWriter(fileOutputStream);
+        for (String pattern : additionalPatterns) {
+          printWriter.write("\n" + pattern);
+        }
+        printWriter.close();
+        patternsFile = temp.getAbsolutePath();
+        return patternsFile;
+      } catch (IOException e) {
+        throw Throwables.propagate(e);
+      }
+    }
+  }
+
+  // HACK: this must be called for the additional patterns feature to work.
+  @Override
+  public void verify() throws ConfigurationException {
+    Grok grok = new Grok();
+    for (String pattern : additionalPatterns) {
+      String[] parts = pattern.split(" ");
+      String name = parts[0];
+      String regex = String.join(" ", Arrays.copyOfRange(parts, 1, parts.length));
+      try {
+        grok.addPattern(name, regex);
+      } catch (GrokException e) {
+        throw new ConfigurationException("bad grok pattern: " + pattern);
+      }
+    }
+    ensure(aggregationIntervalSeconds > 0, "aggregationIntervalSeconds must be positive.");
+    for (MetricMatcher p : counters) {
+      p.setPatternsFile(patternsFile());
+      p.verify();
+    }
+    for (MetricMatcher p : gauges) {
+      p.setPatternsFile(patternsFile());
+      p.verify();
+      ensure(p.hasCapture("value"), "Must have a capture with label 'value' for a gauge.");
+    }
+
+  }
+}

--- a/proxy/src/main/java/com/wavefront/agent/config/MetricMatcher.java
+++ b/proxy/src/main/java/com/wavefront/agent/config/MetricMatcher.java
@@ -1,0 +1,144 @@
+package com.wavefront.agent.config;
+
+import com.google.common.base.Throwables;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Maps;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.wavefront.agent.logsharvesting.FilebeatMessage;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.http.annotation.ThreadSafe;
+
+import java.util.List;
+import java.util.Map;
+import java.util.logging.Logger;
+
+import oi.thekraken.grok.api.Grok;
+import oi.thekraken.grok.api.Match;
+import oi.thekraken.grok.api.exception.GrokException;
+import sunnylabs.report.TimeSeries;
+
+/**
+ * A configuration for the Wavefront Proxy. A single MetricMatcher defines how to transform a log line into
+ * a timeseries data point, see {@link #timeSeries(FilebeatMessage, Double[])}.
+ *
+ * @author Mori Bellamy (mori@wavefront.com)
+ */
+@ThreadSafe
+public class MetricMatcher extends Configuration {
+  protected static final Logger logger = Logger.getLogger(MetricMatcher.class.getCanonicalName());
+  private final Object grokLock = new Object();
+  /**
+   * A Logstash style grok pattern, see
+   * https://www.elastic.co/guide/en/logstash/current/plugins-filters-grok.html and http://grokdebug.herokuapp.com/.
+   * If a log line matches this pattern, that log line will be transformed into a metric per the other fields
+   * in this object.
+   */
+  @JsonProperty
+  private String pattern = "";
+  /**
+   * The metric name for the point we're creating from the current log line. may contain substitutions from
+   * {@link #pattern}. For example, if your pattern is "operation %{WORD:opName} ...",
+   * and your log line is "operation baz ..." then you can use the metric name "operations.%{opName}".
+   */
+  @JsonProperty
+  private String metricName = "";
+  /**
+   * A list of tags for the point you are creating from the logLine. If you don't want any tags, leave empty. For
+   * example, could be ["myDatacenter", "myEnvironment"] Also see {@link #tagValueLabels}.
+   */
+  @JsonProperty
+  private List<String> tagKeys = ImmutableList.of();
+  /**
+   * A parallel array to {@link #tagKeys}. Each entry is a label you defined in {@link #pattern}. For example, you
+   * might use ["datacenter", "env"] if your pattern is
+   * "operation foo in %{WORD:datacenter}:%{WORD:env} succeeded in %{NUMBER:value} milliseconds", and your log line is
+   * "operation foo in 2a:prod succeeded in 1234 milliseconds", then you would generate the point
+   * "foo.latency 1234 myDataCenter=2a myEnvironment=prod"
+   */
+  @JsonProperty
+  private List<String> tagValueLabels = ImmutableList.of();
+  private Grok grok = null;
+
+  private String patternsFile = null;
+
+  public void setPatternsFile(String patternsFile) {
+    this.patternsFile = patternsFile;
+  }
+
+  // Singleton grok for this pattern.
+  private Grok grok() {
+    if (grok != null) return grok;
+    synchronized (grokLock) {
+      if (grok != null) return grok;
+      try {
+        grok = Grok.create(patternsFile);
+        grok.compile(pattern);
+      } catch (GrokException e) {
+        logger.severe("Invalid grok pattern: " + pattern);
+        throw Throwables.propagate(e);
+      }
+      return grok;
+    }
+  }
+
+  private String dynamicMetricName(Map<String, Object> replacements) {
+    String dynamicName = metricName;
+    for (String key : replacements.keySet()) {
+      String value = (String) replacements.get(key);
+      dynamicName = dynamicName.replaceAll("[%][{]" + key + "[}]", value);
+    }
+    return dynamicName;
+  }
+
+  /**
+   * Convert the given message to a timeSeries and a telemetry datum
+   *
+   * @param filebeatMessage The filebeat message to convert.
+   * @param output          The telemetry parsed from the filebeat message.
+   */
+  public TimeSeries timeSeries(FilebeatMessage filebeatMessage, Double[] output) throws NumberFormatException {
+    Match match = grok().match(filebeatMessage.getLogLine());
+    match.captures();
+    if (match.getEnd() == 0) return null;
+    if (output != null) {
+      if (match.toMap().containsKey("value")) {
+        output[0] = Double.parseDouble((String) match.toMap().get("value"));
+      } else {
+        output[0] = null;
+      }
+    }
+    TimeSeries.Builder builder = TimeSeries.newBuilder();
+    String dynamicName = dynamicMetricName(match.toMap());
+    // Important to use a tree map for tags, since we need a stable ordering for the serialization
+    // into the FilebeatListener.metricsCache.
+    Map<String, String> tags = Maps.newTreeMap();
+    for (int i = 0; i < tagKeys.size(); i++) {
+      String tagKey = tagKeys.get(i);
+      String valueLabel = tagValueLabels.get(i);
+      if (!match.toMap().containsKey(valueLabel)) {
+        // What happened? We shouldn't have had matchEnd != 0 above...
+        logger.severe("Application error: unparsed tag key.");
+        continue;
+      }
+      String value = (String) match.toMap().get(valueLabel);
+      tags.put(tagKey, value);
+    }
+    builder.setAnnotations(tags);
+    return builder.setMetric(dynamicName).setHost(filebeatMessage.hostOrDefault("filebeat")).build();
+  }
+
+  public boolean hasCapture(String label) {
+    return grok().getNamedRegexCollection().values().contains(label);
+  }
+
+
+  @Override
+  public void verify() throws ConfigurationException {
+    ensure(StringUtils.isNotBlank(pattern), "pattern must not be empty.");
+    ensure(StringUtils.isNotBlank(metricName), "metric name must not be empty.");
+    ensure(tagKeys.size() == tagValueLabels.size(), "keys and valueLabels must be parallel arrays.");
+  }
+
+}

--- a/proxy/src/main/java/com/wavefront/agent/logsharvesting/ChangeableGauge.java
+++ b/proxy/src/main/java/com/wavefront/agent/logsharvesting/ChangeableGauge.java
@@ -1,0 +1,19 @@
+package com.wavefront.agent.logsharvesting;
+
+import com.yammer.metrics.core.Gauge;
+
+/**
+ * @author Mori Bellamy (mori@wavefront.com)
+ */
+public class ChangeableGauge<T> extends Gauge<T> {
+  private T value;
+
+  public void setValue(T value) {
+    this.value = value;
+  }
+
+  @Override
+  public T value() {
+    return this.value;
+  }
+}

--- a/proxy/src/main/java/com/wavefront/agent/logsharvesting/FilebeatListener.java
+++ b/proxy/src/main/java/com/wavefront/agent/logsharvesting/FilebeatListener.java
@@ -57,11 +57,11 @@ public class FilebeatListener implements IMessageListener {
     this.logsIngestionConfig = logsIngestionConfig;
     this.metricsRegistry = new MetricsRegistry();
     // Meta metrics.
-    this.received = Metrics.newCounter(FilebeatListener.class, "logsharvesting.received");
-    this.evicted = Metrics.newCounter(FilebeatListener.class, "logsharvesting.evicted");
-    this.unparsed = Metrics.newCounter(FilebeatListener.class, "logsharvesting.unparsed");
-    this.parsed = Metrics.newCounter(FilebeatListener.class, "logsharvesting.parsed");
-    this.batchesProcessed = Metrics.newCounter(FilebeatListener.class, "logsharvesting.unparsed");
+    this.received = Metrics.newCounter(new MetricName("logsharvesting", "", "received"));
+    this.evicted = Metrics.newCounter(new MetricName("logsharvesting", "", "evicted"));
+    this.unparsed = Metrics.newCounter(new MetricName("logsharvesting", "", "unparsed"));
+    this.parsed = Metrics.newCounter(new MetricName("logsharvesting", "", "parsed"));
+    this.batchesProcessed = Metrics.newCounter(new MetricName("logsharvesting", "", "batchesProcessed"));
 
     // Set up user specified metric harvesting.
     this.metricCache = Caffeine.<MetricName, Metric>newBuilder()

--- a/proxy/src/main/java/com/wavefront/agent/logsharvesting/FilebeatListener.java
+++ b/proxy/src/main/java/com/wavefront/agent/logsharvesting/FilebeatListener.java
@@ -1,0 +1,185 @@
+package com.wavefront.agent.logsharvesting;
+
+import com.google.common.annotations.VisibleForTesting;
+
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.LoadingCache;
+import com.github.benmanes.caffeine.cache.RemovalCause;
+import com.wavefront.agent.PointHandler;
+import com.wavefront.agent.config.LogsIngestionConfig;
+import com.wavefront.agent.config.MetricMatcher;
+import com.yammer.metrics.core.Counter;
+import com.yammer.metrics.core.Gauge;
+import com.yammer.metrics.core.Metric;
+import com.yammer.metrics.core.MetricName;
+import com.yammer.metrics.core.MetricsRegistry;
+
+import org.logstash.beats.IMessageListener;
+import org.logstash.beats.Message;
+
+import java.util.Timer;
+import java.util.TimerTask;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Logger;
+
+import io.netty.channel.ChannelHandlerContext;
+import sunnylabs.report.ReportPoint;
+import sunnylabs.report.TimeSeries;
+
+/**
+ * Listens for messages from Filebeat and processes them, sending telemetry to a given sink.
+ *
+ * @author Mori Bellamy (mori@wavefront.com)
+ */
+public class FilebeatListener implements IMessageListener {
+  protected static final Logger logger = Logger.getLogger(FilebeatListener.class.getCanonicalName());
+  private static final FlushProcessor flushProcessor = new FlushProcessor();
+  private static ReadProcessor readProcessor = new ReadProcessor();
+  private final PointHandler pointHandler;
+  private final MetricsRegistry metricsRegistry;
+  private final LogsIngestionConfig logsIngestionConfig;
+  private final LoadingCache<MetricName, Metric> metricCache;
+  private final Counter received, evicted, unparsed, batchesProcessed, parsed;
+  private final String hostname, prefix;
+
+  /**
+   * @param pointHandler        Play parsed metrics and meta-metrics to this
+   * @param logsIngestionConfig configuration object for logs harvesting
+   * @param hostname            hostname for meta-metrics (so, for this proxy)
+   * @param prefix              all harvested metrics start with this prefix
+   * @param reportMetaMetrics   if true, report meta-metrics. parameterized so we can turn off for testing
+   */
+  public FilebeatListener(PointHandler pointHandler, LogsIngestionConfig logsIngestionConfig, String hostname,
+                          String prefix, boolean reportMetaMetrics) {
+    this.pointHandler = pointHandler;
+    this.hostname = hostname;
+    this.prefix = prefix;
+    this.logsIngestionConfig = logsIngestionConfig;
+    this.metricsRegistry = new MetricsRegistry();
+    // Meta metrics.
+    this.received = metricsRegistry.newCounter(FilebeatListener.class, "received");
+    this.evicted = metricsRegistry.newCounter(FilebeatListener.class, "evicted");
+    this.unparsed = metricsRegistry.newCounter(FilebeatListener.class, "unparsed");
+    this.parsed = metricsRegistry.newCounter(FilebeatListener.class, "parsed");
+    this.batchesProcessed = metricsRegistry.newCounter(FilebeatListener.class, "unparsed");
+
+    if (reportMetaMetrics) {
+      Timer t = new Timer();
+      t.scheduleAtFixedRate(new TimerTask() {
+        @Override
+        public void run() {
+          pointHandler.reportPoint(ReportPoint.newBuilder().setMetric("~agent.logsharvesting.received")
+              .setHost(hostname).setValue(received.count()).setTimestamp(System.currentTimeMillis()).build(), null);
+          pointHandler.reportPoint(ReportPoint.newBuilder().setMetric("~agent.logsharvesting.evicted")
+              .setHost(hostname).setValue(evicted.count()).setTimestamp(System.currentTimeMillis()).build(), null);
+          pointHandler.reportPoint(ReportPoint.newBuilder().setMetric("~agent.logsharvesting.unparsed")
+              .setHost(hostname).setValue(unparsed.count()).setTimestamp(System.currentTimeMillis()).build(), null);
+          pointHandler.reportPoint(ReportPoint.newBuilder().setMetric("~agent.logsharvesting.parsed")
+              .setHost(hostname).setValue(parsed.count()).setTimestamp(System.currentTimeMillis()).build(), null);
+          pointHandler.reportPoint(ReportPoint.newBuilder().setMetric("~agent.logsharvesting.batchesProcessed")
+              .setHost(hostname).setValue(batchesProcessed.count())
+              .setTimestamp(System.currentTimeMillis()).build(), null);
+        }
+      }, 1000, 1000);
+    }
+
+    // Set up user specified metric harvesting.
+    this.metricCache = Caffeine.<MetricName, Metric>newBuilder()
+        .softValues()
+        .expireAfterWrite(logsIngestionConfig.aggregationIntervalSeconds, TimeUnit.SECONDS)
+        .removalListener((key, value, cause) -> {
+          MetricName metricName = (MetricName) key;
+          Metric metric = (Metric) value;
+          if (cause == RemovalCause.COLLECTED) {
+            metricsRegistry.removeMetric(metricName);
+            evicted.inc();
+          } else if (metric != null) {
+            try {
+              metric.processWith(flushProcessor, metricName, new FlushProcessorContext(
+                  TimeSeriesUtils.fromMetricName(metricName), prefix, this.pointHandler));
+            } catch (Exception e) {
+              e.printStackTrace();
+            }
+          } else {
+            logger.severe("Null metric retrieved from cache: " + metricName.toString());
+          }
+        })
+        .build(new MetricCacheLoader(this.metricsRegistry));
+  }
+
+  /**
+   * Send currently aggregated points to the sink.
+   */
+  @VisibleForTesting
+  synchronized void flush() throws Exception {
+    for (MetricName metricName : metricCache.asMap().keySet()) {
+      Metric metric = metricCache.get(metricName);
+      metric.processWith(new FlushProcessor(), metricName,
+          new FlushProcessorContext(TimeSeriesUtils.fromMetricName(metricName), prefix, pointHandler));
+    }
+  }
+
+  @Override
+  public void onNewMessage(ChannelHandlerContext ctx, Message message) {
+    received.inc();
+    FilebeatMessage filebeatMessage;
+    boolean success = false;
+    try {
+      filebeatMessage = new FilebeatMessage(message);
+    } catch (MalformedMessageException exn) {
+      logger.severe("Malformed message received from filebeat, dropping.");
+      return;
+    }
+
+    Double[] output = {null};
+    for (MetricMatcher metricMatcher : logsIngestionConfig.counters) {
+      TimeSeries timeSeries = metricMatcher.timeSeries(filebeatMessage, output);
+      if (timeSeries == null) continue;
+      readMetric(Counter.class, timeSeries, output[0]);
+      success = true;
+    }
+    if (success) return;
+
+    for (MetricMatcher metricMatcher : logsIngestionConfig.gauges) {
+      TimeSeries timeSeries = metricMatcher.timeSeries(filebeatMessage, output);
+      if (timeSeries == null) continue;
+      readMetric(Gauge.class, timeSeries, output[0]);
+      success = true;
+    }
+    if (success) return;
+
+    unparsed.inc();
+  }
+
+  private void readMetric(Class clazz, TimeSeries timeSeries, Double value) {
+    MetricName metricName = TimeSeriesUtils.toMetricName(clazz, timeSeries);
+    Metric metric = metricCache.get(metricName);
+    try {
+      metric.processWith(readProcessor, metricName, new ReadProcessorContext(value));
+    } catch (Exception e) {
+      logger.severe("Could not process metric " + metricName.toString());
+      e.printStackTrace();
+    }
+    parsed.inc();
+  }
+
+  @Override
+  public void onNewConnection(ChannelHandlerContext ctx) {
+
+  }
+
+  @Override
+  public void onConnectionClose(ChannelHandlerContext ctx) {
+
+  }
+
+  @Override
+  public void onException(ChannelHandlerContext ctx, Throwable cause) {
+
+  }
+
+  @Override
+  public void onChannelInitializeException(ChannelHandlerContext ctx, Throwable cause) {
+
+  }
+}

--- a/proxy/src/main/java/com/wavefront/agent/logsharvesting/FilebeatMessage.java
+++ b/proxy/src/main/java/com/wavefront/agent/logsharvesting/FilebeatMessage.java
@@ -1,0 +1,37 @@
+package com.wavefront.agent.logsharvesting;
+
+import org.logstash.beats.Message;
+
+import java.util.Map;
+
+/**
+ * Abstraction for {@link org.logstash.beats.Message}
+ *
+ * @author Mori Bellamy (mori@wavefront.com)
+ */
+public class FilebeatMessage {
+  private final Message wrapped;
+  private final Map messageData;
+  private final Map beatData;
+  private final String logLine;
+
+  public FilebeatMessage(Message wrapped) throws MalformedMessageException {
+    this.wrapped = wrapped;
+    this.messageData = this.wrapped.getData();
+    if (!this.messageData.containsKey("beat")) throw new MalformedMessageException("No beat metadata.");
+    this.beatData = (Map) this.messageData.get("beat");
+    if (!this.messageData.containsKey("message")) throw new MalformedMessageException("No log line in message.");
+    this.logLine = (String) this.messageData.get("message");
+  }
+
+  public String getLogLine() {
+    return logLine;
+  }
+
+  public String hostOrDefault(String fallbackHost) {
+    if (this.beatData.containsKey("hostname")) {
+      return (String) this.beatData.get("hostname");
+    }
+    return fallbackHost;
+  }
+}

--- a/proxy/src/main/java/com/wavefront/agent/logsharvesting/FlushProcessor.java
+++ b/proxy/src/main/java/com/wavefront/agent/logsharvesting/FlushProcessor.java
@@ -1,0 +1,53 @@
+package com.wavefront.agent.logsharvesting;
+
+import com.yammer.metrics.core.Counter;
+import com.yammer.metrics.core.Gauge;
+import com.yammer.metrics.core.Histogram;
+import com.yammer.metrics.core.Metered;
+import com.yammer.metrics.core.MetricName;
+import com.yammer.metrics.core.MetricProcessor;
+import com.yammer.metrics.core.Timer;
+
+import sun.reflect.generics.reflectiveObjects.NotImplementedException;
+
+import sunnylabs.report.ReportPoint;
+
+/**
+ * @author Mori Bellamy (mori@wavefront.com)
+ */
+public class FlushProcessor implements MetricProcessor<FlushProcessorContext> {
+  @Override
+  public void processMeter(MetricName name, Metered meter, FlushProcessorContext context) throws Exception {
+    throw new NotImplementedException();
+  }
+
+  @Override
+  public void processCounter(MetricName name, Counter counter, FlushProcessorContext context) throws Exception {
+    context.getPointHandler().reportPoint(
+        context.reportPointBuilder()
+            .setValue(counter.count())
+            .setTimestamp(System.currentTimeMillis()).build(),
+        null);
+  }
+
+  @Override
+  public void processHistogram(MetricName name, Histogram histogram, FlushProcessorContext context) throws Exception {
+    throw new NotImplementedException();
+  }
+
+  @Override
+  public void processTimer(MetricName name, Timer timer, FlushProcessorContext context) throws Exception {
+    throw new NotImplementedException();
+  }
+
+  @Override
+  public void processGauge(MetricName name, Gauge<?> gauge, FlushProcessorContext context) throws Exception {
+    ChangeableGauge<Double> changeableGauge = (ChangeableGauge<Double>) gauge;
+    context.getPointHandler().reportPoint(
+        context.reportPointBuilder()
+            .setValue(changeableGauge.value())
+            .setTimestamp(System.currentTimeMillis()).build(),
+        null);
+
+  }
+}

--- a/proxy/src/main/java/com/wavefront/agent/logsharvesting/FlushProcessorContext.java
+++ b/proxy/src/main/java/com/wavefront/agent/logsharvesting/FlushProcessorContext.java
@@ -1,0 +1,37 @@
+package com.wavefront.agent.logsharvesting;
+
+import com.wavefront.agent.PointHandler;
+
+import sunnylabs.report.ReportPoint;
+import sunnylabs.report.TimeSeries;
+
+/**
+ * @author Mori Bellamy (mori@wavefront.com)
+ */
+public class FlushProcessorContext {
+  private TimeSeries timeSeries;
+  private PointHandler pointHandler;
+  private String prefix;
+
+  public FlushProcessorContext(TimeSeries timeSeries, String prefix, PointHandler pointHandler) {
+    this.timeSeries = TimeSeries.newBuilder(timeSeries).build();
+    this.pointHandler = pointHandler;
+    this.prefix = prefix;
+  }
+
+  public TimeSeries getTimeSeries() {
+    return timeSeries;
+  }
+
+  public PointHandler getPointHandler() {
+    return pointHandler;
+  }
+
+  public ReportPoint.Builder reportPointBuilder() {
+    return ReportPoint.newBuilder()
+        .setHost(timeSeries.getHost())
+        .setAnnotations(timeSeries.getAnnotations())
+        .setMetric(prefix == null ? timeSeries.getMetric() : prefix + "." + timeSeries.getMetric());
+  }
+
+}

--- a/proxy/src/main/java/com/wavefront/agent/logsharvesting/MalformedMessageException.java
+++ b/proxy/src/main/java/com/wavefront/agent/logsharvesting/MalformedMessageException.java
@@ -1,0 +1,10 @@
+package com.wavefront.agent.logsharvesting;
+
+/**
+ * @author Mori Bellamy (mori@wavefront.com)
+ */
+public class MalformedMessageException extends Exception {
+  MalformedMessageException(String msg) {
+    super(msg);
+  }
+}

--- a/proxy/src/main/java/com/wavefront/agent/logsharvesting/MetricCacheLoader.java
+++ b/proxy/src/main/java/com/wavefront/agent/logsharvesting/MetricCacheLoader.java
@@ -1,0 +1,33 @@
+package com.wavefront.agent.logsharvesting;
+
+
+import com.github.benmanes.caffeine.cache.CacheLoader;
+import com.yammer.metrics.core.Counter;
+import com.yammer.metrics.core.Gauge;
+import com.yammer.metrics.core.Histogram;
+import com.yammer.metrics.core.Metric;
+import com.yammer.metrics.core.MetricName;
+import com.yammer.metrics.core.MetricsRegistry;
+
+/**
+ * @author Mori Bellamy (mori@wavefront.com)
+ */
+public class MetricCacheLoader implements CacheLoader<MetricName, Metric> {
+  private MetricsRegistry metricsRegistry;
+
+  MetricCacheLoader(MetricsRegistry metricsRegistry) {
+    this.metricsRegistry = metricsRegistry;
+  }
+
+  @Override
+  public Metric load(MetricName key) throws Exception {
+    if (key.getType().equals(Counter.class.getTypeName())) {
+      return metricsRegistry.newCounter(key);
+    } else if (key.getType().equals(Histogram.class.getTypeName())) {
+      return metricsRegistry.newHistogram(key, false);
+    } else if (key.getType().equals(Gauge.class.getTypeName())) {
+      return metricsRegistry.newGauge(key, new ChangeableGauge<Double>());
+    }
+    throw new RuntimeException("Unsupported metric type: " + key.getType());
+  }
+}

--- a/proxy/src/main/java/com/wavefront/agent/logsharvesting/ReadProcessor.java
+++ b/proxy/src/main/java/com/wavefront/agent/logsharvesting/ReadProcessor.java
@@ -1,0 +1,45 @@
+package com.wavefront.agent.logsharvesting;
+
+import com.yammer.metrics.core.Counter;
+import com.yammer.metrics.core.Gauge;
+import com.yammer.metrics.core.Histogram;
+import com.yammer.metrics.core.Metered;
+import com.yammer.metrics.core.MetricName;
+import com.yammer.metrics.core.MetricProcessor;
+import com.yammer.metrics.core.Timer;
+
+import sun.reflect.generics.reflectiveObjects.NotImplementedException;
+
+/**
+ * @author Mori Bellamy (mori@wavefront.com)
+ */
+public class ReadProcessor implements MetricProcessor<ReadProcessorContext> {
+  @Override
+  public void processMeter(MetricName name, Metered meter, ReadProcessorContext context) throws Exception {
+    throw new NotImplementedException();
+  }
+
+  @Override
+  public void processCounter(MetricName name, Counter counter, ReadProcessorContext context) throws Exception {
+    counter.inc(context.getValue() == null ? 1L : Math.round(context.getValue()));
+  }
+
+  @Override
+  public void processHistogram(MetricName name, Histogram histogram, ReadProcessorContext context) throws Exception {
+    throw new NotImplementedException();
+  }
+
+  @Override
+  public void processTimer(MetricName name, Timer timer, ReadProcessorContext context) throws Exception {
+    throw new NotImplementedException();
+  }
+
+  @Override
+  @SuppressWarnings("unchecked")
+  public void processGauge(MetricName name, Gauge<?> gauge, ReadProcessorContext context) throws Exception {
+    if (context.getValue() == null) {
+      throw new MalformedMessageException("Need an explicit value for updating a gauge.");
+    }
+    ((ChangeableGauge<Double>) gauge).setValue(context.getValue());
+  }
+}

--- a/proxy/src/main/java/com/wavefront/agent/logsharvesting/ReadProcessorContext.java
+++ b/proxy/src/main/java/com/wavefront/agent/logsharvesting/ReadProcessorContext.java
@@ -1,0 +1,16 @@
+package com.wavefront.agent.logsharvesting;
+
+/**
+ * @author Mori Bellamy (mori@wavefront.com)
+ */
+public class ReadProcessorContext {
+  private Double value;
+
+  public ReadProcessorContext(Double value) {
+    this.value = value;
+  }
+
+  public Double getValue() {
+    return value;
+  }
+}

--- a/proxy/src/main/java/com/wavefront/agent/logsharvesting/TimeSeriesUtils.java
+++ b/proxy/src/main/java/com/wavefront/agent/logsharvesting/TimeSeriesUtils.java
@@ -1,0 +1,30 @@
+package com.wavefront.agent.logsharvesting;
+
+import com.yammer.metrics.core.MetricName;
+
+import org.apache.avro.io.DatumReader;
+import org.apache.avro.io.Decoder;
+import org.apache.avro.io.DecoderFactory;
+import org.apache.avro.specific.SpecificDatumReader;
+
+import java.io.IOException;
+
+import sunnylabs.report.TimeSeries;
+
+/**
+ * @author Mori Bellamy (mori@wavefront.com)
+ */
+public class TimeSeriesUtils {
+
+  private static DatumReader<TimeSeries> datumReader = new SpecificDatumReader<>(TimeSeries.class);
+
+  public static TimeSeries fromMetricName(MetricName metricName) throws IOException {
+    Decoder decoder = DecoderFactory.get().jsonDecoder(TimeSeries.SCHEMA$, metricName.getName());
+    return datumReader.read(null, decoder);
+  }
+
+  public static MetricName toMetricName(Class type, TimeSeries timeSeries) {
+    return new MetricName("group", type.getTypeName(), timeSeries.toString());
+  }
+
+}

--- a/proxy/src/main/java/org/logstash/beats/Ack.java
+++ b/proxy/src/main/java/org/logstash/beats/Ack.java
@@ -1,0 +1,18 @@
+package org.logstash.beats;
+
+public class Ack {
+    private final byte protocol;
+    private final int sequence;
+    public Ack(byte protocol, int sequence) {
+        this.protocol = protocol;
+        this.sequence = sequence;
+    }
+
+    public byte getProtocol() {
+        return protocol;
+    }
+
+    public int getSequence() {
+        return sequence;
+    }
+}

--- a/proxy/src/main/java/org/logstash/beats/AckEncoder.java
+++ b/proxy/src/main/java/org/logstash/beats/AckEncoder.java
@@ -1,0 +1,19 @@
+package org.logstash.beats;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.MessageToByteEncoder;
+
+/**
+ *  This Class is mostly used in the test suite to make the right assertions with the encoded data frame.
+ *  This class support creating v1 or v2 lumberjack frames.
+ *
+ */
+public class AckEncoder extends MessageToByteEncoder<Ack> {
+    @Override
+    protected void encode(ChannelHandlerContext ctx, Ack ack, ByteBuf out) throws Exception {
+        out.writeByte(ack.getProtocol());
+        out.writeByte('A');
+        out.writeInt(ack.getSequence());
+    }
+}

--- a/proxy/src/main/java/org/logstash/beats/Batch.java
+++ b/proxy/src/main/java/org/logstash/beats/Batch.java
@@ -1,0 +1,47 @@
+package org.logstash.beats;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class Batch {
+    private byte protocol = Protocol.VERSION_2;
+    private int batchSize;
+    private List<Message> messages = new ArrayList();
+
+    public List<Message> getMessages() {
+        return messages;
+    }
+
+    public void addMessage(Message message) {
+        message.setBatch(this);
+        messages.add(message);
+    }
+
+    public int size() {
+        return messages.size();
+    }
+
+    public void setBatchSize(int size) {
+        batchSize = size;
+    }
+
+    public int getBatchSize() {
+        return batchSize;
+    }
+
+    public boolean isEmpty() {
+        return 0 == messages.size();
+    }
+
+    public boolean complete() {
+        return size() == getBatchSize();
+    }
+
+    public byte getProtocol() {
+        return protocol;
+    }
+
+    public void setProtocol(byte protocol) {
+        this.protocol = protocol;
+    }
+}

--- a/proxy/src/main/java/org/logstash/beats/BeatsHandler.java
+++ b/proxy/src/main/java/org/logstash/beats/BeatsHandler.java
@@ -1,0 +1,98 @@
+package org.logstash.beats;
+
+import io.netty.channel.ChannelHandler;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.SimpleChannelInboundHandler;
+import io.netty.handler.timeout.IdleState;
+import io.netty.handler.timeout.IdleStateEvent;
+import org.apache.log4j.Logger;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+@ChannelHandler.Sharable
+public class BeatsHandler extends SimpleChannelInboundHandler<Batch> {
+    private final static Logger logger = Logger.getLogger(BeatsHandler.class);
+    private final AtomicBoolean processing = new AtomicBoolean(false);
+    private final IMessageListener messageListener;
+    private ChannelHandlerContext context;
+
+
+    public BeatsHandler(IMessageListener listener) {
+        messageListener = listener;
+    }
+
+    @Override
+    public void handlerAdded(ChannelHandlerContext ctx) throws Exception {
+        context = ctx;
+        messageListener.onNewConnection(ctx);
+    }
+
+    @Override
+    public void handlerRemoved(ChannelHandlerContext ctx) throws Exception {
+        messageListener.onConnectionClose(ctx);
+    }
+
+    @Override
+    public void channelRead0(ChannelHandlerContext ctx, Batch batch) throws Exception {
+        logger.debug("Received a new payload");
+
+        processing.compareAndSet(false, true);
+
+        for(Message message : batch.getMessages()) {
+            logger.debug("Sending a new message for the listener, sequence: " + message.getSequence());
+            messageListener.onNewMessage(ctx, message);
+
+            if(needAck(message)) {
+                ack(ctx, message);
+            }
+        }
+        ctx.flush();
+        processing.compareAndSet(true, false);
+
+    }
+
+    @Override
+    public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+        messageListener.onException(ctx, cause);
+        logger.error("Exception: " + cause.getMessage());
+        ctx.close();
+    }
+
+    @Override
+    public void userEventTriggered(ChannelHandlerContext ctx, Object event) {
+        if(event instanceof IdleStateEvent) {
+            IdleStateEvent e = (IdleStateEvent) event;
+
+            if(e.state() == IdleState.WRITER_IDLE) {
+                sendKeepAlive();
+            } else if(e.state() == IdleState.READER_IDLE) {
+                clientTimeout();
+            }
+        }
+    }
+
+    private boolean needAck(Message message) {
+        return message.getSequence() == message.getBatch().getBatchSize();
+    }
+
+    private void ack(ChannelHandlerContext ctx, Message message) {
+        writeAck(ctx, message.getBatch().getProtocol(), message.getSequence());
+    }
+
+    private void writeAck(ChannelHandlerContext ctx, byte protocol, int sequence) {
+        ctx.write(new Ack(protocol, sequence));
+    }
+
+    private void clientTimeout() {
+        logger.debug("Client Timeout");
+        this.context.close();
+    }
+
+    private void sendKeepAlive() {
+        // If we are actually blocked on processing
+        // we can send a keep alive.
+        if(processing.get()) {
+            writeAck(context, Protocol.VERSION_2, 0);
+        }
+    }
+}

--- a/proxy/src/main/java/org/logstash/beats/BeatsParser.java
+++ b/proxy/src/main/java/org/logstash/beats/BeatsParser.java
@@ -1,0 +1,248 @@
+package org.logstash.beats;
+
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.module.afterburner.AfterburnerModule;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufOutputStream;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.ByteToMessageDecoder;
+import org.apache.log4j.Logger;
+
+
+import java.nio.charset.Charset;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.zip.Inflater;
+import java.util.zip.InflaterOutputStream;
+
+
+public class BeatsParser extends ByteToMessageDecoder {
+    private static final int CHUNK_SIZE = 1024;
+    public final static ObjectMapper MAPPER = new ObjectMapper().registerModule(new AfterburnerModule());
+    private final static Logger logger = Logger.getLogger(BeatsParser.class);
+
+    private Batch batch = new Batch();
+
+    private enum States {
+        READ_HEADER(1),
+        READ_FRAME_TYPE(1),
+        READ_WINDOW_SIZE(4),
+        READ_JSON_HEADER(8),
+        READ_COMPRESSED_FRAME_HEADER(4),
+        READ_COMPRESSED_FRAME(-1), // -1 means the length to read is variable and defined in the frame itself.
+        READ_JSON(-1),
+        READ_DATA_FIELDS(-1);
+
+        private int length;
+
+        States(int length) {
+            this.length = length;
+        }
+
+    }
+
+    private States currentState = States.READ_HEADER;
+    private int requiredBytes = 0;
+    private int sequence = 0;
+
+    @Override
+    protected void decode(ChannelHandlerContext ctx, ByteBuf in, List<Object> out) throws Exception {
+        if(!hasEnoughBytes(in)) {
+            return;
+        }
+
+        switch (currentState) {
+            case READ_HEADER: {
+                logger.debug("Running: READ_HEADER");
+
+                byte currentVersion = in.readByte();
+
+                if(Protocol.isVersion2(currentVersion)) {
+                    logger.debug("Frame version 2 detected");
+                    batch.setProtocol(Protocol.VERSION_2);
+                } else {
+                    logger.debug("Frame version 1 detected");
+                    batch.setProtocol(Protocol.VERSION_1);
+                }
+
+                transition(States.READ_FRAME_TYPE);
+                break;
+            }
+            case READ_FRAME_TYPE: {
+                byte frameType = in.readByte();
+
+                switch(frameType) {
+                    case Protocol.CODE_WINDOW_SIZE: {
+                        transition(States.READ_WINDOW_SIZE);
+                        break;
+                    }
+                    case Protocol.CODE_JSON_FRAME: {
+                        // Reading Sequence + size of the payload
+                        transition(States.READ_JSON_HEADER);
+                        break;
+                    }
+                    case Protocol.CODE_COMPRESSED_FRAME: {
+                        transition(States.READ_COMPRESSED_FRAME_HEADER);
+                        break;
+                    }
+                    case Protocol.CODE_FRAME: {
+                        transition(States.READ_DATA_FIELDS);
+                        break;
+                    }
+                    default: {
+                        throw new InvalidFrameProtocolException("Invalid Frame Type, received: " + frameType);
+                    }
+                }
+                break;
+            }
+            case READ_WINDOW_SIZE: {
+                logger.debug("Running: READ_WINDOW_SIZE");
+
+                batch.setBatchSize((int) in.readUnsignedInt());
+
+                // This is unlikely to happen but I have no way to known when a frame is
+                // actually completely done other than checking the windows and the sequence number,
+                // If the FSM read a new window and I have still
+                // events buffered I should send the current batch down to the next handler.
+                if(!batch.isEmpty()) {
+                    logger.warn("New window size received but the current batch was not complete, sending the current batch");
+                    out.add(batch);
+                    batchComplete();
+                }
+
+                transition(States.READ_HEADER);
+                break;
+            }
+            case READ_DATA_FIELDS: {
+                // Lumberjack version 1 protocol, which use the Key:Value format.
+                logger.debug("Running: READ_DATA_FIELDS");
+                sequence = (int) in.readUnsignedInt();
+                int fieldsCount = (int) in.readUnsignedInt();
+                int count = 0;
+
+                if(fieldsCount <= 0) {
+                    throw new InvalidFrameProtocolException("Invalid number of fields, received: " + fieldsCount);
+                }
+
+                Map dataMap = new HashMap<String, String>(fieldsCount);
+
+                while(count < fieldsCount) {
+                    int fieldLength = (int) in.readUnsignedInt();
+                    ByteBuf fieldBuf = in.readBytes(fieldLength);
+                    String field = fieldBuf.toString(Charset.forName("UTF8"));
+                    fieldBuf.release();
+
+                    int dataLength = (int) in.readUnsignedInt();
+                    ByteBuf dataBuf = in.readBytes(dataLength);
+                    String data = dataBuf.toString(Charset.forName("UTF8"));
+                    dataBuf.release();
+
+                    dataMap.put(field, data);
+
+                    count++;
+                }
+
+                Message message = new Message(sequence, dataMap);
+                batch.addMessage(message);
+
+                if(batch.complete()) {
+                    out.add(batch);
+                    batchComplete();
+                }
+
+                transition(States.READ_HEADER);
+
+                break;
+            }
+            case READ_JSON_HEADER: {
+                logger.debug("Running: READ_JSON_HEADER");
+
+                sequence = (int) in.readUnsignedInt();
+                int jsonPayloadSize = (int) in.readUnsignedInt();
+
+                if(jsonPayloadSize <= 0) {
+                    throw new InvalidFrameProtocolException("Invalid json length, received: " + jsonPayloadSize);
+                }
+
+                transition(States.READ_JSON, jsonPayloadSize);
+                break;
+            }
+            case READ_COMPRESSED_FRAME_HEADER: {
+                logger.debug("Running: READ_COMPRESSED_FRAME_HEADER");
+
+                transition(States.READ_COMPRESSED_FRAME, in.readInt());
+                break;
+            }
+
+            case READ_COMPRESSED_FRAME: {
+                logger.debug("Running: READ_COMPRESSED_FRAME");
+                // Use the compressed size as the safe start for the buffer.
+                ByteBuf buffer = ctx.alloc().buffer(requiredBytes);
+                try (
+                        ByteBufOutputStream buffOutput = new ByteBufOutputStream(buffer);
+                        InflaterOutputStream inflater = new InflaterOutputStream(buffOutput, new Inflater());
+                ) {
+                    ByteBuf bytesRead = in.readBytes(inflater, requiredBytes);
+                    transition(States.READ_HEADER);
+                    try {
+                        while (buffer.readableBytes() > 0) {
+                            decode(ctx, buffer, out);
+                        }
+                    } finally {
+                        buffer.release();
+                    }
+                }
+
+                break;
+            }
+            case READ_JSON: {
+                logger.debug("Running: READ_JSON");
+
+                byte[] bytes = new byte[requiredBytes];
+                in.readBytes(bytes);
+                Message message = new Message(sequence, (Map) MAPPER.readValue(bytes, Object.class));
+
+                batch.addMessage(message);
+
+                if(batch.size() == batch.getBatchSize()) {
+                    logger.debug("Sending batch size: " + this.batch.size() + ", windowSize: " + batch.getBatchSize() +  " , seq: " + sequence);
+
+                    out.add(batch);
+                    batchComplete();
+                }
+
+                transition(States.READ_HEADER);
+                break;
+            }
+        }
+    }
+
+    private boolean hasEnoughBytes(ByteBuf in) {
+        return in.readableBytes() >= requiredBytes;
+    }
+
+    private void transition(States next) {
+        transition(next, next.length);
+    }
+
+    private void transition(States nextState, int requiredBytes) {
+        logger.debug("Transition, from: " + currentState + ", to: " +  nextState + ", requiring " + requiredBytes + " bytes");
+        this.currentState = nextState;
+        this.requiredBytes = requiredBytes;
+    }
+
+    private void batchComplete() {
+        requiredBytes = 0;
+        sequence = 0;
+        batch = new Batch();
+    }
+
+    public class InvalidFrameProtocolException extends Exception {
+        InvalidFrameProtocolException(String message) {
+            super(message);
+        }
+    }
+
+}

--- a/proxy/src/main/java/org/logstash/beats/IMessageListener.java
+++ b/proxy/src/main/java/org/logstash/beats/IMessageListener.java
@@ -1,0 +1,51 @@
+package org.logstash.beats;
+
+import io.netty.channel.ChannelHandlerContext;
+
+/**
+ * This class is implemented in ruby in `lib/logstash/inputs/beats/message_listener`,
+ * this class is used to link the events triggered from the different connection to the actual
+ * work inside the plugin.
+ */
+public interface IMessageListener {
+    /**
+     * This is triggered on every new message parsed by the beats handler
+     * and should be executed in the ruby world.
+     *
+     * @param ctx
+     * @param message
+     */
+    public void onNewMessage(ChannelHandlerContext ctx, Message message);
+
+    /**
+     * Triggered when a new client connect to the input, this is used to link a connection
+     * to a codec in the ruby world.
+     * @param ctx
+     */
+    public void onNewConnection(ChannelHandlerContext ctx);
+
+    /**
+     * Triggered when a connection is close on the remote end and we need to flush buffered
+     * events to the queue.
+     *
+     * @param ctx
+     */
+    public void onConnectionClose(ChannelHandlerContext ctx);
+
+    /**
+     * Called went something bad occur in the pipeline, allow to clear buffered codec went
+     * somethign goes wrong.
+     *
+     * @param ctx
+     * @param cause
+     */
+    public void onException(ChannelHandlerContext ctx, Throwable cause);
+
+    /**
+     * Called when a error occur in the channel initialize, usually ssl handshake error.
+     *
+     * @param ctx
+     * @param cause
+     */
+    public void onChannelInitializeException(ChannelHandlerContext ctx, Throwable cause);
+}

--- a/proxy/src/main/java/org/logstash/beats/Message.java
+++ b/proxy/src/main/java/org/logstash/beats/Message.java
@@ -1,0 +1,61 @@
+package org.logstash.beats;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class Message implements Comparable<Message> {
+    private final int sequence;
+    private String identityStream;
+    private final Map data;
+    private Batch batch;
+
+    public Message(int sequence, Map map) {
+        this.sequence = sequence;
+        this.data = map;
+
+        identityStream = extractIdentityStream();
+    }
+
+    public int getSequence() {
+        return sequence;
+    }
+
+
+    public Map getData() {
+        return data;
+    }
+
+    @Override
+    public int compareTo(Message o) {
+        return Integer.compare(getSequence(), o.getSequence());
+    }
+
+    public Batch getBatch() {
+        return batch;
+    }
+
+    public void setBatch(Batch newBatch) {
+        batch = newBatch;
+    }
+
+    public String getIdentityStream() {
+        return identityStream;
+    }
+
+    private String extractIdentityStream() {
+        Map beatsData = (HashMap<String, String>) this.getData().get("beat");
+
+        if(beatsData != null) {
+            String id = (String) beatsData.get("id");
+            String resourceId = (String) beatsData.get("resource_id");
+
+            if(id != null && resourceId != null) {
+                return id + "-" + resourceId;
+            } else {
+                return (String) beatsData.get("name") + "-" + (String) beatsData.get("source");
+            }
+        }
+
+        return null;
+    }
+}

--- a/proxy/src/main/java/org/logstash/beats/MessageListener.java
+++ b/proxy/src/main/java/org/logstash/beats/MessageListener.java
@@ -1,0 +1,67 @@
+package org.logstash.beats;
+
+import io.netty.channel.ChannelHandlerContext;
+import org.apache.log4j.Logger;
+
+
+/**
+ * This class is implemented in ruby in `lib/logstash/inputs/beats/message_listener`,
+ * this class is used to link the events triggered from the different connection to the actual
+ * work inside the plugin.
+ */
+// This need to be implemented in Ruby
+public class MessageListener implements IMessageListener {
+    private final static Logger logger = Logger.getLogger(MessageListener.class);
+
+
+    /**
+     * This is triggered on every new message parsed by the beats handler
+     * and should be executed in the ruby world.
+     *
+     * @param ctx
+     * @param message
+     */
+    public void onNewMessage(ChannelHandlerContext ctx, Message message) {
+        logger.debug("onNewMessage");
+    }
+
+    /**
+     * Triggered when a new client connect to the input, this is used to link a connection
+     * to a codec in the ruby world.
+     * @param ctx
+     */
+    public void onNewConnection(ChannelHandlerContext ctx) {
+        logger.debug("onNewConnection");
+    }
+
+    /**
+     * Triggered when a connection is close on the remote end and we need to flush buffered
+     * events to the queue.
+     *
+     * @param ctx
+     */
+    public void onConnectionClose(ChannelHandlerContext ctx) {
+        logger.debug("onConnectionClose");
+    }
+
+    /**
+     * Called went something bad occur in the pipeline, allow to clear buffered codec went
+     * somethign goes wrong.
+     *
+     * @param ctx
+     * @param cause
+     */
+    public void onException(ChannelHandlerContext ctx, Throwable cause) {
+        logger.debug("onException");
+    }
+
+    /**
+     * Called when a error occur in the channel initialize, usually ssl handshake error.
+     *
+     * @param ctx
+     * @param cause
+     */
+    public void onChannelInitializeException(ChannelHandlerContext ctx, Throwable cause) {
+        logger.debug("onException");
+    }
+}

--- a/proxy/src/main/java/org/logstash/beats/Protocol.java
+++ b/proxy/src/main/java/org/logstash/beats/Protocol.java
@@ -1,0 +1,22 @@
+package org.logstash.beats;
+
+/**
+ * Created by ph on 2016-05-16.
+ */
+public class Protocol {
+    public static final byte VERSION_1 = '1';
+    public static final byte VERSION_2 = '2';
+
+    public static final byte CODE_WINDOW_SIZE = 'W';
+    public static final byte CODE_JSON_FRAME = 'J';
+    public static final byte CODE_COMPRESSED_FRAME = 'C';
+    public static final byte CODE_FRAME = 'D';
+
+    public static boolean isVersion2(byte versionRead) {
+        if(Protocol.VERSION_2 == versionRead){
+            return true;
+        } else {
+            return false;
+        }
+    }
+}

--- a/proxy/src/main/java/org/logstash/beats/Runner.java
+++ b/proxy/src/main/java/org/logstash/beats/Runner.java
@@ -1,0 +1,41 @@
+package org.logstash.beats;
+
+import org.apache.log4j.Logger;
+import org.logstash.netty.SslSimpleBuilder;
+
+
+public class Runner {
+    private static final int DEFAULT_PORT = 5044;
+    private final static Logger logger = Logger.getLogger(Runner.class);
+
+
+
+    static public void main(String[] args) throws Exception {
+        logger.info("Starting Beats Bulk");
+
+        // Check for leaks.
+        // ResourceLeakDetector.setLevel(ResourceLeakDetector.Level.PARANOID);
+
+        Server server = new Server(DEFAULT_PORT);
+
+            if(args.length > 0 && args[0].equals("ssl")) {
+            logger.debug("Using SSL");
+
+            String sslCertificate = "/Users/ph/es/certificates/certificate.crt";
+            String sslKey = "/Users/ph/es/certificates/certificate.pkcs8.key";
+            String noPkcs7SslKey = "/Users/ph/es/certificates/certificate.key";
+            String[] certificateAuthorities = new String[] { "/Users/ph/es/certificates/certificate.crt" };
+
+
+
+            SslSimpleBuilder sslBuilder = new SslSimpleBuilder(sslCertificate, sslKey, null)
+                    .setProtocols(new String[] { "TLSv1.2" })
+                    .setCertificateAuthorities(certificateAuthorities)
+                    .setHandshakeTimeoutMilliseconds(10000);
+
+            server.enableSSL(sslBuilder);
+        }
+
+        server.listen();
+    }
+}

--- a/proxy/src/main/java/org/logstash/beats/Server.java
+++ b/proxy/src/main/java/org/logstash/beats/Server.java
@@ -1,0 +1,159 @@
+package org.logstash.beats;
+
+import io.netty.bootstrap.ServerBootstrap;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInitializer;
+import io.netty.channel.ChannelPipeline;
+import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.channel.socket.SocketChannel;
+import io.netty.channel.socket.nio.NioServerSocketChannel;
+import io.netty.handler.logging.LoggingHandler;
+import io.netty.handler.ssl.SslHandler;
+import io.netty.handler.timeout.IdleStateHandler;
+import io.netty.util.concurrent.DefaultEventExecutorGroup;
+import io.netty.util.concurrent.EventExecutorGroup;
+import io.netty.util.concurrent.Future;
+import org.apache.log4j.Logger;
+import org.logstash.netty.SslSimpleBuilder;
+
+import java.io.IOException;
+import java.security.NoSuchAlgorithmException;
+import java.security.cert.CertificateException;
+import java.util.concurrent.TimeUnit;
+
+
+
+public class Server {
+    private final static Logger logger = Logger.getLogger(Server.class);
+
+    static final long SHUTDOWN_TIMEOUT_SECONDS = 10;
+    private static final int DEFAULT_CLIENT_TIMEOUT_SECONDS = 15;
+
+
+    private final int port;
+    private final NioEventLoopGroup bossGroup;
+    private final NioEventLoopGroup workGroup;
+    private IMessageListener messageListener = new MessageListener();
+    private SslSimpleBuilder sslBuilder;
+
+    private final int clientInactivityTimeoutSeconds;
+
+    public Server(int p) {
+        this(p, DEFAULT_CLIENT_TIMEOUT_SECONDS);
+    }
+
+    public Server(int p, int timeout) {
+        port = p;
+        clientInactivityTimeoutSeconds = timeout;
+        bossGroup = new NioEventLoopGroup(10);
+        //bossGroup.setIoRatio(10);
+        workGroup = new NioEventLoopGroup(50);
+        //workGroup.setIoRatio(10);
+    }
+
+    public void enableSSL(SslSimpleBuilder builder) {
+        sslBuilder = builder;
+    }
+
+    public Server listen() throws InterruptedException {
+        BeatsInitializer beatsInitializer = null;
+
+        try {
+            logger.info("Starting server on port: " +  this.port);
+
+            beatsInitializer = new BeatsInitializer(isSslEnable(), messageListener, clientInactivityTimeoutSeconds);
+
+            ServerBootstrap server = new ServerBootstrap();
+            server.group(bossGroup, workGroup)
+                    .channel(NioServerSocketChannel.class)
+                    .childHandler(beatsInitializer);
+
+            Channel channel = server.bind(port).sync().channel();
+            channel.closeFuture().sync();
+        } finally {
+            beatsInitializer.shutdownEventExecutor();
+
+            bossGroup.shutdownGracefully(0, SHUTDOWN_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+            workGroup.shutdownGracefully(0, SHUTDOWN_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+        }
+
+        return this;
+    }
+
+    public void stop() throws InterruptedException {
+        logger.debug("Server shutting down");
+
+        Future<?> bossWait = bossGroup.shutdownGracefully(0, SHUTDOWN_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+        Future<?> workWait = workGroup.shutdownGracefully(0, SHUTDOWN_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+        
+        logger.debug("Server stopped");
+    }
+
+    public void setMessageListener(IMessageListener listener) {
+        messageListener = listener;
+    }
+
+    public boolean isSslEnable() {
+        return this.sslBuilder != null;
+    }
+
+    private class BeatsInitializer extends ChannelInitializer<SocketChannel> {
+        private final String LOGGER_HANDLER = "logger";
+        private final String SSL_HANDLER = "ssl-handler";
+        private final String KEEP_ALIVE_HANDLER = "keep-alive-handler";
+        private final String BEATS_PARSER = "beats-parser";
+        private final String BEATS_HANDLER = "beats-handler";
+        private final String BEATS_ACKER = "beats-acker";
+
+        private final int DEFAULT_IDLESTATEHANDLER_THREAD = 4;
+        private final int IDLESTATE_WRITER_IDLE_TIME_SECONDS = 5;
+        private final int IDLESTATE_ALL_IDLE_TIME_SECONDS = 0;
+
+        private final EventExecutorGroup idleExecutorGroup;
+        private final BeatsHandler beatsHandler;
+        private final IMessageListener message;
+        private int clientInactivityTimeoutSeconds;
+        private final LoggingHandler loggingHandler = new LoggingHandler();
+
+
+        private boolean enableSSL = false;
+
+        public BeatsInitializer(Boolean secure, IMessageListener messageListener, int clientInactivityTimeoutSeconds) {
+            enableSSL = secure;
+            this.message = messageListener;
+            beatsHandler = new BeatsHandler(this.message);
+            this.clientInactivityTimeoutSeconds = clientInactivityTimeoutSeconds;
+            idleExecutorGroup = new DefaultEventExecutorGroup(DEFAULT_IDLESTATEHANDLER_THREAD);
+        }
+
+        public void initChannel(SocketChannel socket) throws IOException, NoSuchAlgorithmException, CertificateException {
+            ChannelPipeline pipeline = socket.pipeline();
+
+            pipeline.addLast(LOGGER_HANDLER, loggingHandler);
+
+            if(enableSSL) {
+                SslHandler sslHandler = sslBuilder.build(socket.alloc());
+                pipeline.addLast(SSL_HANDLER, sslHandler);
+            }
+
+            // We have set a specific executor for the idle check, because the `beatsHandler` can be
+            // blocked on the queue, this the idleStateHandler manage the `KeepAlive` signal.
+            pipeline.addLast(idleExecutorGroup, KEEP_ALIVE_HANDLER, new IdleStateHandler(clientInactivityTimeoutSeconds, IDLESTATE_WRITER_IDLE_TIME_SECONDS , IDLESTATE_ALL_IDLE_TIME_SECONDS));
+
+            pipeline.addLast(BEATS_PARSER, new BeatsParser());
+            pipeline.addLast(BEATS_ACKER, new AckEncoder());
+            pipeline.addLast(BEATS_HANDLER, beatsHandler);
+
+        }
+
+        @Override
+        public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
+            this.message.onChannelInitializeException(ctx, cause);
+        }
+
+        public void shutdownEventExecutor() {
+            idleExecutorGroup.shutdownGracefully(0, SHUTDOWN_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+        }
+    }
+}

--- a/proxy/src/main/java/org/logstash/netty/SslSimpleBuilder.java
+++ b/proxy/src/main/java/org/logstash/netty/SslSimpleBuilder.java
@@ -1,0 +1,174 @@
+package org.logstash.netty;
+
+import io.netty.buffer.ByteBufAllocator;
+import io.netty.handler.ssl.SslContext;
+import io.netty.handler.ssl.SslContextBuilder;
+import io.netty.handler.ssl.SslHandler;
+import org.apache.log4j.Logger;
+import org.logstash.beats.Server;
+
+import javax.net.ssl.SSLEngine;
+import java.io.*;
+import java.security.NoSuchAlgorithmException;
+import java.security.cert.CertificateException;
+import java.security.cert.CertificateFactory;
+import java.security.cert.X509Certificate;
+import java.util.Arrays;
+
+/**
+ * Created by ph on 2016-05-27.
+ */
+public class SslSimpleBuilder {
+
+
+    public static enum SslClientVerifyMode {
+        VERIFY_PEER,
+        FORCE_PEER,
+    }
+    private final static Logger logger = Logger.getLogger(SslSimpleBuilder.class);
+
+
+    private File sslKeyFile;
+    private File sslCertificateFile;
+    private SslClientVerifyMode verifyMode = SslClientVerifyMode.FORCE_PEER;
+
+    private long handshakeTimeoutMilliseconds = 10000;
+
+    /*
+    Mordern Ciphers List from
+    https://wiki.mozilla.org/Security/Server_Side_TLS
+    This list require the OpenSSl engine for netty.
+    */
+    public final static String[] DEFAULT_CIPHERS = new String[] {
+            "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA38",
+            "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
+            "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
+            "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+            "TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384",
+            "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384",
+            "TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256"
+    };
+
+    private String[] ciphers = DEFAULT_CIPHERS;
+    private String[] protocols = new String[] { "TLSv1.2" };
+    private String[] certificateAuthorities;
+    private String passPhrase;
+
+    public SslSimpleBuilder(String sslCertificateFilePath, String sslKeyFilePath, String pass) throws FileNotFoundException {
+        sslCertificateFile = new File(sslCertificateFilePath);
+        sslKeyFile = new File(sslKeyFilePath);
+        passPhrase = pass;
+        ciphers = DEFAULT_CIPHERS;
+    }
+
+    public SslSimpleBuilder setProtocols(String[] protocols) {
+        protocols = protocols;
+        return this;
+    }
+
+    public SslSimpleBuilder setCipherSuites(String[] ciphersSuite) {
+        ciphers = ciphersSuite;
+        return this;
+    }
+
+    public SslSimpleBuilder setCertificateAuthorities(String[] cert) {
+        certificateAuthorities = cert;
+        return this;
+    }
+
+    public SslSimpleBuilder setHandshakeTimeoutMilliseconds(int timeout) {
+        handshakeTimeoutMilliseconds = timeout;
+        return this;
+    }
+
+    public SslSimpleBuilder setVerifyMode(SslClientVerifyMode mode) {
+        verifyMode = mode;
+        return this;
+    }
+
+    public File getSslKeyFile() {
+        return sslKeyFile;
+    }
+
+    public File getSslCertificateFile() {
+        return sslCertificateFile;
+    }
+
+    public SslHandler build(ByteBufAllocator bufferAllocator) throws IOException, NoSuchAlgorithmException, CertificateException {
+        SslContextBuilder builder = SslContextBuilder.forServer(sslCertificateFile, sslKeyFile, passPhrase);
+
+        if(logger.isDebugEnabled())
+            logger.debug("Ciphers:  " + ciphers.toString());
+
+        builder.ciphers(Arrays.asList(ciphers));
+
+        if(requireClientAuth()) {
+            if (logger.isDebugEnabled())
+                logger.debug("Certificate Authorities: " + certificateAuthorities.toString());
+
+            builder.trustManager(loadCertificateCollection(certificateAuthorities));
+        }
+
+        SslContext context = builder.build();
+        SslHandler sslHandler = context.newHandler(bufferAllocator);
+
+        if(logger.isDebugEnabled())
+            logger.debug("TLS: " + protocols.toString());
+
+        SSLEngine engine = sslHandler.engine();
+        engine.setEnabledProtocols(protocols);
+
+
+        if(requireClientAuth()) {
+            // server is doing the handshake
+            engine.setUseClientMode(false);
+
+            if(verifyMode == SslClientVerifyMode.FORCE_PEER) {
+                // Explicitely require a client certificate
+                engine.setNeedClientAuth(true);
+            } else if(verifyMode == SslClientVerifyMode.VERIFY_PEER) {
+                // If the client supply a client certificate we will verify it.
+                engine.setWantClientAuth(true);
+            }
+        }
+
+        sslHandler.setHandshakeTimeoutMillis(handshakeTimeoutMilliseconds);
+
+        return sslHandler;
+    }
+
+    private X509Certificate[] loadCertificateCollection(String[] certificates) throws IOException, CertificateException {
+        CertificateFactory certificateFactory = CertificateFactory.getInstance("X.509");
+
+        X509Certificate[] collections = new X509Certificate[certificates.length];
+
+        for(int i = 0; i < certificates.length; i++) {
+            String certificate = certificates[i];
+
+            InputStream in = null;
+
+            try {
+                in = new FileInputStream(certificate);
+                collections[i] = (X509Certificate) certificateFactory.generateCertificate(in);
+            } finally {
+                if(in != null) {
+                    in.close();
+                }
+            }
+        }
+
+        return collections;
+    }
+
+    private boolean requireClientAuth() {
+        if(certificateAuthorities != null) {
+            return true;
+        }
+
+        return false;
+    }
+
+    private FileInputStream createFileInputStream(String filepath) throws FileNotFoundException {
+        return new FileInputStream(filepath);
+    }
+}

--- a/proxy/src/main/resources/patterns/patterns
+++ b/proxy/src/main/resources/patterns/patterns
@@ -1,0 +1,108 @@
+# Forked from https://github.com/elasticsearch/logstash/tree/v1.4.0/patterns
+
+USERNAME [a-zA-Z0-9._-]+
+USER %{USERNAME:UNWANTED}
+INT (?:[+-]?(?:[0-9]+))
+BASE10NUM (?<![0-9.+-])(?>[+-]?(?:(?:[0-9]+(?:\.[0-9]+)?)|(?:\.[0-9]+)))
+NUMBER (?:%{BASE10NUM:UNWANTED})
+BASE16NUM (?<![0-9A-Fa-f])(?:[+-]?(?:0x)?(?:[0-9A-Fa-f]+))
+BASE16FLOAT \b(?<![0-9A-Fa-f.])(?:[+-]?(?:0x)?(?:(?:[0-9A-Fa-f]+(?:\.[0-9A-Fa-f]*)?)|(?:\.[0-9A-Fa-f]+)))\b
+
+POSINT \b(?:[1-9][0-9]*)\b
+NONNEGINT \b(?:[0-9]+)\b
+WORD \b\w+\b
+NOTSPACE \S+
+SPACE \s*
+DATA .*?
+GREEDYDATA .*
+#QUOTEDSTRING (?:(?<!\\)(?:"(?:\\.|[^\\"])*"|(?:'(?:\\.|[^\\'])*')|(?:`(?:\\.|[^\\`])*`)))
+QUOTEDSTRING (?>(?<!\\)(?>"(?>\\.|[^\\"]+)+"|""|(?>'(?>\\.|[^\\']+)+')|''|(?>`(?>\\.|[^\\`]+)+`)|``))
+UUID [A-Fa-f0-9]{8}-(?:[A-Fa-f0-9]{4}-){3}[A-Fa-f0-9]{12}
+
+# Networking
+MAC (?:%{CISCOMAC:UNWANTED}|%{WINDOWSMAC:UNWANTED}|%{COMMONMAC:UNWANTED})
+CISCOMAC (?:(?:[A-Fa-f0-9]{4}\.){2}[A-Fa-f0-9]{4})
+WINDOWSMAC (?:(?:[A-Fa-f0-9]{2}-){5}[A-Fa-f0-9]{2})
+COMMONMAC (?:(?:[A-Fa-f0-9]{2}:){5}[A-Fa-f0-9]{2})
+IPV6 ((([0-9A-Fa-f]{1,4}:){7}([0-9A-Fa-f]{1,4}|:))|(([0-9A-Fa-f]{1,4}:){6}(:[0-9A-Fa-f]{1,4}|((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3})|:))|(([0-9A-Fa-f]{1,4}:){5}(((:[0-9A-Fa-f]{1,4}){1,2})|:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3})|:))|(([0-9A-Fa-f]{1,4}:){4}(((:[0-9A-Fa-f]{1,4}){1,3})|((:[0-9A-Fa-f]{1,4})?:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:))|(([0-9A-Fa-f]{1,4}:){3}(((:[0-9A-Fa-f]{1,4}){1,4})|((:[0-9A-Fa-f]{1,4}){0,2}:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:))|(([0-9A-Fa-f]{1,4}:){2}(((:[0-9A-Fa-f]{1,4}){1,5})|((:[0-9A-Fa-f]{1,4}){0,3}:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:))|(([0-9A-Fa-f]{1,4}:){1}(((:[0-9A-Fa-f]{1,4}){1,6})|((:[0-9A-Fa-f]{1,4}){0,4}:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:))|(:(((:[0-9A-Fa-f]{1,4}){1,7})|((:[0-9A-Fa-f]{1,4}){0,5}:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:)))(%.+)?
+IPV4 (?<![0-9])(?:(?:25[0-5]|2[0-4][0-9]|[0-1]?[0-9]{1,2})[.](?:25[0-5]|2[0-4][0-9]|[0-1]?[0-9]{1,2})[.](?:25[0-5]|2[0-4][0-9]|[0-1]?[0-9]{1,2})[.](?:25[0-5]|2[0-4][0-9]|[0-1]?[0-9]{1,2}))(?![0-9])
+IP (?:%{IPV6:UNWANTED}|%{IPV4:UNWANTED})
+HOSTNAME \b(?:[0-9A-Za-z][0-9A-Za-z-]{0,62})(?:\.(?:[0-9A-Za-z][0-9A-Za-z-]{0,62}))*(\.?|\b)
+HOST %{HOSTNAME:UNWANTED}
+IPORHOST (?:%{HOSTNAME:UNWANTED}|%{IP:UNWANTED})
+HOSTPORT (?:%{IPORHOST}:%{POSINT:PORT})
+
+# paths
+PATH (?:%{UNIXPATH}|%{WINPATH})
+UNIXPATH (?>/(?>[\w_%!$@:.,~-]+|\\.)*)+
+#UNIXPATH (?<![\w\/])(?:/[^\/\s?*]*)+
+TTY (?:/dev/(pts|tty([pq])?)(\w+)?/?(?:[0-9]+))
+WINPATH (?>[A-Za-z]+:|\\)(?:\\[^\\?*]*)+
+URIPROTO [A-Za-z]+(\+[A-Za-z+]+)?
+URIHOST %{IPORHOST}(?::%{POSINT:port})?
+# uripath comes loosely from RFC1738, but mostly from what Firefox
+# doesn't turn into %XX
+URIPATH (?:/[A-Za-z0-9$.+!*'(){},~:;=@#%_\-]*)+
+#URIPARAM \?(?:[A-Za-z0-9]+(?:=(?:[^&]*))?(?:&(?:[A-Za-z0-9]+(?:=(?:[^&]*))?)?)*)?
+URIPARAM \?[A-Za-z0-9$.+!*'|(){},~@#%&/=:;_?\-\[\]]*
+URIPATHPARAM %{URIPATH}(?:%{URIPARAM})?
+URI %{URIPROTO}://(?:%{USER}(?::[^@]*)?@)?(?:%{URIHOST})?(?:%{URIPATHPARAM})?
+
+# Months: January, Feb, 3, 03, 12, December
+MONTH \b(?:Jan(?:uary)?|Feb(?:ruary)?|Mar(?:ch)?|Apr(?:il)?|May|Jun(?:e)?|Jul(?:y)?|Aug(?:ust)?|Sep(?:tember)?|Oct(?:ober)?|Nov(?:ember)?|Dec(?:ember)?)\b
+MONTHNUM (?:0?[1-9]|1[0-2])
+MONTHNUM2 (?:0[1-9]|1[0-2])
+MONTHDAY (?:(?:0[1-9])|(?:[12][0-9])|(?:3[01])|[1-9])
+
+# Days: Monday, Tue, Thu, etc...
+DAY (?:Mon(?:day)?|Tue(?:sday)?|Wed(?:nesday)?|Thu(?:rsday)?|Fri(?:day)?|Sat(?:urday)?|Sun(?:day)?)
+
+# Years?
+YEAR (?>\d\d){1,2}
+# Time: HH:MM:SS
+#TIME \d{2}:\d{2}(?::\d{2}(?:\.\d+)?)?
+# I'm still on the fence about using grok to perform the time match,
+# since it's probably slower.
+# TIME %{POSINT<24}:%{POSINT<60}(?::%{POSINT<60}(?:\.%{POSINT})?)?
+HOUR (?:2[0123]|[01]?[0-9])
+MINUTE (?:[0-5][0-9])
+# '60' is a leap second in most time standards and thus is valid.
+SECOND (?:(?:[0-5]?[0-9]|60)(?:[:.,][0-9]+)?)
+TIME (?!<[0-9])%{HOUR}:%{MINUTE}(?::%{SECOND})(?![0-9])
+# datestamp is YYYY/MM/DD-HH:MM:SS.UUUU (or something like it)
+DATE_US %{MONTHNUM}[/-]%{MONTHDAY}[/-]%{YEAR}
+DATE_EU %{MONTHDAY}[./-]%{MONTHNUM}[./-]%{YEAR}
+ISO8601_TIMEZONE (?:Z|[+-]%{HOUR}(?::?%{MINUTE}))
+ISO8601_SECOND (?:%{SECOND}|60)
+TIMESTAMP_ISO8601 %{YEAR}-%{MONTHNUM}-%{MONTHDAY}[T ]%{HOUR}:?%{MINUTE}(?::?%{SECOND})?%{ISO8601_TIMEZONE}?
+DATE %{DATE_US}|%{DATE_EU}
+DATESTAMP %{DATE}[- ]%{TIME}
+TZ (?:[PMCE][SD]T|UTC)
+DATESTAMP_RFC822 %{DAY} %{MONTH} %{MONTHDAY} %{YEAR} %{TIME} %{TZ}
+DATESTAMP_RFC2822 %{DAY}, %{MONTHDAY} %{MONTH} %{YEAR} %{TIME} %{ISO8601_TIMEZONE}
+DATESTAMP_OTHER %{DAY} %{MONTH} %{MONTHDAY} %{TIME} %{TZ} %{YEAR}
+DATESTAMP_EVENTLOG %{YEAR}%{MONTHNUM2}%{MONTHDAY}%{HOUR}%{MINUTE}%{SECOND}
+
+# Syslog Dates: Month Day HH:MM:SS
+SYSLOGTIMESTAMP %{MONTH} +%{MONTHDAY} %{TIME}
+PROG (?:[\w._/%-]+)
+SYSLOGPROG %{PROG:program}(?:\[%{POSINT:pid}\])?
+SYSLOGHOST %{IPORHOST}
+SYSLOGFACILITY <%{NONNEGINT:facility}.%{NONNEGINT:priority}>
+HTTPDATE %{MONTHDAY}/%{MONTH}/%{YEAR}:%{TIME} %{INT}
+
+# Shortcuts
+QS %{QUOTEDSTRING:UNWANTED}
+
+# Log formats
+SYSLOGBASE %{SYSLOGTIMESTAMP:timestamp} (?:%{SYSLOGFACILITY} )?%{SYSLOGHOST:logsource} %{SYSLOGPROG}:
+
+MESSAGESLOG %{SYSLOGBASE} %{DATA}
+
+COMMONAPACHELOG %{IPORHOST:clientip} %{USER:ident} %{USER:auth} \[%{HTTPDATE:timestamp}\] "(?:%{WORD:verb} %{NOTSPACE:request}(?: HTTP/%{NUMBER:httpversion})?|%{DATA:rawrequest})" %{NUMBER:response} (?:%{NUMBER:bytes}|-)
+COMBINEDAPACHELOG %{COMMONAPACHELOG} %{QS:referrer} %{QS:agent}
+COMMONAPACHELOG_DATATYPED %{IPORHOST:clientip} %{USER:ident;boolean} %{USER:auth} \[%{HTTPDATE:timestamp;date;dd/MMM/yyyy:HH:mm:ss Z}\] "(?:%{WORD:verb;string} %{NOTSPACE:request}(?: HTTP/%{NUMBER:httpversion;float})?|%{DATA:rawrequest})" %{NUMBER:response;int} (?:%{NUMBER:bytes;long}|-)
+
+
+# Log Levels
+LOGLEVEL ([A|a]lert|ALERT|[T|t]race|TRACE|[D|d]ebug|DEBUG|[N|n]otice|NOTICE|[I|i]nfo|INFO|[W|w]arn?(?:ing)?|WARN?(?:ING)?|[E|e]rr?(?:or)?|ERR?(?:OR)?|[C|c]rit?(?:ical)?|CRIT?(?:ICAL)?|[F|f]atal|FATAL|[S|s]evere|SEVERE|EMERG(?:ENCY)?|[Ee]merg(?:ency)?)

--- a/proxy/src/test/java/com/wavefront/agent/PointMatchers.java
+++ b/proxy/src/test/java/com/wavefront/agent/PointMatchers.java
@@ -1,0 +1,58 @@
+package com.wavefront.agent;
+
+import org.hamcrest.BaseMatcher;
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+
+import java.util.Map;
+
+import sunnylabs.report.ReportPoint;
+
+/**
+ * @author Mori Bellamy (mori@wavefront.com)
+ */
+public class PointMatchers {
+
+  private static String mapToString(Map<String, String> map) {
+    StringBuilder sb = new StringBuilder();
+    for (Map.Entry<String, String> entry : map.entrySet()) {
+      sb.append(entry.getKey()).append("=").append(entry.getValue()).append(", ");
+    }
+    int len = sb.toString().length();
+    sb.replace(len - 2, len, "");
+    return sb.toString();
+  }
+
+  private static <T, S> boolean isSubMap(Map<T, S> m1, Map<T, S> m2) {
+    for (Map.Entry<T, S> m1entry : m1.entrySet()) {
+      if (!m2.keySet().contains(m1entry.getKey())) return false;
+      if (!m2.get(m1entry.getKey()).equals(m1entry.getValue())) return false;
+    }
+    return true;
+  }
+
+  private static <T, S> boolean mapsEqual(Map<T, S> m1, Map<T, S> m2) {
+    return isSubMap(m1, m2) && isSubMap(m2, m1);
+  }
+
+  public static Matcher<ReportPoint> matches(Object value, String metricName, Map<String, String> tags) {
+    return new BaseMatcher<ReportPoint>() {
+
+      @Override
+      public boolean matches(Object o) {
+        ReportPoint me = (ReportPoint) o;
+        return me.getValue().equals(value) && me.getMetric().equals(metricName)
+            && mapsEqual(me.getAnnotations(), tags);
+      }
+
+      @Override
+      public void describeTo(Description description) {
+        description.appendText(
+            "Value should equal " + value.toString() + " and have metric name " + metricName + " and tags "
+                + mapToString(tags));
+
+      }
+    };
+  }
+
+}

--- a/proxy/src/test/java/com/wavefront/agent/logsharvesting/FilebeatListenerTest.java
+++ b/proxy/src/test/java/com/wavefront/agent/logsharvesting/FilebeatListenerTest.java
@@ -1,0 +1,140 @@
+package com.wavefront.agent.logsharvesting;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Maps;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import com.wavefront.agent.PointHandler;
+import com.wavefront.agent.PointMatchers;
+import com.wavefront.agent.config.ConfigurationException;
+import com.wavefront.agent.config.LogsIngestionConfig;
+
+import org.easymock.Capture;
+import org.easymock.CaptureType;
+import org.easymock.EasyMock;
+import org.junit.Test;
+import org.logstash.beats.Message;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+import oi.thekraken.grok.api.exception.GrokException;
+import sunnylabs.report.ReportPoint;
+
+import static org.easymock.EasyMock.createMock;
+import static org.easymock.EasyMock.expectLastCall;
+import static org.easymock.EasyMock.replay;
+import static org.easymock.EasyMock.reset;
+import static org.easymock.EasyMock.verify;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+
+/**
+ * @author Mori Bellamy (mori@wavefront.com)
+ */
+public class FilebeatListenerTest {
+  private LogsIngestionConfig logsIngestionConfig;
+  private FilebeatListener filebeatListenerUnderTest;
+  private PointHandler mockPointHandler;
+
+  private void setup(String configPath) throws IOException, GrokException, ConfigurationException {
+    File configFile = new File(FilebeatListenerTest.class.getClassLoader().getResource(configPath).getPath());
+    ObjectMapper objectMapper = new ObjectMapper(new YAMLFactory());
+    logsIngestionConfig = objectMapper.readValue(configFile, LogsIngestionConfig.class);
+    logsIngestionConfig.aggregationIntervalSeconds = 5;
+    logsIngestionConfig.verify();
+    mockPointHandler = createMock(PointHandler.class);
+    filebeatListenerUnderTest = new FilebeatListener(
+        mockPointHandler, logsIngestionConfig, "myhostname", null, false);
+  }
+
+  private void recieveLog(String log) {
+    Map<String, Object> data = Maps.newHashMap();
+    data.put("message", log);
+    data.put("beat", Maps.newHashMap());
+    filebeatListenerUnderTest.onNewMessage(null, new Message(0, data));
+  }
+
+  private List<ReportPoint> getPoints(int numPoints, String... logLines) throws Exception {
+    Capture<ReportPoint> reportPointCapture = Capture.newInstance(CaptureType.ALL);
+    reset(mockPointHandler);
+    mockPointHandler.reportPoint(EasyMock.capture(reportPointCapture), EasyMock.isNull(String.class));
+    expectLastCall().times(numPoints);
+    replay(mockPointHandler);
+    for (String line : logLines) recieveLog(line);
+    filebeatListenerUnderTest.flush();
+    verify(mockPointHandler);
+    return reportPointCapture.getValues();
+  }
+
+  @Test
+  public void testPrefixIsApplied() throws Exception {
+    setup("test.yml");
+    filebeatListenerUnderTest = new FilebeatListener(
+        mockPointHandler, logsIngestionConfig, "myhostname", "myPrefix", false);
+    assertThat(
+        getPoints(1, "plainCounter"),
+        contains(PointMatchers.matches(1L, "myPrefix.plainCounter", ImmutableMap.of())));
+  }
+
+  @Test(expected = ConfigurationException.class)
+  public void testGaugeWithoutValue() throws Exception {
+    setup("badGauge.yml");
+  }
+
+  @Test(expected = ConfigurationException.class)
+  public void testTagsNonParallelArrays() throws Exception {
+    setup("badTags.yml");
+  }
+
+  @Test
+  public void testMetricsAggregation() throws Exception {
+    setup("test.yml");
+    assertThat(
+        getPoints(6,
+            "plainCounter", "noMatch 42.123 bar", "plainCounter",
+            "gauges 42",
+            "counterWithValue 2", "counterWithValue 3",
+            "dynamicCounter foo 1 done", "dynamicCounter foo 2 done", "dynamicCounter baz 1 done"),
+        containsInAnyOrder(
+            ImmutableList.of(
+                PointMatchers.matches(2L, "plainCounter", ImmutableMap.of()),
+                PointMatchers.matches(5L, "counterWithValue", ImmutableMap.of()),
+                PointMatchers.matches(1L, "dynamic_foo_1", ImmutableMap.of()),
+                PointMatchers.matches(1L, "dynamic_foo_2", ImmutableMap.of()),
+                PointMatchers.matches(1L, "dynamic_baz_1", ImmutableMap.of()),
+                PointMatchers.matches(42.0, "myGauge", ImmutableMap.of())))
+    );
+  }
+
+  @Test
+  public void testDynamicLabels() throws Exception {
+    setup("test.yml");
+    assertThat(
+        getPoints(3,
+            "operation foo took 2 seconds in DC=wavefront AZ=2a",
+            "operation foo took 2 seconds in DC=wavefront AZ=2a",
+            "operation foo took 3 seconds in DC=wavefront AZ=2b",
+            "operation bar took 4 seconds in DC=wavefront AZ=2a"),
+        containsInAnyOrder(
+            ImmutableList.of(
+                PointMatchers.matches(4L, "foo.totalSeconds", ImmutableMap.of("theDC", "wavefront", "theAZ", "2a")),
+                PointMatchers.matches(3L, "foo.totalSeconds", ImmutableMap.of("theDC", "wavefront", "theAZ", "2b")),
+                PointMatchers.matches(4L, "bar.totalSeconds", ImmutableMap.of("theDC", "wavefront", "theAZ", "2a"))
+            )
+        ));
+  }
+
+  @Test
+  public void testAdditionalPatterns() throws Exception {
+    setup("test.yml");
+    assertThat(
+        getPoints(1, "foo and 42"),
+        contains(PointMatchers.matches(42L, "customPatternCounter", ImmutableMap.of())));
+  }
+}

--- a/proxy/src/test/java/com/wavefront/agent/logsharvesting/FilebeatListenerTest.java
+++ b/proxy/src/test/java/com/wavefront/agent/logsharvesting/FilebeatListenerTest.java
@@ -50,7 +50,7 @@ public class FilebeatListenerTest {
     logsIngestionConfig.verify();
     mockPointHandler = createMock(PointHandler.class);
     filebeatListenerUnderTest = new FilebeatListener(
-        mockPointHandler, logsIngestionConfig, "myhostname", null, false);
+        mockPointHandler, logsIngestionConfig, "myhostname", null);
   }
 
   private void recieveLog(String log) {
@@ -76,7 +76,7 @@ public class FilebeatListenerTest {
   public void testPrefixIsApplied() throws Exception {
     setup("test.yml");
     filebeatListenerUnderTest = new FilebeatListener(
-        mockPointHandler, logsIngestionConfig, "myhostname", "myPrefix", false);
+        mockPointHandler, logsIngestionConfig, "myhostname", "myPrefix");
     assertThat(
         getPoints(1, "plainCounter"),
         contains(PointMatchers.matches(1L, "myPrefix.plainCounter", ImmutableMap.of())));

--- a/proxy/src/test/resources/badGauge.yml
+++ b/proxy/src/test/resources/badGauge.yml
@@ -1,0 +1,3 @@
+gauges:
+  - pattern: "badgauge"
+    metricName: "gaugeWithoutValueWillThrowAnError"

--- a/proxy/src/test/resources/badTags.yml
+++ b/proxy/src/test/resources/badTags.yml
@@ -1,0 +1,9 @@
+counters:
+  - pattern: "operation %{WORD:op} took %{NUMBER:value} seconds in DC=%{WORD:dc}.*AZ=%{WORD:az}"
+    metricName: "%{op}.totalSeconds"
+    tagKeys:
+      - "theDC"
+      - "theAZ"
+    tagValueLabels:
+      - "dc"
+      # Missing entry!

--- a/proxy/src/test/resources/test.yml
+++ b/proxy/src/test/resources/test.yml
@@ -1,0 +1,25 @@
+counters:
+  - pattern: "counterWithValue %{NUMBER:value}%{GREEDYDATA:extra}"
+    metricName: "counterWithValue"
+  - pattern: "plainCounter"
+    metricName: "plainCounter"
+  - pattern: "dynamicCounter %{WORD:name} %{NUMBER:type} done"
+    metricName: "dynamic_%{name}_%{type}"
+  - pattern: "%{MYPATTERN}"
+    metricName: "customPatternCounter"
+  - pattern: "operation %{WORD:op} took %{NUMBER:value} seconds in DC=%{WORD:dc}.*AZ=%{WORD:az}"
+    metricName: "%{op}.totalSeconds"
+    tagKeys:
+      - "theDC"
+      - "theAZ"
+    tagValueLabels:
+      - "dc"
+      - "az"
+
+gauges:
+  - pattern: "gauges %{NUMBER:value}"
+    metricName: "myGauge"
+
+
+additionalPatterns:
+  - "MYPATTERN %{WORD:myword} and %{NUMBER:value}"


### PR DESCRIPTION
Initial version has support for counters and Gauges.

To use this new feature:

* in your config file (wavefront.conf), specify `logsIngestionConfigFile=logsIngestion.yaml`
* logsIngestion.yaml has a configuration object, namely LogsIngestionConfig. for example, you could use the following config to send a counter to wavefront:

```
 - pattern: "operation %{WORD:op} took %{NUMBER:value} seconds in DC=%{WORD:dc}.*AZ=%{WORD:az}"
    metricName: "%{op}.totalSeconds"
    tagKeys:
      - "theDC"
      - "theAZ"
    tagValueLabels:
      - "dc"
      - "az"
```

so, if you had a log line that was "operation foo took 2 seconds in DC=wavefront AZ=2a”, we would notice a match in your config, and construct the point  `foo.totalSeconds 2 theDC=wavefront theAZ=2a`