### PR TITLE
Add ability to disable RDNS lookup

### DIFF
--- a/proxy/src/main/java/com/wavefront/agent/AbstractAgent.java
+++ b/proxy/src/main/java/com/wavefront/agent/AbstractAgent.java
@@ -340,6 +340,9 @@ public abstract class AbstractAgent {
   @Parameter(names = {"--ephemeral"}, description = "If true, this agent is removed from Wavefront after 24 hours of inactivity.")
   protected boolean ephemeral = false;
 
+  @Parameter(names = {"--disableRdnsLookup"}, description = "When receiving Wavefront-formatted data without source/host specified, use remote IP address as source instead of trying to resolve the DNS name. Default false.")
+  protected boolean disableRdnsLookup = false;
+
   @Parameter(names = {"--javaNetConnection"}, description = "If true, use JRE's own http client when making connections instead of Apache HTTP Client")
   protected boolean javaNetConnection = false;
 
@@ -611,6 +614,8 @@ public abstract class AbstractAgent {
         customSourceTagsProperty = prop.getProperty("customSourceTags", customSourceTagsProperty);
         agentMetricsPointTags = prop.getProperty("agentMetricsPointTags", agentMetricsPointTags);
         ephemeral = Boolean.parseBoolean(prop.getProperty("ephemeral", String.valueOf(ephemeral)));
+        disableRdnsLookup = Boolean.parseBoolean(prop.getProperty("disableRdnsLookup",
+            String.valueOf(disableRdnsLookup)));
         picklePorts = prop.getProperty("picklePorts", picklePorts);
         bufferFile = prop.getProperty("buffer", bufferFile);
         preprocessorConfigFile = prop.getProperty("preprocessorConfigFile", preprocessorConfigFile);

--- a/proxy/src/main/java/com/wavefront/agent/PushAgent.java
+++ b/proxy/src/main/java/com/wavefront/agent/PushAgent.java
@@ -446,7 +446,9 @@ public class PushAgent extends AbstractAgent {
         @Override
         public ChannelHandler apply(Channel input) {
           SocketChannel ch = (SocketChannel) input;
-          return new GraphiteHostAnnotator(ch.remoteAddress().getHostName(), customSourceTags);
+          return new GraphiteHostAnnotator(disableRdnsLookup
+              ? ch.remoteAddress().getAddress().getHostAddress()
+              : ch.remoteAddress().getHostName(), customSourceTags);
         }
       });
       startAsManagedThread(new StringLineIngester(handler, graphiteHandler, port)


### PR DESCRIPTION
Customer request: disable RDNS lookup for remote clients and use remote IP address to annotate metrics that come without source/host instead