### PR TITLE
Fix point lag tracking metric

### DIFF
--- a/proxy/src/main/java/com/wavefront/agent/PointHandlerImpl.java
+++ b/proxy/src/main/java/com/wavefront/agent/PointHandlerImpl.java
@@ -3,9 +3,9 @@ package com.wavefront.agent;
 import com.google.common.annotations.VisibleForTesting;
 
 import com.wavefront.common.Clock;
+import com.yammer.metrics.Metrics;
 import com.yammer.metrics.core.Histogram;
 import com.yammer.metrics.core.MetricName;
-import com.yammer.metrics.core.WavefrontHistogram;
 
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang.StringUtils;
@@ -57,7 +57,7 @@ public class PointHandlerImpl implements PointHandler {
     this.blockedPointsPerBatch = blockedPointsPerBatch;
     this.prefix = prefix;
 
-    this.receivedPointLag = WavefrontHistogram.get(new MetricName("points." + handle + ".received", "", "lag"));
+    this.receivedPointLag = Metrics.newHistogram(new MetricName("points." + handle + ".received", "", "lag"));
 
     this.sendDataTasks = sendDataTasks;
   }


### PR DESCRIPTION
Switch ~agent.points.*.received.lag.* metrics back to use the pre-5.0 implementation 