### PR TITLE
Allow WavefrontYammerMetricsExporter to prepend group names to outbound metrics.

### DIFF
--- a/java-lib/src/main/java/com/wavefront/common/MetricsToTimeseries.java
+++ b/java-lib/src/main/java/com/wavefront/common/MetricsToTimeseries.java
@@ -3,10 +3,12 @@ package com.wavefront.common;
 import com.google.common.collect.ImmutableMap;
 
 import com.yammer.metrics.core.Metered;
+import com.yammer.metrics.core.MetricName;
 import com.yammer.metrics.core.Sampling;
 import com.yammer.metrics.core.Summarizable;
 
 import java.util.Map;
+import java.util.regex.Pattern;
 
 /**
  * @author Mori Bellamy (mori@wavefront.com)
@@ -36,10 +38,17 @@ public abstract class MetricsToTimeseries {
   public static Map<String, Double> explodeMetered(Metered metered) {
     return ImmutableMap.<String, Double>builder()
         .put("count", new Long(metered.count()).doubleValue())
-        .put("mean", metered.oneMinuteRate())
+        .put("mean", metered.meanRate())
         .put("m1", metered.oneMinuteRate())
         .put("m5", metered.fiveMinuteRate())
         .put("m15", metered.fifteenMinuteRate())
         .build();
   }
+
+  private static final Pattern SIMPLE_NAMES = Pattern.compile("[^a-zA-Z0-9_.\\-~]");
+
+  public static String sanitize(MetricName metricName) {
+    return SIMPLE_NAMES.matcher(metricName.getGroup() + "." + metricName.getName()).replaceAll("_");
+  }
+
 }

--- a/java-lib/src/test/java/com/wavefront/metrics/JsonMetricsGeneratorTest.java
+++ b/java-lib/src/test/java/com/wavefront/metrics/JsonMetricsGeneratorTest.java
@@ -48,7 +48,7 @@ public class JsonMetricsGeneratorTest {
 
     String json = generate(false, false, false);
 
-    assertThat(json).isEqualTo("{\"test.metric\":{\"count\":3,\"min\":10.0,\"max\":1000.0,\"mean\":370.0,\"median\":100.0,\"p75\":1000.0,\"p95\":1000.0,\"p99\":1000.0,\"p999\":1000.0}}");
+    assertThat(json).isEqualTo("{\"test.metric\":{\"count\":3,\"min\":10.0,\"max\":1000.0,\"mean\":370.0,\"sum\":1110.0,\"stddev\":547.4486277268397,\"median\":100.0,\"p75\":1000.0,\"p95\":1000.0,\"p99\":1000.0,\"p999\":1000.0}}");
   }
 
   @Test

--- a/yammer-metrics/src/main/java/com/wavefront/integrations/metrics/WavefrontYammerMetricsReporter.java
+++ b/yammer-metrics/src/main/java/com/wavefront/integrations/metrics/WavefrontYammerMetricsReporter.java
@@ -21,10 +21,16 @@ public class WavefrontYammerMetricsReporter extends AbstractPollingReporter {
   private SocketMetricsProcessor socketMetricProcessor;
 
   public WavefrontYammerMetricsReporter(MetricsRegistry metricsRegistry, String name, String hostname, int port,
-                                        int wavefrontHistogramPort, Supplier<Long> timeSupplier)
-      throws IOException {
+                                        int wavefrontHistogramPort, Supplier<Long> timeSupplier) throws IOException {
+    this(metricsRegistry, name, hostname, port, wavefrontHistogramPort, timeSupplier, false);
+  }
+
+  public WavefrontYammerMetricsReporter(MetricsRegistry metricsRegistry, String name, String hostname, int port,
+                                        int wavefrontHistogramPort, Supplier<Long> timeSupplier,
+                                        boolean prependGroupName) throws IOException {
     super(metricsRegistry, name);
-    this.socketMetricProcessor = new SocketMetricsProcessor(hostname, port, wavefrontHistogramPort, timeSupplier);
+    this.socketMetricProcessor = new SocketMetricsProcessor(hostname, port, wavefrontHistogramPort, timeSupplier,
+        prependGroupName);
   }
 
   @Override


### PR DESCRIPTION
Also fix a bug where mean was mis-reported as one-minute-rate for
Metered metrics.