### PR TITLE
Attempt to resolve DNS on connect()

### DIFF
--- a/java-client/src/main/java/com/wavefront/integrations/Wavefront.java
+++ b/java-client/src/main/java/com/wavefront/integrations/Wavefront.java
@@ -96,7 +96,7 @@ public class Wavefront implements WavefrontSender {
     if (socket != null) {
       throw new IllegalStateException("Already connected");
     }
-    InetSocketAddress address = this.address;
+    InetSocketAddress address = new InetSocketAddress(this.address.getHostName(), this.address.getPort());
     if (address.getAddress() == null) {
       throw new UnknownHostException(address.getHostName());
     }


### PR DESCRIPTION
When client connection to the proxy is broken, try to resolve the proxy host name again in case the DNS entry has changed. Requires networkaddress.cache.ttl or sun.net.inetaddr.ttl security property to be set to a positive number (30 or 60 is a good default).