### PR TITLE
Misc improvements

### DIFF
--- a/java-lib/src/main/java/com/wavefront/ingester/GraphiteHostAnnotator.java
+++ b/java-lib/src/main/java/com/wavefront/ingester/GraphiteHostAnnotator.java
@@ -34,6 +34,6 @@ public class GraphiteHostAnnotator extends MessageToMessageDecoder<String> {
         return;
       }
     }
-    out.add(msg + " source=" + hostName);
+    out.add(msg + " source=\"" + hostName + "\"");
   }
 }

--- a/java-lib/src/test/java/com/wavefront/ingester/GraphiteHostAnnotatorTest.java
+++ b/java-lib/src/test/java/com/wavefront/ingester/GraphiteHostAnnotatorTest.java
@@ -43,7 +43,7 @@ public class GraphiteHostAnnotatorTest {
     List<Object> out = new LinkedList<Object>();
     String msg = "test.metric 1";
     handler.decode(null, msg, out);
-    assertEquals("test.metric 1 source=test.host.com", out.get(0));
+    assertEquals("test.metric 1 source=\"test.host.com\"", out.get(0));
   }
 
   @Test

--- a/java-lib/src/test/java/com/wavefront/ingester/GraphiteHostAnnotatorTest.java
+++ b/java-lib/src/test/java/com/wavefront/ingester/GraphiteHostAnnotatorTest.java
@@ -67,7 +67,7 @@ public class GraphiteHostAnnotatorTest {
     List<Object> out = new LinkedList<Object>();
     String msg = "test.metric 1 foo=bar";
     handler.decode(null, msg, out);
-    assertEquals("test.metric 1 foo=bar source=test.host.com", out.get(0));
+    assertEquals("test.metric 1 foo=bar source=\"test.host.com\"", out.get(0));
   }
 
   @Ignore

--- a/proxy/src/main/java/com/wavefront/agent/AbstractAgent.java
+++ b/proxy/src/main/java/com/wavefront/agent/AbstractAgent.java
@@ -402,14 +402,17 @@ public abstract class AbstractAgent {
     @Override
     public void run() {
       long startTime = System.currentTimeMillis();
+      boolean isRetry = false;
       try {
         AgentConfiguration config = fetchConfig();
         if (config != null) {
           processConfiguration(config);
+        } else {
+          isRetry = true;
         }
       } finally {
-        // schedule the next run in 1 minute, compensated for the time taken to check in
-        long nextRun = Math.max(5000, 60000 - (System.currentTimeMillis() - startTime));
+        // schedule the next run in 1 minute, compensated for the time taken to check in. if failed, retry in 500ms
+        long nextRun = isRetry ? 500 : Math.max(5000, 60000 - (System.currentTimeMillis() - startTime));
         auxiliaryExecutor.schedule(this, nextRun, TimeUnit.MILLISECONDS);
       }
     }

--- a/proxy/src/main/java/com/wavefront/agent/AbstractAgent.java
+++ b/proxy/src/main/java/com/wavefront/agent/AbstractAgent.java
@@ -1074,12 +1074,14 @@ public abstract class AbstractAgent {
       Enumeration<NetworkInterface> nics = NetworkInterface.getNetworkInterfaces();
       while (nics.hasMoreElements()) {
         NetworkInterface network = nics.nextElement();
-        if (!network.isUp() || network.isLoopback())
+        if (!network.isUp() || network.isLoopback()) {
           continue;
+        }
         for (Enumeration<InetAddress> addresses = network.getInetAddresses(); addresses.hasMoreElements(); ) {
           InetAddress address = addresses.nextElement();
-          if (address.isAnyLocalAddress() || address.isLoopbackAddress() || address.isMulticastAddress())
+          if (address.isAnyLocalAddress() || address.isLoopbackAddress() || address.isMulticastAddress()) {
             continue;
+          }
           if (address instanceof Inet4Address) { // prefer ipv4
             localAddress = address;
             break;

--- a/proxy/src/main/java/com/wavefront/agent/AbstractAgent.java
+++ b/proxy/src/main/java/com/wavefront/agent/AbstractAgent.java
@@ -127,12 +127,12 @@ public abstract class AbstractAgent {
   @Parameter(names = {"--retryThreads"}, description = "Number of threads retrying failed transmissions. Defaults to " +
       "the number of processors (min. 4). Buffer files are maxed out at 2G each so increasing the number of retry " +
       "threads effectively governs the maximum amount of space the agent will use to buffer points locally")
-  protected int retryThreads = Math.max(4, Runtime.getRuntime().availableProcessors());
+  protected int retryThreads = Math.min(16, Math.max(4, Runtime.getRuntime().availableProcessors()));
 
   @Parameter(names = {"--flushThreads"}, description = "Number of threads that flush data to the server. Defaults to" +
       "the number of processors (min. 4). Setting this value too large will result in sending batches that are too " +
       "small to the server and wasting connections. This setting is per listening port.")
-  protected int flushThreads = Math.max(4, Runtime.getRuntime().availableProcessors());
+  protected int flushThreads = Math.min(16, Math.max(4, Runtime.getRuntime().availableProcessors()));
 
   @Parameter(names = {"--purgeBuffer"}, description = "Whether to purge the retry buffer on start-up. Defaults to " +
       "false.")
@@ -818,6 +818,7 @@ public abstract class AbstractAgent {
     } else {
       HttpClient httpClient = HttpClientBuilder.create().
           useSystemProperties().
+          disableAutomaticRetries().
           setUserAgent(httpUserAgent).
           setMaxConnTotal(200).
           setMaxConnPerRoute(100).


### PR DESCRIPTION
1. InetAddress.getLocalHost() returns 127.0.1.1 on Debian - work around this issue by using the address from the first connected network interface, prefer IPv4 if available.
2. Cap auto-configured number of threads at 16, so instances running in containers on powerful hardware won't spawn too many threads
3. Disable automatic retries in HTTPClient so push threads can regain control quickly