### PR TITLE
Limit rate at the proxy

### DIFF
--- a/java-lib/src/main/java/com/wavefront/ingester/StringLineIngester.java
+++ b/java-lib/src/main/java/com/wavefront/ingester/StringLineIngester.java
@@ -84,4 +84,12 @@ public class StringLineIngester extends TcpIngester {
     index.add(pushData.length());
     return index;
   }
+
+  public static int pushDataSize(String pushData) {
+    int length = StringUtils.countMatches(pushData, PUSH_DATA_DELIMETER);
+    return length > 0
+        ? length + 1
+        : (pushData.length() > 0 ? 1 : 0);
+
+  }
 }

--- a/java-lib/src/main/java/com/wavefront/ingester/StringLineIngester.java
+++ b/java-lib/src/main/java/com/wavefront/ingester/StringLineIngester.java
@@ -85,6 +85,11 @@ public class StringLineIngester extends TcpIngester {
     return index;
   }
 
+  /**
+   * Calculates the number of points in the pushData payload
+   * @param pushData a delimited string with the points payload
+   * @return number of points
+   */
   public static int pushDataSize(String pushData) {
     int length = StringUtils.countMatches(pushData, PUSH_DATA_DELIMETER);
     return length > 0

--- a/pkg/etc/wavefront/wavefront-proxy/wavefront.conf.default
+++ b/pkg/etc/wavefront/wavefront-proxy/wavefront.conf.default
@@ -64,6 +64,14 @@ pushFlushMaxPoints=40000
 # Milliseconds between flushes to the Wavefront servers. Typically 1000.
 pushFlushInterval=1000
 
+## Limit rate at the proxy (averaged over 1 minute). Default: do not throttle
+#pushRateLimit=20000
+
+## Max number of points that can stay in memory buffers before spooling to disk. Defaults to 16 * pushFlushMaxPoints,
+## minimum allowed size: pushFlushMaxPoints. Setting this value lower than default reduces memory usage but will force
+# the proxy to spool to disk more frequently if you have points arriving at the proxy in short bursts.
+#pushMemoryBufferLimit=6400000
+
 # If there are blocked points, how many lines to print to the log every 10 flushes. Typically 5.
 pushBlockedSamples=5
 
@@ -134,6 +142,10 @@ buffer=/var/spool/wavefront-proxy/buffer
 #
 ## The following setting enables SO_LINGER with the specified linger time in seconds (SO_LINGER disabled by default)
 #soLingerTime=0
+## HTTP connect timeout (in milliseconds). Default: 5s (5000)
+#httpConnectTimeout=5000
+## HTTP request timeout (in milliseconds). Default: 20s (20000)
+#httpRequestTimeout=20000
 
 ## Path to the optional config file with preprocessor rules (advanced regEx replacements and whitelist/blacklists)
 #preprocessorConfigFile=/etc/wavefront/wavefront-proxy/preprocessor_rules.yaml

--- a/pkg/etc/wavefront/wavefront-proxy/wavefront.conf.default
+++ b/pkg/etc/wavefront/wavefront-proxy/wavefront.conf.default
@@ -70,7 +70,7 @@ pushFlushInterval=1000
 ## Max number of points that can stay in memory buffers before spooling to disk. Defaults to 16 * pushFlushMaxPoints,
 ## minimum allowed size: pushFlushMaxPoints. Setting this value lower than default reduces memory usage but will force
 # the proxy to spool to disk more frequently if you have points arriving at the proxy in short bursts.
-#pushMemoryBufferLimit=6400000
+#pushMemoryBufferLimit=640000
 
 # If there are blocked points, how many lines to print to the log every 10 flushes. Typically 5.
 pushBlockedSamples=5

--- a/proxy/src/main/java/com/google/common/util/concurrent/RecyclableRateLimiter.java
+++ b/proxy/src/main/java/com/google/common/util/concurrent/RecyclableRateLimiter.java
@@ -59,6 +59,11 @@ public class RecyclableRateLimiter extends RateLimiter {
     this.setRate(permitsPerSecond);
   }
 
+  /**
+   * Get the number of accumulated permits
+   *
+   * @return number of accumulated permits
+   */
   public double getAvailablePermits() {
     synchronized (mutex) {
       resync(stopwatch.readMicros());
@@ -66,6 +71,11 @@ public class RecyclableRateLimiter extends RateLimiter {
     }
   }
 
+  /**
+   * Return the specified number of permits back to the pool
+   *
+   * @param permits number of permits to return
+   */
   public void recyclePermits(int permits) {
     synchronized (mutex) {
       long nowMicros = stopwatch.readMicros();
@@ -81,6 +91,7 @@ public class RecyclableRateLimiter extends RateLimiter {
     }
   }
 
+  @Override
   final void doSetRate(double permitsPerSecond, long nowMicros) {
     synchronized (mutex) {
       resync(nowMicros);

--- a/proxy/src/main/java/com/google/common/util/concurrent/RecyclableRateLimiter.java
+++ b/proxy/src/main/java/com/google/common/util/concurrent/RecyclableRateLimiter.java
@@ -1,0 +1,136 @@
+package com.google.common.util.concurrent;
+
+import com.google.common.math.LongMath;
+
+import static java.lang.Math.max;
+import static java.lang.Math.min;
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+/**
+ * An alternative RateLimiter implementation that allows to "return" unused permits back to the pool to handle retries
+ * gracefully and allow precise control over outgoing rate, plus allows accumulating "credits" for unused permits over
+ * a time window other than 1 second.
+ *
+ * Created by: vasily@wavefront.com, with portions from Guava library source code
+ */
+public class RecyclableRateLimiter extends RateLimiter {
+  /**
+   * The currently stored permits.
+   */
+  private double storedPermits;
+
+  /**
+   * The maximum number of stored permits.
+   */
+  private double maxPermits;
+
+  /**
+   * The interval between two unit requests, at our stable rate. E.g., a stable rate of 5 permits
+   * per second has a stable interval of 200ms.
+   */
+  private double stableIntervalMicros;
+
+  /**
+   * The time when the next request (no matter its size) will be granted. After granting a
+   * request, this is pushed further in the future. Large requests push this further than small
+   * requests.
+   */
+  private long nextFreeTicketMicros = 0L; // could be either in the past or future
+
+  /** The work (permits) of how many seconds can be saved up if this RateLimiter is unused? */
+  private final double maxBurstSeconds;
+
+  private final SleepingStopwatch stopwatch;
+
+  private final Object mutex;
+
+  public static RecyclableRateLimiter create(double permitsPerSecond, double maxBurstSeconds) {
+    return new RecyclableRateLimiter(
+        SleepingStopwatch.createFromSystemTimer(),
+        permitsPerSecond,
+        maxBurstSeconds);
+  }
+
+  private RecyclableRateLimiter(SleepingStopwatch stopwatch, double permitsPerSecond, double maxBurstSeconds) {
+    super(stopwatch);
+    this.mutex = new Object();
+    this.stopwatch = stopwatch;
+    this.maxBurstSeconds = maxBurstSeconds;
+    this.setRate(permitsPerSecond);
+  }
+
+  public double getAvailablePermits() {
+    resync(stopwatch.readMicros());
+    return storedPermits;
+  }
+
+  public void recyclePermits(int permits) {
+    synchronized (mutex) {
+      long nowMicros = stopwatch.readMicros();
+      resync(nowMicros);
+      long surplusPermits = permits - (long) ((nextFreeTicketMicros - nowMicros) / stableIntervalMicros);
+      long waitMicros = -min((long) (surplusPermits * stableIntervalMicros), 0L);
+      try {
+        this.nextFreeTicketMicros = LongMath.checkedAdd(nowMicros, waitMicros);
+      } catch (ArithmeticException e) {
+        this.nextFreeTicketMicros = Long.MAX_VALUE;
+      }
+      storedPermits = min(maxPermits, storedPermits + max(surplusPermits, 0L));
+    }
+  }
+
+  final void doSetRate(double permitsPerSecond, long nowMicros) {
+    synchronized (mutex) {
+      resync(nowMicros);
+      this.stableIntervalMicros = SECONDS.toMicros(1L) / permitsPerSecond;
+      double oldMaxPermits = this.maxPermits;
+      maxPermits = maxBurstSeconds * permitsPerSecond;
+      storedPermits = (oldMaxPermits == Double.POSITIVE_INFINITY)
+          ? maxPermits
+          : (oldMaxPermits == 0.0)
+          ? 0.0 // initial state
+          : storedPermits * maxPermits / oldMaxPermits;
+    }
+  }
+
+  @Override
+  final double doGetRate() {
+    return SECONDS.toMicros(1L) / stableIntervalMicros;
+  }
+
+  @Override
+  final long queryEarliestAvailable(long nowMicros) {
+    synchronized (mutex) {
+      return nextFreeTicketMicros;
+    }
+  }
+
+  @Override
+  final long reserveEarliestAvailable(int requiredPermits, long nowMicros) {
+    synchronized (mutex) {
+      resync(nowMicros);
+      long returnValue = nextFreeTicketMicros;
+      double storedPermitsToSpend = min(requiredPermits, this.storedPermits);
+      double freshPermits = requiredPermits - storedPermitsToSpend;
+      long waitMicros = (long) (freshPermits * stableIntervalMicros);
+
+      try {
+        this.nextFreeTicketMicros = LongMath.checkedAdd(nextFreeTicketMicros, waitMicros);
+      } catch (ArithmeticException e) {
+        this.nextFreeTicketMicros = Long.MAX_VALUE;
+      }
+      this.storedPermits -= storedPermitsToSpend;
+      return returnValue;
+    }
+  }
+
+  private void resync(long nowMicros) {
+    // if nextFreeTicket is in the past, resync to now
+    if (nowMicros > nextFreeTicketMicros) {
+      storedPermits = min(maxPermits,
+          storedPermits
+              + (nowMicros - nextFreeTicketMicros) / stableIntervalMicros);
+      nextFreeTicketMicros = nowMicros;
+    }
+  }
+}

--- a/proxy/src/main/java/com/google/common/util/concurrent/RecyclableRateLimiter.java
+++ b/proxy/src/main/java/com/google/common/util/concurrent/RecyclableRateLimiter.java
@@ -60,8 +60,10 @@ public class RecyclableRateLimiter extends RateLimiter {
   }
 
   public double getAvailablePermits() {
-    resync(stopwatch.readMicros());
-    return storedPermits;
+    synchronized (mutex) {
+      resync(stopwatch.readMicros());
+      return storedPermits;
+    }
   }
 
   public void recyclePermits(int permits) {

--- a/proxy/src/main/java/com/wavefront/agent/PostPushDataTimedTask.java
+++ b/proxy/src/main/java/com/wavefront/agent/PostPushDataTimedTask.java
@@ -21,7 +21,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import javax.annotation.Nullable;
 import javax.ws.rs.core.Response;
 
 /**

--- a/proxy/src/main/java/com/wavefront/agent/PostPushDataTimedTask.java
+++ b/proxy/src/main/java/com/wavefront/agent/PostPushDataTimedTask.java
@@ -226,6 +226,9 @@ public class PostPushDataTimedTask implements Runnable {
     }
   }
 
+  /**
+   * Shut down the scheduler for this task (prevent future scheduled runs)
+   */
   public void shutdown() {
     scheduler.shutdown();
   }

--- a/proxy/src/main/java/com/wavefront/agent/ResubmissionTask.java
+++ b/proxy/src/main/java/com/wavefront/agent/ResubmissionTask.java
@@ -23,5 +23,7 @@ public abstract class ResubmissionTask<T extends ResubmissionTask<T>> implements
    */
   protected UUID currentAgentId = null;
 
+  public abstract int size();
+
   public abstract List<T> splitTask();
 }


### PR DESCRIPTION
Limit outgoing rate at the proxy (averaged over 1 minute), with a single limit controlling both data flows (incoming points and retry queue). Incoming points are always given a priority, and retry queue is considered ok to start processing if there is more than 1 second worth of accumulated unused "credits" (which means that the rate for incoming points is less than the limit).
