### PR TITLE
Histogram refactoring/performance improvements

### DIFF
--- a/java-lib/src/main/java/com/wavefront/ingester/IngesterFormatter.java
+++ b/java-lib/src/main/java/com/wavefront/ingester/IngesterFormatter.java
@@ -50,7 +50,7 @@ public class IngesterFormatter {
     @Override
     public void syntaxError(Recognizer<?, ?> recognizer, Object offendingSymbol, int line,
                             int charPositionInLine, String msg, RecognitionException e) {
-      throw new RuntimeException(msg, e);
+      throw new RuntimeException("Syntax error at line " + line + ", position " + charPositionInLine + ": " + msg, e);
     }
   };
 
@@ -77,7 +77,7 @@ public class IngesterFormatter {
     DSWrapperLexer lexer = dsWrapperLexerThreadLocal.get();
     lexer.setInputStream(new ANTLRInputStream(input));
     CommonTokenStream commonTokenStream = new CommonTokenStream(lexer);
-    commonTokenStream.getText();
+    commonTokenStream.fill();
     List<Token> tokens = commonTokenStream.getTokens();
     if (tokens.isEmpty()) {
       throw new RuntimeException("Could not parse: " + input);

--- a/proxy/src/main/java/com/wavefront/agent/AbstractAgent.java
+++ b/proxy/src/main/java/com/wavefront/agent/AbstractAgent.java
@@ -199,8 +199,29 @@ public abstract class AbstractAgent {
 
   @Parameter(
       names = {"--histogramAccumulatorResolveInterval"},
-      description = "Interval to write-back accumulation changes to disk in millis.")
+      description = "Interval to write-back accumulation changes from memory cache to disk in millis (only " +
+          "applicable when memory cache is enabled")
   protected Long histogramAccumulatorResolveInterval = 100L;
+
+  @Parameter(
+      names = {"--histogramAccumulatorFlushInterval"},
+      description = "Interval to check for histograms to send to Wavefront in millis (Default: 1000)")
+  protected Long histogramAccumulatorFlushInterval = 1000L;
+
+  @Parameter(
+      names = {"--histogramAccumulatorFlushMaxBatchSize"},
+      description = "Max number of histograms to send to Wavefront in one flush (Default: no limit)")
+  protected Integer histogramAccumulatorFlushMaxBatchSize = -1;
+
+  @Parameter(
+      names = {"--histogramReceiveBufferFlushInterval"},
+      description = "Interval to send received points to the processing queue in millis (Default: 100)")
+  protected Integer histogramReceiveBufferFlushInterval = 100;
+
+  @Parameter(
+      names = {"--histogramProcessingQueueScanInterval"},
+      description = "Processing queue scan interval in millis (Default: 20)")
+  protected Integer histogramProcessingQueueScanInterval = 20;
 
   @Parameter(
       names = {"--histogramMinuteListenerPorts"},
@@ -218,6 +239,33 @@ public abstract class AbstractAgent {
   protected Integer histogramMinuteFlushSecs = 70;
 
   @Parameter(
+      names = {"--histogramMinuteCompression"},
+      description = "Controls allowable number of centroids per histogram. Must be in [20;1000]")
+  protected Short histogramMinuteCompression = 100;
+
+  @Parameter(
+      names = {"--histogramMinuteAvgKeyBytes"},
+      description = "Average number of bytes in a [UTF-8] encoded histogram key. Generally corresponds to a metric, " +
+          "source and tags concatenation.")
+  protected Integer histogramMinuteAvgKeyBytes = 150;
+
+  @Parameter(
+      names = {"--histogramMinuteAvgDigestBytes"},
+      description = "Average number of bytes in a encoded histogram.")
+  protected Integer histogramMinuteAvgDigestBytes = 500;
+
+  @Parameter(
+      names = {"--histogramMinuteAccumulatorSize"},
+      description = "Expected upper bound of concurrent accumulations, ~ #timeseries * #parallel reporting bins")
+  protected Long histogramMinuteAccumulatorSize = 100000L;
+
+  @Parameter(
+      names = {"--histogramMinuteMemoryCache"},
+      description = "Enabling memory cache reduces I/O load with fewer time series and higher frequency data " +
+          "(more than 1 point per second per time series). Default: false")
+  protected boolean histogramMinuteMemoryCache = false;
+
+  @Parameter(
       names = {"--histogramHourListenerPorts"},
       description = "Comma-separated list of ports to listen on. Defaults to none.")
   protected String histogramHourListenerPorts = "";
@@ -231,6 +279,33 @@ public abstract class AbstractAgent {
       names = {"--histogramHourFlushSecs"},
       description = "Number of seconds to keep an hour granularity accumulator open for new samples.")
   protected Integer histogramHourFlushSecs = 4200;
+
+  @Parameter(
+      names = {"--histogramHourCompression"},
+      description = "Controls allowable number of centroids per histogram. Must be in [20;1000]")
+  protected Short histogramHourCompression = 100;
+
+  @Parameter(
+      names = {"--histogramHourAvgKeyBytes"},
+      description = "Average number of bytes in a [UTF-8] encoded histogram key. Generally corresponds to a metric, " +
+          "source and tags concatenation.")
+  protected Integer histogramHourAvgKeyBytes = 150;
+
+  @Parameter(
+      names = {"--histogramHourAvgDigestBytes"},
+      description = "Average number of bytes in a encoded histogram.")
+  protected Integer histogramHourAvgDigestBytes = 500;
+
+  @Parameter(
+      names = {"--histogramHourAccumulatorSize"},
+      description = "Expected upper bound of concurrent accumulations, ~ #timeseries * #parallel reporting bins")
+  protected Long histogramHourAccumulatorSize = 100000L;
+
+  @Parameter(
+      names = {"--histogramHourMemoryCache"},
+      description = "Enabling memory cache reduces I/O load with fewer time series and higher frequency data " +
+          "(more than 1 point per second per time series). Default: false")
+  protected boolean histogramHourMemoryCache = false;
 
   @Parameter(
       names = {"--histogramDayListenerPorts"},
@@ -248,6 +323,33 @@ public abstract class AbstractAgent {
   protected Integer histogramDayFlushSecs = 18000;
 
   @Parameter(
+      names = {"--histogramDayCompression"},
+      description = "Controls allowable number of centroids per histogram. Must be in [20;1000]")
+  protected Short histogramDayCompression = 100;
+
+  @Parameter(
+      names = {"--histogramDayAvgKeyBytes"},
+      description = "Average number of bytes in a [UTF-8] encoded histogram key. Generally corresponds to a metric, " +
+          "source and tags concatenation.")
+  protected Integer histogramDayAvgKeyBytes = 150;
+
+  @Parameter(
+      names = {"--histogramDayAvgHistogramDigestBytes"},
+      description = "Average number of bytes in a encoded histogram.")
+  protected Integer histogramDayAvgDigestBytes = 500;
+
+  @Parameter(
+      names = {"--histogramDayAccumulatorSize"},
+      description = "Expected upper bound of concurrent accumulations, ~ #timeseries * #parallel reporting bins")
+  protected Long histogramDayAccumulatorSize = 100000L;
+
+  @Parameter(
+      names = {"--histogramDayMemoryCache"},
+      description = "Enabling memory cache reduces I/O load with fewer time series and higher frequency data " +
+          "(more than 1 point per second per time series). Default: false")
+  protected boolean histogramDayMemoryCache = false;
+
+  @Parameter(
       names = {"--histogramDistListenerPorts"},
       description = "Comma-separated list of ports to listen on. Defaults to none.")
   protected String histogramDistListenerPorts = "";
@@ -263,20 +365,49 @@ public abstract class AbstractAgent {
   protected Integer histogramDistFlushSecs = 70;
 
   @Parameter(
-      names = {"--histogramAccumulatorSize"},
+      names = {"--histogramDistCompression"},
+      description = "Controls allowable number of centroids per histogram. Must be in [20;1000]")
+  protected Short histogramDistCompression = 100;
+
+  @Parameter(
+      names = {"--histogramDistAvgKeyBytes"},
+      description = "Average number of bytes in a [UTF-8] encoded histogram key. Generally corresponds to a metric, " +
+          "source and tags concatenation.")
+  protected Integer histogramDistAvgKeyBytes = 150;
+
+  @Parameter(
+      names = {"--histogramDistAvgDigestBytes"},
+      description = "Average number of bytes in a encoded histogram.")
+  protected Integer histogramDistAvgDigestBytes = 500;
+
+  @Parameter(
+      names = {"--histogramDistAccumulatorSize"},
       description = "Expected upper bound of concurrent accumulations, ~ #timeseries * #parallel reporting bins")
-  protected Long histogramAccumulatorSize = 100000L;
+  protected Long histogramDistAccumulatorSize = 100000L;
+
+  @Parameter(
+      names = {"--histogramDistMemoryCache"},
+      description = "Enabling memory cache reduces I/O load with fewer time series and higher frequency data " +
+          "(more than 1 point per second per time series). Default: false")
+  protected boolean histogramDistMemoryCache = false;
+
+  @Parameter(
+      names = {"--histogramAccumulatorSize"},
+      description = "(DEPRECATED FOR histogramMinuteAccumulatorSize/histogramHourAccumulatorSize/" +
+          "histogramDayAccumulatorSize/histogramDistAccumulatorSize)")
+  protected Long histogramAccumulatorSize = null;
 
   @Parameter(
       names = {"--avgHistogramKeyBytes"},
-      description = "Average number of bytes in a [UTF-8] encoded histogram key. Generally corresponds to a metric, " +
-          "source and tags concatenation.")
-  protected Integer avgHistogramKeyBytes = 150;
+      description = "(DEPRECATED FOR histogramMinuteAvgKeyBytes/histogramHourAvgKeyBytes/" +
+          "histogramDayAvgHistogramKeyBytes/histogramDistAvgKeyBytes)")
+  protected Integer avgHistogramKeyBytes = null;
 
   @Parameter(
       names = {"--avgHistogramDigestBytes"},
-      description = "Average number of bytes in a encoded histogram.")
-  protected Integer avgHistogramDigestBytes = 500;
+      description = "(DEPRECATED FOR histogramMinuteAvgDigestBytes/histogramHourAvgDigestBytes/" +
+          "histogramDayAvgHistogramDigestBytes/histogramDistAvgDigestBytes)")
+  protected Integer avgHistogramDigestBytes = null;
 
   @Parameter(
       names = {"--persistMessages"},
@@ -294,8 +425,9 @@ public abstract class AbstractAgent {
 
   @Parameter(
       names = {"--histogramCompression"},
-      description = "Controls allowable number of centroids per histogram. Must be in [20;1000]")
-  protected Short histogramCompression = 100;
+      description = "(DEPRECATED FOR histogramMinuteCompression/histogramHourCompression/" +
+          "histogramDayCompression/histogramDistCompression)")
+  protected Short histogramCompression = null;
 
   @Parameter(names = {"--graphitePorts"}, description = "Comma-separated list of ports to listen on for graphite " +
       "data. Defaults to empty list.")
@@ -620,34 +752,101 @@ public abstract class AbstractAgent {
         pushBlockedSamples = config.getNumber("pushBlockedSamples", pushBlockedSamples).intValue();
         pushListenerPorts = config.getString("pushListenerPorts", pushListenerPorts);
         memGuardFlushThreshold = config.getNumber("memGuardFlushThreshold", memGuardFlushThreshold).intValue();
+
+        // Histogram: global settings
         histogramStateDirectory = config.getString("histogramStateDirectory", histogramStateDirectory);
         histogramAccumulatorResolveInterval = config.getNumber("histogramAccumulatorResolveInterval",
             histogramAccumulatorResolveInterval).longValue();
-        histogramMinuteListenerPorts = config.getString("histogramMinuteListenerPorts", histogramMinuteListenerPorts);
-        histogramMinuteAccumulators = config.getNumber("histogramMinuteAccumulators", histogramMinuteAccumulators).
-            intValue();
-        histogramMinuteFlushSecs = config.getNumber("histogramMinuteFlushSecs", histogramMinuteFlushSecs).intValue();
-        histogramHourListenerPorts = config.getString("histogramHourListenerPorts", histogramHourListenerPorts);
-        histogramHourAccumulators = config.getNumber("histogramHourAccumulators", histogramHourAccumulators).intValue();
-        histogramHourFlushSecs = config.getNumber("histogramHourFlushSecs", histogramHourFlushSecs).intValue();
-        histogramDayListenerPorts = config.getString("histogramDayListenerPorts", histogramDayListenerPorts);
-        histogramDayAccumulators = config.getNumber("histogramDayAccumulators", histogramDayAccumulators).intValue();
-        histogramDayFlushSecs = config.getNumber("histogramDayFlushSecs", histogramDayFlushSecs).intValue();
-        histogramDistListenerPorts = config.getString("histogramDistListenerPorts", histogramDistListenerPorts);
-        histogramDistAccumulators = config.getNumber("histogramDistAccumulators", histogramDistAccumulators).intValue();
-        histogramDistFlushSecs = config.getNumber("histogramDistFlushSecs", histogramDistFlushSecs).intValue();
-        histogramAccumulatorSize = config.getNumber("histogramAccumulatorSize", histogramAccumulatorSize).longValue();
-        histogramCompression = config.getNumber("histogramCompression", histogramCompression).shortValue();
-        avgHistogramKeyBytes = config.getNumber("avgHistogramKeyBytes", avgHistogramKeyBytes).intValue();
-
-        // these defaults should work well in most cases
-        avgHistogramDigestBytes = 32 + Math.round(histogramCompression * 10.5f);
-
-        avgHistogramDigestBytes = config.getNumber("avgHistogramDigestBytes", avgHistogramDigestBytes).intValue();
+        histogramAccumulatorFlushInterval = config.getNumber("histogramAccumulatorFlushInterval",
+            histogramAccumulatorFlushInterval).longValue();
+        histogramAccumulatorFlushMaxBatchSize = config.getNumber("histogramAccumulatorFlushMaxBatchSize",
+            histogramAccumulatorFlushMaxBatchSize).intValue();
+        histogramReceiveBufferFlushInterval = config.getNumber("histogramReceiveBufferFlushInterval",
+            histogramReceiveBufferFlushInterval).intValue();
+        histogramProcessingQueueScanInterval = config.getNumber("histogramProcessingQueueScanInterval",
+            histogramProcessingQueueScanInterval).intValue();
         persistAccumulator = config.getBoolean("persistAccumulator", persistAccumulator);
         persistMessages = config.getBoolean("persistMessages", persistMessages);
         persistMessagesCompression = config.getBoolean("persistMessagesCompression",
             persistMessagesCompression);
+
+        // Histogram: deprecated settings - fall back for backwards compatibility
+        if (config.isDefined("avgHistogramKeyBytes")) {
+          histogramMinuteAvgKeyBytes = histogramHourAvgKeyBytes = histogramDayAvgKeyBytes =
+              histogramDistAvgKeyBytes = config.getNumber("avgHistogramKeyBytes", avgHistogramKeyBytes).intValue();
+        }
+        if (config.isDefined("avgHistogramDigestBytes")) {
+          histogramMinuteAvgDigestBytes = histogramHourAvgDigestBytes = histogramDayAvgDigestBytes =
+              histogramDistAvgDigestBytes = config.getNumber("avgHistogramDigestBytes", avgHistogramDigestBytes).
+                  intValue();
+        }
+        if (config.isDefined("histogramAccumulatorSize")) {
+          histogramMinuteAccumulatorSize = histogramHourAccumulatorSize = histogramDayAccumulatorSize =
+              histogramDistAccumulatorSize = config.getNumber("histogramAccumulatorSize",
+                  histogramAccumulatorSize).longValue();
+        }
+        if (config.isDefined("histogramCompression")) {
+          histogramMinuteCompression = histogramHourCompression = histogramDayCompression =
+              histogramDistCompression = config.getNumber("histogramCompression", null, 20, 1000).shortValue();
+        }
+
+        // Histogram: minute accumulator settings
+        histogramMinuteListenerPorts = config.getString("histogramMinuteListenerPorts", histogramMinuteListenerPorts);
+        histogramMinuteAccumulators = config.getNumber("histogramMinuteAccumulators", histogramMinuteAccumulators).
+            intValue();
+        histogramMinuteFlushSecs = config.getNumber("histogramMinuteFlushSecs", histogramMinuteFlushSecs).intValue();
+        histogramMinuteCompression = config.getNumber("histogramMinuteCompression",
+            histogramMinuteCompression, 20, 1000).shortValue();
+        histogramMinuteAvgKeyBytes = config.getNumber("histogramMinuteAvgKeyBytes", histogramMinuteAvgKeyBytes).
+            intValue();
+        histogramMinuteAvgDigestBytes = 32 + histogramMinuteCompression * 7;
+        histogramMinuteAvgDigestBytes = config.getNumber("histogramMinuteAvgDigestBytes",
+            histogramMinuteAvgDigestBytes).intValue();
+        histogramMinuteAccumulatorSize = config.getNumber("histogramMinuteAccumulatorSize",
+            histogramMinuteAccumulatorSize).longValue();
+        histogramMinuteMemoryCache = config.getBoolean("histogramMinuteMemoryCache", histogramMinuteMemoryCache);
+
+        // Histogram: hour accumulator settings
+        histogramHourListenerPorts = config.getString("histogramHourListenerPorts", histogramHourListenerPorts);
+        histogramHourAccumulators = config.getNumber("histogramHourAccumulators", histogramHourAccumulators).intValue();
+        histogramHourFlushSecs = config.getNumber("histogramHourFlushSecs", histogramHourFlushSecs).intValue();
+        histogramHourCompression = config.getNumber("histogramHourCompression",
+            histogramHourCompression, 20, 1000).shortValue();
+        histogramHourAvgKeyBytes = config.getNumber("histogramHourAvgKeyBytes", histogramHourAvgKeyBytes).intValue();
+        histogramHourAvgDigestBytes = 32 + histogramHourCompression * 7;
+        histogramHourAvgDigestBytes = config.getNumber("histogramHourAvgDigestBytes", histogramHourAvgDigestBytes).
+            intValue();
+        histogramHourAccumulatorSize = config.getNumber("histogramHourAccumulatorSize", histogramHourAccumulatorSize).
+            longValue();
+        histogramHourMemoryCache = config.getBoolean("histogramHourMemoryCache", histogramHourMemoryCache);
+
+        // Histogram: day accumulator settings
+        histogramDayListenerPorts = config.getString("histogramDayListenerPorts", histogramDayListenerPorts);
+        histogramDayAccumulators = config.getNumber("histogramDayAccumulators", histogramDayAccumulators).intValue();
+        histogramDayFlushSecs = config.getNumber("histogramDayFlushSecs", histogramDayFlushSecs).intValue();
+        histogramDayCompression = config.getNumber("histogramDayCompression",
+            histogramDayCompression, 20, 1000).shortValue();
+        histogramDayAvgKeyBytes = config.getNumber("histogramDayAvgKeyBytes", histogramDayAvgKeyBytes).intValue();
+        histogramDayAvgDigestBytes = 32 + histogramDayCompression * 7;
+        histogramDayAvgDigestBytes = config.getNumber("histogramDayAvgDigestBytes", histogramDayAvgDigestBytes).
+            intValue();
+        histogramDayAccumulatorSize = config.getNumber("histogramDayAccumulatorSize", histogramDayAccumulatorSize).
+            longValue();
+        histogramDayMemoryCache = config.getBoolean("histogramDayMemoryCache", histogramDayMemoryCache);
+
+        // Histogram: dist accumulator settings
+        histogramDistListenerPorts = config.getString("histogramDistListenerPorts", histogramDistListenerPorts);
+        histogramDistAccumulators = config.getNumber("histogramDistAccumulators", histogramDistAccumulators).intValue();
+        histogramDistFlushSecs = config.getNumber("histogramDistFlushSecs", histogramDistFlushSecs).intValue();
+        histogramDistCompression = config.getNumber("histogramDistCompression",
+            histogramDistCompression, 20, 1000).shortValue();
+        histogramDistAvgKeyBytes = config.getNumber("histogramDistAvgKeyBytes", histogramDistAvgKeyBytes).intValue();
+        histogramDistAvgDigestBytes = 32 + histogramDistCompression * 7;
+        histogramDistAvgDigestBytes = config.getNumber("histogramDistAvgDigestBytes", histogramDistAvgDigestBytes).
+            intValue();
+        histogramDistAccumulatorSize = config.getNumber("histogramDistAccumulatorSize", histogramDistAccumulatorSize).
+            longValue();
+        histogramDistMemoryCache = config.getBoolean("histogramDistMemoryCache", histogramDistMemoryCache);
 
         retryThreads = config.getNumber("retryThreads", retryThreads).intValue();
         flushThreads = config.getNumber("flushThreads", flushThreads).intValue();

--- a/proxy/src/main/java/com/wavefront/agent/PointHandlerImpl.java
+++ b/proxy/src/main/java/com/wavefront/agent/PointHandlerImpl.java
@@ -1,7 +1,5 @@
 package com.wavefront.agent;
 
-import com.google.common.annotations.VisibleForTesting;
-
 import com.wavefront.common.Clock;
 import com.yammer.metrics.Metrics;
 import com.yammer.metrics.core.Histogram;
@@ -88,6 +86,7 @@ public class PointHandlerImpl implements PointHandler {
         validPointsLogger.info(strPoint);
       }
       randomPostTask.addPoint(strPoint);
+      randomPostTask.enforceBufferLimits();
       receivedPointLag.update(Clock.now() - point.getTimestamp());
 
     } catch (IllegalArgumentException e) {

--- a/proxy/src/main/java/com/wavefront/agent/PushAgent.java
+++ b/proxy/src/main/java/com/wavefront/agent/PushAgent.java
@@ -463,7 +463,7 @@ public class PushAgent extends AbstractAgent {
         TimeUnit.SECONDS);
 
     AccumulationCache cachedAccumulator = new AccumulationCache(accumulator,
-        (memoryCacheEnabled ? accumulatorSize : 0),null);
+        (memoryCacheEnabled ? accumulatorSize : 0), null);
 
     // Schedule write-backs
     histogramExecutor.scheduleWithFixedDelay(

--- a/proxy/src/main/java/com/wavefront/agent/histogram/MapLoader.java
+++ b/proxy/src/main/java/com/wavefront/agent/histogram/MapLoader.java
@@ -4,6 +4,11 @@ import com.google.common.base.Preconditions;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+
+import com.wavefront.agent.ResubmissionTask;
+import com.wavefront.agent.ResubmissionTaskDeserializer;
 
 import net.openhft.chronicle.hash.serialization.BytesReader;
 import net.openhft.chronicle.hash.serialization.BytesWriter;
@@ -12,10 +17,18 @@ import net.openhft.chronicle.hash.serialization.SizedWriter;
 import net.openhft.chronicle.map.ChronicleMap;
 import net.openhft.chronicle.map.VanillaChronicleMap;
 
+import java.io.BufferedReader;
 import java.io.File;
+import java.io.FileReader;
+import java.io.FileWriter;
 import java.io.IOException;
+import java.io.Reader;
+import java.io.Writer;
+import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+
+import javax.validation.constraints.NotNull;
 
 /**
  * Loader for {@link ChronicleMap}. If a file already exists at the given location, will make an attempt to load the map
@@ -25,6 +38,12 @@ import java.util.logging.Logger;
  */
 public class MapLoader<K, V, KM extends BytesReader<K> & BytesWriter<K>, VM extends SizedReader<V> & SizedWriter<V>> {
   private static final Logger logger = Logger.getLogger(MapLoader.class.getCanonicalName());
+
+  /**
+   * Allow ChronicleMap to grow beyond initially allocated size instead of crashing. Since it makes the map a lot less
+   * efficient, we should log a warning if the actual number of elements exceeds the allocated
+   */
+  private static final double MAX_BLOAT_FACTOR = 5;
 
   private final Class<K> keyClass;
   private final Class<V> valueClass;
@@ -44,6 +63,7 @@ public class MapLoader<K, V, KM extends BytesReader<K> & BytesWriter<K>, VM exte
               .entries(entries)
               .averageKeySize(avgKeySize)
               .averageValueSize(avgValueSize)
+              .maxBloatFactor(MAX_BLOAT_FACTOR)
               .createPersistedTo(file);
         }
 
@@ -54,11 +74,27 @@ public class MapLoader<K, V, KM extends BytesReader<K> & BytesWriter<K>, VM exte
               .entries(entries)
               .averageKeySize(avgKeySize)
               .averageValueSize(avgValueSize)
+              .maxBloatFactor(MAX_BLOAT_FACTOR)
               .create();
         }
 
+        private MapSettings loadSettings(File file) throws IOException {
+          Gson gson = new GsonBuilder().
+              registerTypeHierarchyAdapter(Class.class, new MapSettings.ClassNameSerializer()).create();
+          Reader br = new BufferedReader(new FileReader(file));
+          return gson.fromJson(br, MapSettings.class);
+        }
+
+        private void saveSettings(MapSettings settings, File file) throws IOException {
+          Gson gson = new GsonBuilder().
+              registerTypeHierarchyAdapter(Class.class, new MapSettings.ClassNameSerializer()).create();
+          Writer writer = new FileWriter(file);
+          gson.toJson(settings, writer);
+          writer.close();
+        }
+
         @Override
-        public ChronicleMap<K, V> load(File file) throws Exception {
+        public ChronicleMap<K, V> load(@NotNull File file) throws Exception {
           if (!doPersist) {
             logger.log(
                 Level.WARNING,
@@ -67,9 +103,49 @@ public class MapLoader<K, V, KM extends BytesReader<K> & BytesWriter<K>, VM exte
             return newInMemoryMap();
           }
 
+          MapSettings newSettings = new MapSettings(keyClass, valueClass,
+              keyMarshaller.getClass(), valueMarshaller.getClass(), entries, avgKeySize, avgValueSize);
+          File settingsFile = new File(file.getAbsolutePath().concat(".settings"));
           try {
             if (file.exists()) {
-              logger.fine("Restoring accumulator state...");
+              if (settingsFile.exists()) {
+                MapSettings settings = loadSettings(settingsFile);
+                if (!settings.equals(newSettings)) {
+                  logger.info(file.getName() + " settings changed, reconfiguring (this may take a few moments)...");
+                  File originalFile = new File(file.getAbsolutePath());
+                  File oldFile = new File(file.getAbsolutePath().concat(".temp"));
+                  if (oldFile.exists()) {
+                    oldFile.delete();
+                  }
+                  file.renameTo(oldFile);
+
+                  ChronicleMap<K, V> toMigrate = ChronicleMap
+                      .of(keyClass, valueClass)
+                      .entries(settings.getEntries())
+                      .averageKeySize(settings.getAvgKeySize())
+                      .averageValueSize(settings.getAvgValueSize())
+                      .recoverPersistedTo(oldFile, false);
+
+                  ChronicleMap<K, V> result = newPersistedMap(originalFile);
+
+                  if (toMigrate.size() > 0) {
+                    logger.info(originalFile.getName() + " starting data migration (" + toMigrate.size() + " records)");
+                    for (K key : toMigrate.keySet()) {
+                      result.put(key, toMigrate.get(key));
+                    }
+                    toMigrate.close();
+                    logger.info(originalFile.getName() + " data migration finished");
+                  }
+
+                  saveSettings(newSettings, settingsFile);
+                  oldFile.delete();
+                  logger.info(originalFile.getName() + " reconfiguration finished");
+
+                  return result;
+                }
+              }
+
+              logger.fine("Restoring accumulator state from " + file.getAbsolutePath());
               // Note: this relies on an uncorrupted header, which according to the docs would be due to a hardware error or fs bug.
               ChronicleMap<K, V> result = ChronicleMap
                   .of(keyClass, valueClass)
@@ -82,12 +158,12 @@ public class MapLoader<K, V, KM extends BytesReader<K> & BytesWriter<K>, VM exte
                 // Create a new map with the supplied settings to be safe.
                 result.close();
                 file.delete();
-                logger.fine("Accumulator map initialized");
+                logger.fine("Empty accumulator - reinitializing: " + file.getName());
                 result = newPersistedMap(file);
               } else {
                 // Note: as of 3.10 all instances are.
                 if (result instanceof VanillaChronicleMap) {
-                  logger.fine("Accumulator map restored");
+                  logger.fine("Accumulator map restored from " + file.getAbsolutePath());
                   VanillaChronicleMap vcm = (VanillaChronicleMap) result;
                   if (!vcm.keyClass().equals(keyClass) ||
                       !vcm.valueClass().equals(valueClass)) {
@@ -97,10 +173,12 @@ public class MapLoader<K, V, KM extends BytesReader<K> & BytesWriter<K>, VM exte
                   }
                 }
               }
+              saveSettings(newSettings, settingsFile);
               return result;
 
             } else {
-              logger.info("Accumulator map initialized");
+              logger.fine("Accumulator map initialized as " + file.getName());
+              saveSettings(newSettings, settingsFile);
               return newPersistedMap(file);
             }
           } catch (Exception e) {

--- a/proxy/src/main/java/com/wavefront/agent/histogram/MapSettings.java
+++ b/proxy/src/main/java/com/wavefront/agent/histogram/MapSettings.java
@@ -1,0 +1,110 @@
+package com.wavefront.agent.histogram;
+
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonSerializationContext;
+import com.google.gson.JsonSerializer;
+
+import java.lang.reflect.Type;
+
+/**
+ * Stores settings ChronicleMap has been initialized with to trigger map re-creation when settings change
+ * (since ChronicleMap doesn't persist init values for entries/avgKeySize/avgValueSize)
+ *
+ * @author vasily@wavefront.com
+ */
+public class MapSettings {
+  private final Class keyClass;
+  private final Class valueClass;
+  private final Class keyMarshaller;
+  private final Class valueMarshaller;
+  private final long entries;
+  private final double avgKeySize;
+  private final double avgValueSize;
+
+  public MapSettings(Class keyClass, Class valueClass, Class keyMarshaller, Class valueMarshaller,
+                     long entries, double avgKeySize, double avgValueSize) {
+    this.keyClass = keyClass;
+    this.valueClass = valueClass;
+    this.keyMarshaller = keyMarshaller;
+    this.valueMarshaller = valueMarshaller;
+    this.entries = entries;
+    this.avgKeySize = avgKeySize;
+    this.avgValueSize = avgValueSize;
+  }
+
+  public Class getKeyClass() {
+    return keyClass;
+  }
+
+  public Class getValueClass() {
+    return valueClass;
+  }
+
+  public Class getKeyMarshaller() {
+    return keyMarshaller;
+  }
+
+  public Class getValueMarshaller() {
+    return valueMarshaller;
+  }
+
+  public long getEntries() {
+    return entries;
+  }
+
+  public double getAvgKeySize() {
+    return avgKeySize;
+  }
+
+  public double getAvgValueSize() {
+    return avgValueSize;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    MapSettings that = (MapSettings)o;
+
+    return (this.keyClass == that.keyClass
+        && this.valueClass == that.valueClass
+        && this.keyMarshaller == that.keyMarshaller
+        && this.valueMarshaller == that.valueMarshaller
+        && this.entries == that.entries
+        && this.avgKeySize == that.avgKeySize
+        && this.avgValueSize == that.avgValueSize);
+  }
+
+  @Override
+  public String toString() {
+    return "MapSettings{" +
+        "keyClass=" + (keyClass == null ? "(null)" : keyClass.getName()) +
+        ", valueClass=" + (valueClass == null ? "(null)" : valueClass.getName()) +
+        ", keyMarshaller=" + (keyMarshaller == null ? "(null)" : keyMarshaller.getName()) +
+        ", valueMarshaller=" + (valueMarshaller == null ? "(null)" : valueMarshaller.getName()) +
+        ", entries=" + entries +
+        ", avgKeySize=" + avgKeySize +
+        ", avgValueSize=" + avgValueSize +
+        '}';
+  }
+
+  public static class ClassNameSerializer implements JsonSerializer<Class>, JsonDeserializer<Class> {
+    @Override
+    public JsonElement serialize(Class src, Type type, JsonSerializationContext context) {
+      return context.serialize(src.getName());
+    }
+    @Override
+    public Class deserialize(JsonElement src, Type type, JsonDeserializationContext context) {
+      try {
+        return Class.forName(src.getAsString());
+      } catch (ClassNotFoundException e) {
+        return null;
+      }
+    }
+
+  }
+
+
+}

--- a/proxy/src/main/java/com/wavefront/agent/histogram/Utils.java
+++ b/proxy/src/main/java/com/wavefront/agent/histogram/Utils.java
@@ -122,7 +122,7 @@ public final class Utils {
    * @param agentDigest  the digest defining the centroids
    * @return the corresponding point
    */
-  static ReportPoint pointFromKeyAndDigest(HistogramKey histogramKey, AgentDigest agentDigest) {
+  public static ReportPoint pointFromKeyAndDigest(HistogramKey histogramKey, AgentDigest agentDigest) {
     return ReportPoint.newBuilder()
         .setTimestamp(histogramKey.getBinTimeMillis())
         .setMetric(histogramKey.getMetric())
@@ -210,7 +210,8 @@ public final class Utils {
 
     @Override
     public int hashCode() {
-      int result = (int) granularityOrdinal;
+      int result = 1;
+      result = 31 * result + (int) granularityOrdinal;
       result = 31 * result + binId;
       result = 31 * result + metric.hashCode();
       result = 31 * result + (source != null ? source.hashCode() : 0);

--- a/proxy/src/main/java/com/wavefront/agent/histogram/accumulator/AccumulationCache.java
+++ b/proxy/src/main/java/com/wavefront/agent/histogram/accumulator/AccumulationCache.java
@@ -1,16 +1,33 @@
 package com.wavefront.agent.histogram.accumulator;
 
+import com.google.common.annotations.VisibleForTesting;
+
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.CacheWriter;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import com.github.benmanes.caffeine.cache.RemovalCause;
 import com.github.benmanes.caffeine.cache.Ticker;
 import com.tdunning.math.stats.AgentDigest;
+import com.tdunning.math.stats.TDigest;
+import com.wavefront.agent.histogram.TimeProvider;
+import com.wavefront.agent.histogram.Utils;
+import com.yammer.metrics.Metrics;
+import com.yammer.metrics.core.Counter;
+import com.yammer.metrics.core.MetricName;
 
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+import java.util.function.BiFunction;
+import java.util.logging.Logger;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import javax.validation.constraints.NotNull;
+
+import sunnylabs.report.Histogram;
 
 import static com.wavefront.agent.histogram.Utils.HistogramKey;
 
@@ -20,12 +37,27 @@ import static com.wavefront.agent.histogram.Utils.HistogramKey;
  * @author Tim Schmidt (tim@wavefront.com).
  */
 public class AccumulationCache {
+  private final static Logger logger = Logger.getLogger(AccumulationCache.class.getCanonicalName());
+
+  private final Counter binCreatedCounter = Metrics.newCounter(
+      new MetricName("histogram.accumulator", "", "bin_created"));
   private final Cache<HistogramKey, AgentDigest> cache;
+  private final ConcurrentMap<HistogramKey, AgentDigest> backingStore;
+  private final ConcurrentMap<HistogramKey, Long> keyIndex;
 
   public AccumulationCache(
       final ConcurrentMap<HistogramKey, AgentDigest> backingStore,
       final long cacheSize,
       @Nullable Ticker ticker) {
+    this.backingStore = backingStore;
+    this.keyIndex = new ConcurrentHashMap<>(backingStore.size());
+    if (backingStore.size() > 0) {
+      logger.info("Started: Indexing histogram accumulator");
+      for (Map.Entry<HistogramKey, AgentDigest> entry : this.backingStore.entrySet()) {
+        keyIndex.put(entry.getKey(), entry.getValue().getDispatchTimeMillis());
+      }
+      logger.info("Finished: Indexing histogram accumulator");
+    }
     this.cache = Caffeine.newBuilder()
         .maximumSize(cacheSize)
         .ticker((ticker == null ? Ticker.systemTicker() : ticker))
@@ -59,8 +91,117 @@ public class AccumulationCache {
         }).build();
   }
 
-  public Cache<HistogramKey, AgentDigest> getCache() {
+  @VisibleForTesting
+  Cache<HistogramKey, AgentDigest> getCache() {
     return cache;
+  }
+
+  public void put(HistogramKey key, @NotNull AgentDigest value) {
+    cache.asMap().compute(key, (k, v) -> {
+      if (v == null) {
+        keyIndex.put(key, value.getDispatchTimeMillis());
+        return value;
+      } else {
+        keyIndex.compute(key, (k1, v1) -> (
+            v1 != null && v1 > v.getDispatchTimeMillis() ? v1 : v.getDispatchTimeMillis()));
+        v.add(value);
+        return v;
+      }
+    });
+  }
+
+  public void put(HistogramKey key, Double value, short compression, long ttlMillis) {
+    cache.asMap().compute(key, (k, v) -> {
+      if (v == null) {
+        binCreatedCounter.inc();
+        AgentDigest t = new AgentDigest(compression, System.currentTimeMillis() + ttlMillis);
+        keyIndex.compute(key, (k1, v1) -> (
+            v1 != null && v1 > t.getDispatchTimeMillis() ? v1 : t.getDispatchTimeMillis()
+        ));
+        t.add(value);
+        return t;
+      } else {
+        keyIndex.compute(key, (k1, v1) -> (
+            v1 != null && v1 > v.getDispatchTimeMillis() ? v1 : v.getDispatchTimeMillis()
+        ));
+        v.add(value);
+        return v;
+      }
+    });
+  }
+
+  public void put(HistogramKey key, Histogram value, short compression, long ttlMillis) {
+    cache.asMap().compute(key, (k, v) -> {
+      if (v == null) {
+        binCreatedCounter.inc();
+        AgentDigest t = new AgentDigest(compression, System.currentTimeMillis() + ttlMillis);
+        keyIndex.compute(key, (k1, v1) -> (
+            v1 != null && v1 > t.getDispatchTimeMillis() ? v1 : t.getDispatchTimeMillis()));
+        mergeHistogram(t, value);
+        return t;
+      } else {
+        keyIndex.compute(key, (k1, v1) -> (
+            v1 != null && v1 > v.getDispatchTimeMillis() ? v1 : v.getDispatchTimeMillis()));
+        mergeHistogram(v, value);
+        return v;
+      }
+    });
+  }
+
+  public Iterator<HistogramKey> getRipeDigestsIterator(TimeProvider clock) {
+    return new Iterator<HistogramKey>() {
+      private final Iterator<Map.Entry<HistogramKey, Long>> indexIterator = keyIndex.entrySet().iterator();
+      private HistogramKey nextHistogramKey;
+
+      @Override
+      public boolean hasNext() {
+        while (indexIterator.hasNext()) {
+          Map.Entry<Utils.HistogramKey, Long> entry = indexIterator.next();
+          if (entry.getValue() < clock.millisSinceEpoch()) {
+            nextHistogramKey = entry.getKey();
+            return true;
+          }
+        }
+        return false;
+      }
+
+      @Override
+      public HistogramKey next() {
+        return nextHistogramKey;
+      }
+
+      @Override
+      public void remove() {
+        indexIterator.remove();
+      }
+    };
+  }
+
+  public AgentDigest compute(HistogramKey key, BiFunction<? super HistogramKey,? super AgentDigest,
+      ? extends AgentDigest> remappingFunction) {
+    return backingStore.compute(key, remappingFunction);
+  }
+
+  public long size() {
+    return backingStore.size();
+  }
+
+  private static void mergeHistogram(final TDigest target, final Histogram source) {
+    List<Double> means = source.getBins();
+    List<Integer> counts = source.getCounts();
+
+    if (means != null && counts != null) {
+      int len = Math.min(means.size(), counts.size());
+
+      for (int i = 0; i < len; ++i) {
+        Integer count = counts.get(i);
+        Double mean = means.get(i);
+
+        if (count != null && count > 0 && mean != null && Double.isFinite(mean)) {
+          target.add(mean, count);
+        }
+      }
+    }
   }
 
   /**

--- a/proxy/src/test/java/com/wavefront/agent/histogram/accumulator/AccumulationTaskTest.java
+++ b/proxy/src/test/java/com/wavefront/agent/histogram/accumulator/AccumulationTaskTest.java
@@ -18,6 +18,7 @@ import org.junit.Test;
 import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import jersey.repackaged.com.google.common.collect.ImmutableList;
 import sunnylabs.report.ReportPoint;
@@ -38,6 +39,7 @@ public class AccumulationTaskTest {
   private ConcurrentMap<HistogramKey, AgentDigest> out;
   private List<String> badPointsOut;
   private AccumulationTask eventSubject, histoSubject;
+  private AccumulationCache cache;
   private final static long TTL = 30L;
   private final static short COMPRESSION = 100;
 
@@ -57,11 +59,12 @@ public class AccumulationTaskTest {
   private HistogramKey hourKeyA = makeKey("hourKeyA", HOUR);
   private HistogramKey dayKeyA = makeKey("dayKeyA", DAY);
 
-
   @Before
   public void setUp() throws Exception {
+    AtomicInteger timeMillis = new AtomicInteger(0);
     in = new InMemoryObjectQueue<>();
     out = new ConcurrentHashMap<>();
+    cache = new AccumulationCache(out, 0, timeMillis::get);
     badPointsOut = Lists.newArrayList();
 
     PointHandler pointHandler = new PointHandler() {
@@ -83,7 +86,7 @@ public class AccumulationTaskTest {
 
     eventSubject = new AccumulationTask(
         in,
-        out,
+        cache,
         new GraphiteDecoder("unknown", ImmutableList.of()),
         pointHandler,
         Validation.Level.NUMERIC_ONLY,
@@ -93,7 +96,7 @@ public class AccumulationTaskTest {
 
     histoSubject = new AccumulationTask(
         in,
-        out,
+        cache,
         new HistogramDecoder(),
         pointHandler,
         Validation.Level.NUMERIC_ONLY,
@@ -107,6 +110,7 @@ public class AccumulationTaskTest {
     in.add(ImmutableList.of(lineA));
 
     eventSubject.run();
+    cache.getResolveTask().run();
 
     assertThat(badPointsOut).hasSize(0);
     assertThat(out.get(minKeyA)).isNotNull();
@@ -118,6 +122,7 @@ public class AccumulationTaskTest {
     in.add(ImmutableList.of(lineA, lineB, lineC));
 
     eventSubject.run();
+    cache.getResolveTask().run();
 
     assertThat(badPointsOut).hasSize(0);
     assertThat(out.get(minKeyA)).isNotNull();
@@ -136,6 +141,7 @@ public class AccumulationTaskTest {
         "min1 1 " + DEFAULT_TIME_MILLIS));
 
     eventSubject.run();
+    cache.getResolveTask().run();
 
     HistogramKey min0 = Utils.makeKey(ReportPoint.newBuilder()
         .setMetric("min0")
@@ -159,6 +165,7 @@ public class AccumulationTaskTest {
     in.add(ImmutableList.of(lineA, lineA, lineA));
 
     eventSubject.run();
+    cache.getResolveTask().run();
 
     assertThat(out.get(minKeyA)).isNotNull();
     assertThat(out.get(minKeyA).size()).isEqualTo(3);
@@ -169,6 +176,7 @@ public class AccumulationTaskTest {
     in.add(ImmutableList.of("noTimeKey 100"));
 
     eventSubject.run();
+    cache.getResolveTask().run();
 
     assertThat(out).hasSize(1);
   }
@@ -178,6 +186,7 @@ public class AccumulationTaskTest {
     in.add(ImmutableList.of("This is not really a valid sample", lineA, lineA, lineA));
 
     eventSubject.run();
+    cache.getResolveTask().run();
 
     assertThat(badPointsOut).hasSize(1);
     assertThat(badPointsOut.get(0)).contains("This is not really a valid sample");
@@ -191,6 +200,7 @@ public class AccumulationTaskTest {
     in.add(ImmutableList.of(histoMinLineA));
 
     histoSubject.run();
+    cache.getResolveTask().run();
 
     assertThat(badPointsOut).hasSize(0);
     assertThat(out.get(minKeyA)).isNotNull();
@@ -202,6 +212,7 @@ public class AccumulationTaskTest {
     in.add(ImmutableList.of(histoMinLineA, histoMinLineA, histoMinLineA));
 
     histoSubject.run();
+    cache.getResolveTask().run();
 
     assertThat(badPointsOut).hasSize(0);
     assertThat(out.get(minKeyA)).isNotNull();
@@ -213,6 +224,7 @@ public class AccumulationTaskTest {
     in.add(ImmutableList.of(histoMinLineA, histoHourLineA, histoDayLineA));
 
     histoSubject.run();
+    cache.getResolveTask().run();
 
     assertThat(badPointsOut).hasSize(0);
     assertThat(out.get(minKeyA)).isNotNull();
@@ -228,6 +240,7 @@ public class AccumulationTaskTest {
     in.add(ImmutableList.of(histoMinLineA, histoMinLineB, histoMinLineA, histoMinLineB));
 
     histoSubject.run();
+    cache.getResolveTask().run();
 
     assertThat(badPointsOut).hasSize(0);
     assertThat(out.get(minKeyA)).isNotNull();
@@ -241,6 +254,7 @@ public class AccumulationTaskTest {
     in.add(ImmutableList.of(histoMinLineA, "not really valid...", histoMinLineA));
 
     histoSubject.run();
+    cache.getResolveTask().run();
 
     assertThat(badPointsOut).hasSize(1);
     assertThat(badPointsOut.get(0)).contains("not really valid...");


### PR DESCRIPTION
- Separate Chronicle Maps with their own settings for different aggregation intervals
- Configuration setting to bypass Caffeine memory cache to reduce memory use for "many time series" use case (as opposed to "few time series, very high frequency data" use case). 
- Persist Chronicle Map settings and re-initialize accumulator maps with new settings and migrate data when config settings change  
- Allow Chronicle Map growth beyond originally configured values (+ log a warning every 10 seconds if it exceeds 1.5x the originally configured size)
- Maintain separate timestamp index on Chronicle Map to avoid iterating through the entire collection of AgentDigest values as it triggers deserialization
- Better hash function for histogramKey