### PR TITLE
Shell script for wavefront homebrew installation

### DIFF
--- a/proxy/brew/wfproxy
+++ b/proxy/brew/wfproxy
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# Simple wrapper script for the wavefront proxy homebrew installation.
+
+# resolve links - $0 may be a softlink                                                                               
+CMD="$0"
+while [ -h "$CMD" ]; do                                                                                              
+  ls=`ls -ld "$CMD"`                                                                                                 
+  link=`expr "$ls" : '.*-> \(.*\)$'`
+  if expr "$link" : '/.*' > /dev/null; then                                                                          
+    CMD="$link"
+  else 
+    CMD=`dirname "$CMD"`/"$link"
+  fi
+done
+
+CMDDIR=`dirname "$CMD"`                                                                                              
+
+java -jar $CMDDIR/../lib/proxy-uber.jar "$@"


### PR DESCRIPTION
Added a basic shell script for the Homebrew installation of the proxy. This will be installed under `/usr/local/bin/wfproxy`.

Had discussed out of band with Mori and he suggested to put in a new brew subdirectory under java/proxy.

