### PR TITLE
Fix RPM upgrade to 3.26+ on el6/el7

### DIFF
--- a/pkg/README.md
+++ b/pkg/README.md
@@ -31,5 +31,5 @@ Build and run the docker container for building.
 This will build the agent from head and package it into a deb or an rpm. The after-install.sh script will download and install Zulu 8.13.0.5 0f21d10ca4f1 JRE by default, so to bundle the package with a JRE of your choice instead, run the following commands inside the docker container right before build.sh:
 
     sed -ri 's,^curl(.*),#curl\1,g' /opt/wavefront-java-repo/pkg/after-install.sh
-    cp -r /opt/jre /opt/wavefront-java-repo/pkg/build/opt/wavefront/wavefront-proxy/jre
+    cp -r /opt/jre /opt/wavefront-java-repo/pkg/build/opt/wavefront/wavefront-proxy/proxy-jre
 

--- a/pkg/after-install.sh
+++ b/pkg/after-install.sh
@@ -6,7 +6,7 @@ service_name="wavefront-proxy"
 spool_dir="/var/spool/wavefront-proxy"
 wavefront_dir="/opt/wavefront"
 conf_dir="/etc/wavefront"
-jre_dir="$wavefront_dir/$service_name/jre"
+jre_dir="$wavefront_dir/$service_name/proxy-jre"
 
 # Set up wavefront user.
 if ! groupmod $group &> /dev/null; then

--- a/pkg/before-remove.sh
+++ b/pkg/before-remove.sh
@@ -8,8 +8,12 @@ service wavefront-proxy stop || true
 
 # rpm passes "0", "1" or "2" as a command line argument - due to the order in which scripts are executed by rpm
 # (post-install for new version first and only then before-remove for the old version), we can only safely delete
-# the JRE that we downloaded if the argument is "0", meaning that it's an uninstall.
-if [[ "$1" == "0" ]]; then
+# the JRE that we downloaded if the argument is "0", meaning that it's an uninstall
+#
+# Ref:
+#  - http://www.rpm.org/max-rpm/s1-rpm-inside-scripts.html
+#  - https://www.debian.org/doc/debian-policy/ch-maintainerscripts.html
+if [[ "$1" == "0" ]] || [[ "$1" == "remove" ]] || [[ "$1" == "purge" ]]; then
     echo "Removing installed JRE from $jre_dir"
     rm -rf $jre_dir
 fi

--- a/pkg/before-remove.sh
+++ b/pkg/before-remove.sh
@@ -2,12 +2,14 @@
 
 service_name="wavefront-proxy"
 wavefront_dir="/opt/wavefront"
-jre_dir="$wavefront_dir/$service_name/jre"
+jre_dir="$wavefront_dir/$service_name/proxy-jre"
 
 service wavefront-proxy stop || true
 
-# If it's called with "0" argument (rpm) or "remove"/"purge" (deb), remove JRE as well. Otherwise keep it.
-if [[ "$1" == "0" ]] || [[ "$1" == "remove" ]] || [[ "$1" == "purge" ]]; then
+# rpm passes "0", "1" or "2" as a command line argument - due to the order in which scripts are executed by rpm
+# (post-install for new version first and only then before-remove for the old version), we can only safely delete
+# the JRE that we downloaded if the argument is "0", meaning that it's an uninstall.
+if [[ "$1" == "0" ]]; then
     echo "Removing installed JRE from $jre_dir"
     rm -rf $jre_dir
 fi

--- a/pkg/before-remove.sh
+++ b/pkg/before-remove.sh
@@ -6,6 +6,10 @@ jre_dir="$wavefront_dir/$service_name/jre"
 
 service wavefront-proxy stop || true
 
-rm -rf $jre_dir
+# If it's called with "0" argument (rpm) or "remove"/"purge" (deb), remove JRE as well. Otherwise keep it.
+if [[ "$1" == "0" ]] || [[ "$1" == "remove" ]] || [[ "$1" == "purge" ]]; then
+    echo "Removing installed JRE from $jre_dir"
+    rm -rf $jre_dir
+fi
 
 exit 0

--- a/pkg/etc/init.d/wavefront-proxy
+++ b/pkg/etc/init.d/wavefront-proxy
@@ -26,7 +26,7 @@ user="wavefront"
 wavefront_dir="/opt/wavefront"
 proxy_dir=${PROXY_DIR:-$wavefront_dir/wavefront-proxy}
 config_dir=${CONFIG_DIR:-/etc/wavefront/wavefront-proxy}
-export JAVA_HOME="$proxy_dir/jre"
+export JAVA_HOME="$proxy_dir/proxy-jre"
 conf_file=$CONF_FILE
 if [[ -z $conf_file ]]; then
     legacy_config_dir=$proxy_dir/conf


### PR DESCRIPTION
rpm has a package upgrade sequence that is different from dpkg - it installs the new version first, executing the after-install script, and only then it uninstalls a previous version. When proxy is upgraded from an older version to 3.26, where we no longer bundle the JRE, after-install script is executed first, it downloads and unpacks the JRE into the same location, and then rpm deletes all the JRE files as they are still considered part of the old version. 
In this PR: 
- Change the JRE directory name so rpm doesn't confuse it with the one bundled with a previous version
- For future upgrades: only delete the JRE if it's truly an uninstall, and not an upgrade. 