### PR TITLE
Improve preprocessor rules

### DIFF
--- a/proxy/pom.xml
+++ b/proxy/pom.xml
@@ -87,16 +87,6 @@
       <version>3.1</version>
     </dependency>
     <dependency>
-      <groupId>com.squareup</groupId>
-      <artifactId>tape</artifactId>
-      <version>1.2.3</version>
-    </dependency>
-    <dependency>
-      <groupId>com.github.ben-manes.caffeine</groupId>
-      <artifactId>caffeine</artifactId>
-      <version>2.3.2</version>
-    </dependency>
-    <dependency>
       <groupId>net.openhft</groupId>
       <artifactId>chronicle-map</artifactId>
       <version>3.10.1</version>

--- a/proxy/src/main/java/com/wavefront/agent/PushAgent.java
+++ b/proxy/src/main/java/com/wavefront/agent/PushAgent.java
@@ -255,72 +255,61 @@ public class PushAgent extends AbstractAgent {
       graphiteFormatter = new GraphiteFormatter(graphiteFormat, graphiteDelimiters, graphiteFieldsToRemove);
       Iterable<String> ports = Splitter.on(",").omitEmptyStrings().trimResults().split(graphitePorts);
       for (String strPort : ports) {
-        if (strPort.trim().length() > 0) {
-          preprocessors.forPort(strPort).forPointLine().addTransformer(0, graphiteFormatter);
-          startGraphiteListener(strPort, true);
-          logger.info("listening on port: " + strPort + " for graphite metrics");
-        }
+        preprocessors.forPort(strPort).forPointLine().addTransformer(0, graphiteFormatter);
+        startGraphiteListener(strPort, true);
+        logger.info("listening on port: " + strPort + " for graphite metrics");
       }
     }
     if (opentsdbPorts != null) {
       Iterable<String> ports = Splitter.on(",").omitEmptyStrings().trimResults().split(opentsdbPorts);
       for (String strPort : ports) {
-        if (strPort.trim().length() > 0) {
-          startOpenTsdbListener(strPort);
-          logger.info("listening on port: " + strPort + " for OpenTSDB metrics");
-        }
+        startOpenTsdbListener(strPort);
+        logger.info("listening on port: " + strPort + " for OpenTSDB metrics");
       }
     }
     if (picklePorts != null) {
       Iterable<String> ports = Splitter.on(",").omitEmptyStrings().trimResults().split(picklePorts);
       for (String strPort : ports) {
-        if (strPort.trim().length() > 0) {
-          startPickleListener(strPort, graphiteFormatter);
-          logger.info("listening on port: " + strPort + " for pickle protocol metrics");
-        }
+        startPickleListener(strPort, graphiteFormatter);
+        logger.info("listening on port: " + strPort + " for pickle protocol metrics");
       }
     }
     if (httpJsonPorts != null) {
       Iterable<String> ports = Splitter.on(",").omitEmptyStrings().trimResults().split(httpJsonPorts);
       for (String strPort : ports) {
-        strPort = strPort.trim();
-        if (strPort.length() > 0) {
-          preprocessors.forPort(strPort).forReportPoint()
-              .addFilter(new ReportPointTimestampInRangeFilter(dataBackfillCutoffHours));
-          try {
-            // will immediately start the server.
-            JettyHttpContainerFactory.createServer(
-                new URI("http://localhost:" + strPort + "/"),
-                new ResourceConfig(JacksonFeature.class).
-                    register(new JsonMetricsEndpoint(strPort, hostname, prefix,
-                        pushValidationLevel, pushBlockedSamples, getFlushTasks(strPort), preprocessors.forPort(strPort))), true);
-            logger.info("listening on port: " + strPort + " for HTTP JSON metrics");
-          } catch (URISyntaxException e) {
-            throw new RuntimeException("Unable to bind to: " + strPort + " for HTTP JSON metrics", e);
-          }
+        preprocessors.forPort(strPort).forReportPoint()
+            .addFilter(new ReportPointTimestampInRangeFilter(dataBackfillCutoffHours));
+        try {
+          // will immediately start the server.
+          JettyHttpContainerFactory.createServer(
+              new URI("http://localhost:" + strPort + "/"),
+              new ResourceConfig(JacksonFeature.class).
+                  register(new JsonMetricsEndpoint(strPort, hostname, prefix,
+                      pushValidationLevel, pushBlockedSamples, getFlushTasks(strPort), preprocessors.forPort(strPort))),
+              true);
+          logger.info("listening on port: " + strPort + " for HTTP JSON metrics");
+        } catch (URISyntaxException e) {
+          throw new RuntimeException("Unable to bind to: " + strPort + " for HTTP JSON metrics", e);
         }
       }
     }
     if (writeHttpJsonPorts != null) {
       Iterable<String> ports = Splitter.on(",").omitEmptyStrings().trimResults().split(writeHttpJsonPorts);
       for (String strPort : ports) {
-        strPort = strPort.trim();
-        if (strPort.length() > 0) {
-          preprocessors.forPort(strPort).forReportPoint()
-              .addFilter(new ReportPointTimestampInRangeFilter(dataBackfillCutoffHours));
+        preprocessors.forPort(strPort).forReportPoint()
+            .addFilter(new ReportPointTimestampInRangeFilter(dataBackfillCutoffHours));
 
-          try {
-            // will immediately start the server.
-            JettyHttpContainerFactory.createServer(
-                new URI("http://localhost:" + strPort + "/"),
-                new ResourceConfig(JacksonFeature.class).
-                    register(new WriteHttpJsonMetricsEndpoint(strPort, hostname, prefix,
-                        pushValidationLevel, pushBlockedSamples, getFlushTasks(strPort), preprocessors.forPort(strPort))),
-                true);
-            logger.info("listening on port: " + strPort + " for Write HTTP JSON metrics");
-          } catch (URISyntaxException e) {
-            throw new RuntimeException("Unable to bind to: " + strPort + " for Write HTTP JSON metrics", e);
-          }
+        try {
+          // will immediately start the server.
+          JettyHttpContainerFactory.createServer(
+              new URI("http://localhost:" + strPort + "/"),
+              new ResourceConfig(JacksonFeature.class).
+                  register(new WriteHttpJsonMetricsEndpoint(strPort, hostname, prefix,
+                      pushValidationLevel, pushBlockedSamples, getFlushTasks(strPort), preprocessors.forPort(strPort))),
+              true);
+          logger.info("listening on port: " + strPort + " for Write HTTP JSON metrics");
+        } catch (URISyntaxException e) {
+          throw new RuntimeException("Unable to bind to: " + strPort + " for Write HTTP JSON metrics", e);
         }
       }
     }

--- a/proxy/src/main/java/com/wavefront/agent/preprocessor/AgentPreprocessorConfiguration.java
+++ b/proxy/src/main/java/com/wavefront/agent/preprocessor/AgentPreprocessorConfiguration.java
@@ -80,9 +80,10 @@ public class AgentPreprocessorConfiguration {
             if (rule.get("scope") != null && rule.get("scope").equals("pointLine")) {
               switch (rule.get("action")) {
                 case "replaceRegex":
-                  allowArguments(rule, "rule", "action", "scope", "search", "replace");
+                  allowArguments(rule, "rule", "action", "scope", "search", "replace", "match");
                   this.forPort(strPort).forPointLine().addTransformer(
-                      new PointLineReplaceRegexTransformer(rule.get("search"), rule.get("replace"), counter));
+                      new PointLineReplaceRegexTransformer(
+                          rule.get("search"), rule.get("replace"), rule.get("match"), counter));
                   break;
                 case "blacklistRegex":
                   allowArguments(rule, "rule", "action", "scope", "match");
@@ -101,10 +102,10 @@ public class AgentPreprocessorConfiguration {
             } else {
               switch (rule.get("action")) {
                 case "replaceRegex":
-                  allowArguments(rule, "rule", "action", "scope", "search", "replace");
+                  allowArguments(rule, "rule", "action", "scope", "search", "replace", "match");
                   this.forPort(strPort).forReportPoint().addTransformer(
                       new ReportPointReplaceRegexTransformer(
-                          rule.get("scope"), rule.get("search"), rule.get("replace"), counter));
+                          rule.get("scope"), rule.get("search"), rule.get("replace"), rule.get("match"), counter));
                   break;
                 case "addTag":
                   allowArguments(rule, "rule", "action", "tag", "value");

--- a/proxy/src/main/java/com/wavefront/agent/preprocessor/PointLineReplaceRegexTransformer.java
+++ b/proxy/src/main/java/com/wavefront/agent/preprocessor/PointLineReplaceRegexTransformer.java
@@ -18,15 +18,19 @@ import javax.annotation.Nullable;
 public class PointLineReplaceRegexTransformer implements Function<String, String> {
 
   private final String patternReplace;
-  private final Pattern compiledPattern;
+  private final Pattern compiledSearchPattern;
+  @Nullable
+  private final Pattern compiledMatchPattern;
   @Nullable
   private final Counter ruleAppliedCounter;
 
-  public PointLineReplaceRegexTransformer(final String patternMatch,
+  public PointLineReplaceRegexTransformer(final String patternSearch,
                                           final String patternReplace,
+                                          @Nullable final String patternMatch,
                                           @Nullable final Counter ruleAppliedCounter) {
-    this.compiledPattern = Pattern.compile(Preconditions.checkNotNull(patternMatch, "[match] can't be null"));
-    Preconditions.checkArgument(!patternMatch.isEmpty(), "[match] can't be blank");
+    this.compiledSearchPattern = Pattern.compile(Preconditions.checkNotNull(patternSearch, "[search] can't be null"));
+    Preconditions.checkArgument(!patternSearch.isEmpty(), "[search] can't be blank");
+    this.compiledMatchPattern = patternMatch != null ? Pattern.compile(patternMatch) : null;
     this.patternReplace = Preconditions.checkNotNull(patternReplace, "[replace] can't be null");
     this.ruleAppliedCounter = ruleAppliedCounter;
   }
@@ -34,7 +38,10 @@ public class PointLineReplaceRegexTransformer implements Function<String, String
   @Override
   public String apply(String pointLine)
   {
-    Matcher patternMatcher = compiledPattern.matcher(pointLine);
+    if (compiledMatchPattern != null && !compiledMatchPattern.matcher(pointLine).matches()) {
+      return pointLine;
+    }
+    Matcher patternMatcher = compiledSearchPattern.matcher(pointLine);
     if (patternMatcher.find()) {
       if (ruleAppliedCounter != null) {
         ruleAppliedCounter.inc();

--- a/proxy/src/main/java/com/wavefront/agent/preprocessor/Preprocessor.java
+++ b/proxy/src/main/java/com/wavefront/agent/preprocessor/Preprocessor.java
@@ -38,6 +38,14 @@ public class Preprocessor<T> {
     return true;
   }
 
+  public boolean hasFilters() {
+    return filters.size() > 0;
+  }
+
+  public boolean hasTransformers() {
+    return transformers.size() > 0;
+  }
+
   @Nullable
   public String getLastFilterResult() {
     return message;

--- a/proxy/src/main/java/com/wavefront/agent/preprocessor/Preprocessor.java
+++ b/proxy/src/main/java/com/wavefront/agent/preprocessor/Preprocessor.java
@@ -9,6 +9,7 @@ import javax.annotation.Nullable;
 import javax.validation.constraints.NotNull;
 
 /**
+ * Generic container class for storing transformation and filter rules
  *
  * Created by Vasily on 9/13/16.
  */
@@ -20,6 +21,11 @@ public class Preprocessor<T> {
   @Nullable
   private String message;
 
+  /**
+   * Apply all transformation rules sequentially
+   * @param point input point
+   * @return transformed point
+   */
   public T transform(@NotNull T point) {
     for (final Function<T, T> func : transformers) {
       point = func.apply(point);
@@ -27,6 +33,11 @@ public class Preprocessor<T> {
     return point;
   }
 
+  /**
+   * Apply all filter predicates sequentially, stop at the first "false" result
+   * @param point point to apply predicates to
+   * @return true if all predicates returned "true"
+   */
   public boolean filter(@NotNull T point) {
     message = null;
     for (final AnnotatedPredicate<T> predicate : filters) {
@@ -38,31 +49,61 @@ public class Preprocessor<T> {
     return true;
   }
 
+  /**
+   * Check if any filters are registered
+   * @return true if it has at least one filter
+   */
   public boolean hasFilters() {
-    return filters.size() > 0;
+    return !filters.isEmpty();
   }
 
+  /**
+   * Check if any transformation rules are registered
+   * @return true if it has at least one transformer
+   */
   public boolean hasTransformers() {
-    return transformers.size() > 0;
+    return !transformers.isEmpty();
   }
 
+  /**
+   * Get the detailed message, if available, with the result of the last filter() operation
+   * @return message
+   */
   @Nullable
   public String getLastFilterResult() {
     return message;
   }
 
+  /**
+   * Register a transformation rule
+   * @param transformer rule
+   */
   public void addTransformer(Function<T, T> transformer) {
     transformers.add(transformer);
   }
 
+  /**
+   * Register a filter rule
+   * @param filter rule
+   */
   public void addFilter(AnnotatedPredicate<T> filter) {
     filters.add(filter);
   }
 
+  /**
+   * Register a transformation rule and place it at a specific index
+   * @param index zero-based index
+   * @param transformer rule
+   */
   public void addTransformer(int index, Function<T, T> transformer) {
     transformers.add(index, transformer);
   }
 
+  /**
+   * Register a filter rule and place it at a specific index
+   * @param index zero-based index
+   * @param filter rule
+   */
   public void addFilter(int index, AnnotatedPredicate<T> filter) {
     filters.add(index, filter);
   }

--- a/proxy/src/test/java/com/wavefront/agent/preprocessor/AgentConfigurationTest.java
+++ b/proxy/src/test/java/com/wavefront/agent/preprocessor/AgentConfigurationTest.java
@@ -18,7 +18,7 @@ public class AgentConfigurationTest {
       fail("Invalid rules did not cause an exception");
     } catch (RuntimeException ex) {
       Assert.assertEquals(0, config.totalValidRules);
-      Assert.assertEquals(90, config.totalInvalidRules);
+      Assert.assertEquals(89, config.totalInvalidRules);
     }
   }
 

--- a/proxy/src/test/resources/com/wavefront/agent/preprocessor/preprocessor_rules_invalid.yaml
+++ b/proxy/src/test/resources/com/wavefront/agent/preprocessor/preprocessor_rules_invalid.yaml
@@ -195,14 +195,6 @@
       replace : ""
       tag     : tag
 
-    # match does not apply
-    - rule    : test-replaceRegex-7
-      action  : replaceRegex
-      scope   : pointLine
-      match   : "foo"
-      search  : "foo"
-      replace : ""
-
     # newtag does not apply
     - rule    : test-replaceRegex-8
       action  : replaceRegex


### PR DESCRIPTION
- Allow pointLine scope rules for binary protocols like graphite pickle, by faking "plaintext" protocol by converting a point to a string and parsing it back. The goal is to provide temporary implementation for the same set of rules during POC trials, when Graphite and Wavefront consume the same data in parallel from carbon-relay, which can only output data in the binary pickle format. Once the trial is over, carbon-relay can be removed from the pipeline and switch back to plaintext protocol.
- Add an optional "match" condition to replaceRegex rules: when defined, apply search/replace regex only if the string matches. In some cases this can significantly simplify search/replace expressions.
