### PR TITLE
Compatibility changes to WavefrontYammerMetricsReporter:

### DIFF
--- a/dropwizard-metrics/3.1/src/main/java/com/wavefront/integrations/metrics/WavefrontReporter.java
+++ b/dropwizard-metrics/3.1/src/main/java/com/wavefront/integrations/metrics/WavefrontReporter.java
@@ -32,6 +32,8 @@ import java.util.concurrent.TimeUnit;
 
 /**
  * A reporter which publishes metric values to a Wavefront Proxy.
+ *
+ * This sends a DIFFERENT metrics taxonomy than the Wavefront "yammer" metrics reporter.
  */
 public class WavefrontReporter extends ScheduledReporter {
   /**

--- a/dropwizard-metrics/4.0/src/main/java/com/wavefront/integrations/metrics/WavefrontReporter.java
+++ b/dropwizard-metrics/4.0/src/main/java/com/wavefront/integrations/metrics/WavefrontReporter.java
@@ -36,6 +36,7 @@ import java.util.concurrent.TimeUnit;
 /**
  * A reporter which publishes metric values to a Wavefront Proxy.
  *
+ * This sends a DIFFERENT metrics taxonomy than the Wavefront "yammer" metrics reporter.
  */
 public class WavefrontReporter extends ScheduledReporter {
   /**

--- a/java-lib/src/main/java/com/wavefront/common/MetricsToTimeseries.java
+++ b/java-lib/src/main/java/com/wavefront/common/MetricsToTimeseries.java
@@ -6,8 +6,10 @@ import com.yammer.metrics.core.Metered;
 import com.yammer.metrics.core.MetricName;
 import com.yammer.metrics.core.Sampling;
 import com.yammer.metrics.core.Summarizable;
+import com.yammer.metrics.core.VirtualMachineMetrics;
 
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
 
 /**
@@ -44,6 +46,62 @@ public abstract class MetricsToTimeseries {
         .put("m15", metered.fifteenMinuteRate())
         .build();
   }
+
+  public static Map<String, Double> memoryMetrics(VirtualMachineMetrics vm) {
+    return ImmutableMap.<String, Double>builder()
+        .put("totalInit", vm.totalInit())
+        .put("totalUsed", vm.totalUsed())
+        .put("totalMax", vm.totalMax())
+        .put("totalCommitted", vm.totalCommitted())
+        .put("heapInit", vm.heapInit())
+        .put("heapUsed", vm.heapUsed())
+        .put("heapMax", vm.heapMax())
+        .put("heapCommitted", vm.heapCommitted())
+        .put("heap_usage", vm.heapUsage())
+        .put("non_heap_usage", vm.nonHeapUsage())
+        .build();
+  }
+
+  public static Map<String, Double> memoryPoolsMetrics(VirtualMachineMetrics vm) {
+    ImmutableMap.Builder<String, Double> builder = ImmutableMap.builder();
+    for (Map.Entry<String, Double> pool : vm.memoryPoolUsage().entrySet()) {
+      builder.put(pool.getKey(), pool.getValue());
+    }
+    return builder.build();
+  }
+
+  public static Map<String, Double> buffersMetrics(VirtualMachineMetrics.BufferPoolStats bps) {
+    return ImmutableMap.<String, Double>builder()
+        .put("count", (double) bps.getCount())
+        .put("memoryUsed", (double) bps.getMemoryUsed())
+        .put("totalCapacity", (double) bps.getTotalCapacity())
+        .build();
+  }
+
+  public static Map<String, Double> vmMetrics(VirtualMachineMetrics vm) {
+    return ImmutableMap.<String, Double>builder()
+        .put("daemon_thread_count", (double) vm.daemonThreadCount())
+        .put("thread_count", (double) vm.threadCount())
+        .put("uptime", (double) vm.uptime())
+        .put("fd_usage", vm.fileDescriptorUsage())
+        .build();
+  }
+
+  public static Map<String, Double> threadStateMetrics(VirtualMachineMetrics vm) {
+    ImmutableMap.Builder<String, Double> builder = ImmutableMap.builder();
+    for (Map.Entry<Thread.State, Double> entry : vm.threadStatePercentages().entrySet()) {
+      builder.put(entry.getKey().toString().toLowerCase(), entry.getValue());
+    }
+    return builder.build();
+  }
+
+  public static Map<String, Double> gcMetrics(VirtualMachineMetrics.GarbageCollectorStats gcs) {
+    return ImmutableMap.<String, Double>builder()
+        .put("runs", (double) gcs.getRuns())
+        .put("time", (double) gcs.getTime(TimeUnit.MILLISECONDS))
+        .build();
+  }
+
 
   private static final Pattern SIMPLE_NAMES = Pattern.compile("[^a-zA-Z0-9_.\\-~]");
 

--- a/java-lib/src/main/java/com/wavefront/common/Pair.java
+++ b/java-lib/src/main/java/com/wavefront/common/Pair.java
@@ -22,4 +22,8 @@ public class Pair<T, V> {
     }
     return false;
   }
+
+  public static <T, V> Pair<T, V> of(T t, V v) {
+    return new Pair<T, V>(t, v);
+  }
 }

--- a/yammer-metrics/src/main/java/com/wavefront/integrations/metrics/WavefrontYammerMetricsReporter.java
+++ b/yammer-metrics/src/main/java/com/wavefront/integrations/metrics/WavefrontYammerMetricsReporter.java
@@ -1,8 +1,14 @@
 package com.wavefront.integrations.metrics;
 
+import com.google.common.annotations.VisibleForTesting;
+
+import com.wavefront.common.MetricsToTimeseries;
+import com.yammer.metrics.core.Clock;
+import com.yammer.metrics.core.Gauge;
 import com.yammer.metrics.core.Metric;
 import com.yammer.metrics.core.MetricName;
 import com.yammer.metrics.core.MetricsRegistry;
+import com.yammer.metrics.core.VirtualMachineMetrics;
 import com.yammer.metrics.reporting.AbstractPollingReporter;
 
 import java.io.IOException;
@@ -14,6 +20,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import javax.annotation.Nullable;
+import javax.annotation.concurrent.NotThreadSafe;
 
 /**
  * @author Mori Bellamy (mori@wavefront.com)
@@ -23,40 +30,84 @@ public class WavefrontYammerMetricsReporter extends AbstractPollingReporter {
   protected static final Logger logger = Logger.getLogger(WavefrontYammerMetricsReporter.class.getCanonicalName());
   private SocketMetricsProcessor socketMetricProcessor;
   private Function<MetricName, MetricName> transformer;
+  private int metricsGeneratedLastPass = 0;  /* How many metrics were emitted in the last call to run()? */
+  private final boolean includeJvmMetrics;
+  private static final Clock clock = Clock.defaultClock();
+  private static final VirtualMachineMetrics vm = VirtualMachineMetrics.getInstance();
 
   public WavefrontYammerMetricsReporter(MetricsRegistry metricsRegistry, String name, String hostname, int port,
                                         int wavefrontHistogramPort, Supplier<Long> timeSupplier) throws IOException {
-    this(metricsRegistry, name, hostname, port, wavefrontHistogramPort, timeSupplier, false, null);
+    this(metricsRegistry, name, hostname, port, wavefrontHistogramPort, timeSupplier, false, null, false);
   }
 
   /**
    * Reporter of a Yammer metrics registry to Wavefront
-   * @param metricsRegistry The registry to scan-and-report
-   * @param name A human readable name for this reporter
-   * @param hostname The remote host where the wavefront proxy resides
-   * @param port Listening port on Wavefront proxy of graphite-like telemetry data
+   *
+   * @param metricsRegistry        The registry to scan-and-report
+   * @param name                   A human readable name for this reporter
+   * @param hostname               The remote host where the wavefront proxy resides
+   * @param port                   Listening port on Wavefront proxy of graphite-like telemetry data
    * @param wavefrontHistogramPort Listening port for Wavefront histogram data
-   * @param timeSupplier Get current timestamp, stubbed for testing
-   * @param prependGroupName If true, outgoing telemetry is of the form "group.name" rather than "name".
-   * @param transformer If present, applied to each MetricName before flushing to Wavefront. This is useful for adding
-   *                    point tags. Warning: this is called once per metric per scan, so it should probably be
-   *                    performant.
+   * @param timeSupplier           Get current timestamp, stubbed for testing
+   * @param prependGroupName       If true, outgoing telemetry is of the form "group.name" rather than "name".
+   * @param transformer            If present, applied to each MetricName before flushing to Wavefront. This is useful
+   *                               for adding point tags. Warning: this is called once per metric per scan, so it should
+   *                               probably be performant.
    * @throws IOException When we can't remotely connect to Wavefront.
    */
   public WavefrontYammerMetricsReporter(MetricsRegistry metricsRegistry, String name, String hostname, int port,
                                         int wavefrontHistogramPort, Supplier<Long> timeSupplier,
                                         boolean prependGroupName,
-                                        @Nullable Function<MetricName, MetricName> transformer)
-      throws IOException {
+                                        @Nullable Function<MetricName, MetricName> transformer,
+                                        boolean includeJvmMetrics) throws IOException {
     super(metricsRegistry, name);
     this.transformer = transformer;
     this.socketMetricProcessor = new SocketMetricsProcessor(hostname, port, wavefrontHistogramPort, timeSupplier,
         prependGroupName);
+    this.includeJvmMetrics = includeJvmMetrics;
+  }
+
+  private <T> void setGauge(String metricName, T t) {
+    getMetricsRegistry().<T>newGauge(new MetricName("", "", metricName), new Gauge<T>() {
+      @Override
+      public T value() {
+        return t;
+      }
+    });
+  }
+
+  private void setGauges(String base, Map<String, Double> metrics) {
+    for (Map.Entry<String, Double> entry : metrics.entrySet()) {
+      setGauge(base + "." + entry.getKey(), entry.getValue());
+    }
+  }
+
+  private void setJavaMetrics() {
+    setGauges("jvm.memory", MetricsToTimeseries.memoryMetrics(vm));
+    setGauges("jvm.buffers.direct", MetricsToTimeseries.buffersMetrics(vm.getBufferPoolStats().get("direct")));
+    setGauges("jvm.buffers.mapped", MetricsToTimeseries.buffersMetrics(vm.getBufferPoolStats().get("mapped")));
+    setGauges("jvm.thread-states", MetricsToTimeseries.threadStateMetrics(vm));
+    setGauges("jvm", MetricsToTimeseries.vmMetrics(vm));
+    setGauge("current_time", clock.time());
+    for (Map.Entry<String, VirtualMachineMetrics.GarbageCollectorStats> entry : vm.garbageCollectors().entrySet()) {
+      setGauges("jvm.garbage-collectors." + entry.getKey(), MetricsToTimeseries.gcMetrics(entry.getValue()));
+    }
+  }
+
+  /**
+   * @return How many metrics were processed during the last call to {@link #run()}.
+   */
+  @VisibleForTesting
+  int getMetricsGeneratedLastPass() {
+    return metricsGeneratedLastPass;
   }
 
   @Override
   public void run() {
+    metricsGeneratedLastPass = 0;
     try {
+      if (includeJvmMetrics) setJavaMetrics();
+
       for (Map.Entry<String, SortedMap<MetricName, Metric>> entry : getMetricsRegistry().groupedMetrics().entrySet()) {
         for (Map.Entry<MetricName, Metric> subEntry : entry.getValue().entrySet()) {
           MetricName metricName = subEntry.getKey();
@@ -64,6 +115,7 @@ public class WavefrontYammerMetricsReporter extends AbstractPollingReporter {
             metricName = transformer.apply(metricName);
           }
           subEntry.getValue().processWith(socketMetricProcessor, metricName, null);
+          metricsGeneratedLastPass++;
         }
       }
       socketMetricProcessor.flush();


### PR DESCRIPTION
1) Optionally add JVM metrics, similarly to JsonMetricsGenerator.
   Refactor that bit to use common code.
2) Break timers into their duration/rate parts, similarly to
   JsonMetricsGenerator and DISsimilarly to WavefrontDropwizardMetricsReporter.