### PR TITLE
Bring back maven-shade for uber jar building

### DIFF
--- a/proxy/pom.xml
+++ b/proxy/pom.xml
@@ -233,6 +233,28 @@
         </configuration>
       </plugin>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <version>3.0.0</version>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <configuration>
+              <finalName>${project.artifactId}-${project.version}-uber</finalName>
+              <transformers>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                  <mainClass>com.wavefront.agent.PushAgent</mainClass>
+                </transformer>
+              </transformers>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.1</version>
         <configuration>


### PR DESCRIPTION
It looks like the removal of maven-shade plugin broke the .rpm/.deb packaging process.
Before proxy 3.17 uber jars were built using maven-assembly plugin, however, we are using a newer version of maven-assembly now that no longer supports custom output file names; and maven-shade seems to be the officially recommended way of building uber jars. 