### PR TITLE
Fix missing ~agent.buffer.fill-rate metric

### DIFF
--- a/proxy/src/main/java/com/wavefront/agent/QueuedAgentService.java
+++ b/proxy/src/main/java/com/wavefront/agent/QueuedAgentService.java
@@ -387,7 +387,6 @@ public class QueuedAgentService implements ForceQueueEnabledAgentAPI {
         ObjectOutputStream oos = new ObjectOutputStream(lz4OutputStream);
         oos.writeObject(task);
         oos.close();
-        lz4OutputStream.finish();
         lz4OutputStream.close();
         resultPostingSizes.update(outputStream.size());
       } catch (Throwable t) {


### PR DESCRIPTION
Background: getPostingSizerTask would quietly throw an InvalidObjectState exception on .finish() before it had a chance to update the histogram with sizes