### PR TITLE
Changed the proxy behavior so that if the agent_configuration.histogram_disabled, then don't ingest histogram points

### DIFF
--- a/java-lib/src/main/java/com/wavefront/api/agent/AgentConfiguration.java
+++ b/java-lib/src/main/java/com/wavefront/api/agent/AgentConfiguration.java
@@ -34,6 +34,9 @@ public class AgentConfiguration {
   private Double retryBackoffBaseSeconds;
   private Boolean shutOffAgents = false;
   private Boolean showTrialExpired = false;
+  // If the value is true, then histogram feature is disabled.
+  // If the value is null or false, then histograms are not disabled i.e. enabled (default behavior)
+  private Boolean histogramDisabled;
 
   public Boolean getCollectorSetsRetryBackoff() {
     return collectorSetsRetryBackoff;
@@ -95,6 +98,14 @@ public class AgentConfiguration {
 
   public void setShowTrialExpired(Boolean trialExpired) {
     this.showTrialExpired = trialExpired;
+  }
+
+  public Boolean getHistogramDisabled() {
+    return histogramDisabled;
+  }
+
+  public void setHistogramDisabled(Boolean histogramDisabled) {
+    this.histogramDisabled = histogramDisabled;
   }
 
   public void validate(boolean local) {

--- a/java-lib/src/main/java/com/wavefront/ingester/HistogramDecoder.java
+++ b/java-lib/src/main/java/com/wavefront/ingester/HistogramDecoder.java
@@ -21,7 +21,7 @@ public class HistogramDecoder implements Decoder<String> {
       .whiteSpace()
       .binType()
       .whiteSpace()
-      .appendTimestamp()
+      .appendOptionalTimestamp()
       .adjustTimestamp()
       .whiteSpace()
       .centroids()

--- a/java-lib/src/test/java/com/wavefront/ingester/HistogramDecoderTest.java
+++ b/java-lib/src/test/java/com/wavefront/ingester/HistogramDecoderTest.java
@@ -1,5 +1,7 @@
 package com.wavefront.ingester;
 
+import com.wavefront.common.Clock;
+
 import org.apache.commons.lang.time.DateUtils;
 import org.junit.Test;
 
@@ -154,12 +156,42 @@ public class HistogramDecoderTest {
     decoder.decodeReportPoints("1471988653 #3 123.237 TestMetric source=Test tag=value", out, "customer");
   }
 
-  @Test(expected = RuntimeException.class)
+  @Test
   public void testMissingTimestamp() {
+    //Note - missingTimestamp to port 40,000 is no longer invalid - see MONIT-6430 for more details
     HistogramDecoder decoder = new HistogramDecoder();
     List<ReportPoint> out = new ArrayList<>();
 
     decoder.decodeReportPoints("!M #3 123.237 TestMetric source=Test tag=value", out, "customer");
+
+    assertThat(out).isNotEmpty();
+    long expectedTimestamp = Clock.now();
+
+    ReportPoint p = out.get(0);
+    assertThat(p.getMetric()).isEqualTo("TestMetric");
+
+    assertThat(p.getValue()).isNotNull();
+    assertThat(p.getValue().getClass()).isEqualTo(Histogram.class);
+
+    // Should be converted to Millis and pinned to the beginning of the corresponding minute
+    long duration = ((Histogram) p.getValue()).getDuration();
+    expectedTimestamp = (expectedTimestamp / duration) * duration;
+    assertThat(p.getTimestamp()).isEqualTo(expectedTimestamp);
+
+    assertThat(p.getHost()).isEqualTo("Test");
+    assertThat(p.getTable()).isEqualTo("customer");
+    assertThat(p.getAnnotations()).isNotNull();
+    assertThat(p.getAnnotations()).containsEntry("_tag", "value");
+
+    Histogram h = (Histogram) p.getValue();
+
+    assertThat(h.getDuration()).isEqualTo(DateUtils.MILLIS_PER_MINUTE);
+    assertThat(h.getBins()).isNotNull();
+    assertThat(h.getBins()).isNotEmpty();
+    assertThat(h.getBins()).containsExactly(123.237D);
+    assertThat(h.getCounts()).isNotNull();
+    assertThat(h.getCounts()).isNotEmpty();
+    assertThat(h.getCounts()).containsExactly(3);
   }
 
   @Test(expected = RuntimeException.class)
@@ -170,12 +202,43 @@ public class HistogramDecoderTest {
     decoder.decodeReportPoints("!M 1471988653 TestMetric source=Test tag=value", out, "customer");
   }
 
-  @Test(expected = RuntimeException.class)
+  @Test
   public void testMissingMean() {
+    //Note - missingTimestamp to port 40,000 is no longer invalid - see MONIT-6430 for more details
+    // as a side-effect of that, this test no longer fails!!!
     HistogramDecoder decoder = new HistogramDecoder();
     List<ReportPoint> out = new ArrayList<>();
 
     decoder.decodeReportPoints("!M #3 1471988653 TestMetric source=Test tag=value", out, "customer");
+
+    assertThat(out).isNotEmpty();
+    long expectedTimestamp = Clock.now();
+
+    ReportPoint p = out.get(0);
+    assertThat(p.getMetric()).isEqualTo("TestMetric");
+
+    assertThat(p.getValue()).isNotNull();
+    assertThat(p.getValue().getClass()).isEqualTo(Histogram.class);
+
+    // Should be converted to Millis and pinned to the beginning of the corresponding minute
+    long duration = ((Histogram) p.getValue()).getDuration();
+    expectedTimestamp = (expectedTimestamp / duration) * duration;
+    assertThat(p.getTimestamp()).isEqualTo(expectedTimestamp);
+
+    assertThat(p.getHost()).isEqualTo("Test");
+    assertThat(p.getTable()).isEqualTo("customer");
+    assertThat(p.getAnnotations()).isNotNull();
+    assertThat(p.getAnnotations()).containsEntry("_tag", "value");
+
+    Histogram h = (Histogram) p.getValue();
+
+    assertThat(h.getDuration()).isEqualTo(DateUtils.MILLIS_PER_MINUTE);
+    assertThat(h.getBins()).isNotNull();
+    assertThat(h.getBins()).isNotEmpty();
+    assertThat(h.getBins()).containsExactly(1471988653.0);
+    assertThat(h.getCounts()).isNotNull();
+    assertThat(h.getCounts()).isNotEmpty();
+    assertThat(h.getCounts()).containsExactly(3);
   }
 
   @Test(expected = RuntimeException.class)

--- a/proxy/src/main/java/com/wavefront/agent/AbstractAgent.java
+++ b/proxy/src/main/java/com/wavefront/agent/AbstractAgent.java
@@ -582,7 +582,7 @@ public abstract class AbstractAgent {
 
   // Will be updated inside processConfiguration method and the new configuration is periodically
   // loaded from the server by invoking agentAPI.checkin
-  protected AtomicBoolean histogramDisabled = new AtomicBoolean(false);
+  protected final AtomicBoolean histogramDisabled = new AtomicBoolean(false);
 
   /**
    * Executors for support tasks.

--- a/proxy/src/main/java/com/wavefront/agent/AbstractAgent.java
+++ b/proxy/src/main/java/com/wavefront/agent/AbstractAgent.java
@@ -83,6 +83,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.logging.Level;
@@ -578,6 +579,10 @@ public abstract class AbstractAgent {
 
   protected final boolean localAgent;
   protected final boolean pushAgent;
+
+  // Will be updated inside processConfiguration method and the new configuration is periodically
+  // loaded from the server by invoking agentAPI.checkin
+  protected AtomicBoolean histogramDisabled = new AtomicBoolean(false);
 
   /**
    * Executors for support tasks.

--- a/proxy/src/main/java/com/wavefront/agent/PostSourceTagTimedTask.java
+++ b/proxy/src/main/java/com/wavefront/agent/PostSourceTagTimedTask.java
@@ -46,7 +46,7 @@ public class PostSourceTagTimedTask implements Runnable {
   private final List<ReportSourceTag> blockedSamples = new ArrayList<>();
   private final Object blockedSamplesMutex = new Object();
 
-  private RateLimiter warningMessageRateLimiter = RateLimiter.create(0.2);
+  private final RateLimiter warningMessageRateLimiter = RateLimiter.create(0.2);
 
   private final Counter sourceTagsReceived;
   private final Counter sourceTagsAttempted;

--- a/proxy/src/main/java/com/wavefront/agent/PushAgent.java
+++ b/proxy/src/main/java/com/wavefront/agent/PushAgent.java
@@ -574,7 +574,8 @@ public class PushAgent extends AbstractAgent {
       histogramScanExecutor.scheduleWithFixedDelay(scanTask,
           histogramProcessingQueueScanInterval, histogramProcessingQueueScanInterval, TimeUnit.MILLISECONDS);
 
-      QueuingChannelHandler<String> inputHandler = new QueuingChannelHandler<>(receiveTape, pushFlushMaxPoints.get());
+      QueuingChannelHandler<String> inputHandler = new QueuingChannelHandler<>(receiveTape,
+          pushFlushMaxPoints.get(), histogramDisabled);
       handlers.add(inputHandler);
       histogramFlushExecutor.scheduleWithFixedDelay(inputHandler.getBufferFlushTask(),
           histogramReceiveBufferFlushInterval, histogramReceiveBufferFlushInterval, TimeUnit.MILLISECONDS);
@@ -619,6 +620,10 @@ public class PushAgent extends AbstractAgent {
         // restores the agent setting
         retryBackoffBaseSeconds.set(retryBackoffBaseSecondsInitialValue);
         logger.fine("Agent backoff base set to (locally) " + retryBackoffBaseSeconds.get());
+      }
+
+      if (config.getHistogramDisabled() != null) {
+        histogramDisabled.set(config.getHistogramDisabled());
       }
     } catch (RuntimeException e) {
       // cannot throw or else configuration update thread would die.

--- a/proxy/src/main/java/com/wavefront/agent/PushAgent.java
+++ b/proxy/src/main/java/com/wavefront/agent/PushAgent.java
@@ -42,6 +42,7 @@ import com.wavefront.ingester.TcpIngester;
 
 import net.openhft.chronicle.map.ChronicleMap;
 
+import org.apache.commons.lang.BooleanUtils;
 import org.logstash.beats.Server;
 
 import java.io.File;
@@ -622,9 +623,7 @@ public class PushAgent extends AbstractAgent {
         logger.fine("Agent backoff base set to (locally) " + retryBackoffBaseSeconds.get());
       }
 
-      if (config.getHistogramDisabled() != null) {
-        histogramDisabled.set(config.getHistogramDisabled());
-      }
+      histogramDisabled.set(BooleanUtils.toBoolean(config.getHistogramDisabled()));
     } catch (RuntimeException e) {
       // cannot throw or else configuration update thread would die.
     }

--- a/proxy/src/main/java/com/wavefront/agent/histogram/QueuingChannelHandler.java
+++ b/proxy/src/main/java/com/wavefront/agent/histogram/QueuingChannelHandler.java
@@ -3,9 +3,14 @@ package com.wavefront.agent.histogram;
 import com.google.common.base.Preconditions;
 
 import com.squareup.tape.ObjectQueue;
+import com.yammer.metrics.Metrics;
+import com.yammer.metrics.core.Counter;
+import com.yammer.metrics.core.MetricName;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.logging.Logger;
 
 import javax.validation.constraints.NotNull;
 
@@ -20,16 +25,21 @@ import io.netty.channel.SimpleChannelInboundHandler;
  */
 @ChannelHandler.Sharable
 public class QueuingChannelHandler<T> extends SimpleChannelInboundHandler<Object> {
+  protected static final Logger logger = Logger.getLogger(QueuingChannelHandler.class.getCanonicalName());
   private final ObjectQueue<List<T>> tape;
   private List<T> buffer;
   private final int maxCapacity;
+  private final AtomicBoolean histogramDisabled;
+  private final Counter discardedHistogramPointsCounter = Metrics.newCounter(new MetricName(
+      "histogram.ingester.disabled", "", "discarded_points"));
 
-  public QueuingChannelHandler(@NotNull ObjectQueue<List<T>> tape, int maxCapacity) {
+  public QueuingChannelHandler(@NotNull ObjectQueue<List<T>> tape, int maxCapacity, AtomicBoolean histogramDisabled) {
     Preconditions.checkNotNull(tape);
     Preconditions.checkArgument(maxCapacity > 0);
     this.tape = tape;
     this.buffer = new ArrayList<>();
     this.maxCapacity = maxCapacity;
+    this.histogramDisabled = histogramDisabled;
   }
 
   private void ship() {
@@ -48,8 +58,15 @@ public class QueuingChannelHandler<T> extends SimpleChannelInboundHandler<Object
   }
 
   private void innerAdd(T t) {
-    synchronized (this) {
-      buffer.add(t);
+    if (histogramDisabled.get()) {
+      // if histogram feature is disabled on the server increment counter and log it ...
+      logger.info("Ingested point discarded because histogram feature is disabled on the server");
+      discardedHistogramPointsCounter.inc();
+    } else {
+      // histograms are not disabled on the server, so add the input to the buffer
+      synchronized (this) {
+        buffer.add(t);
+      }
     }
   }
 

--- a/proxy/src/main/java/com/wavefront/agent/histogram/QueuingChannelHandler.java
+++ b/proxy/src/main/java/com/wavefront/agent/histogram/QueuingChannelHandler.java
@@ -61,7 +61,7 @@ public class QueuingChannelHandler<T> extends SimpleChannelInboundHandler<Object
   }
 
   private void innerAdd(T t) {
-    if (!histogramDisabled.get()) {
+    if (histogramDisabled.get()) {
       // if histogram feature is disabled on the server increment counter and log it every 25 times ...
       discardedHistogramPointsCounter.inc();
       if (channelReadCounter == 0) {


### PR DESCRIPTION
- Changed the proxy behavior so that if the agent_configuration.histogram_disabled then don't bother sending the histogram points to the server.
- Reject the points at QueuingChannelHandler.channelRead phase itself. The agent configuration is periodically polled in the checkin API and updated on the proxy.