### PR TITLE
MONIT-6560, MONIT-6532: Fixed the SourceTag and SourceDescription ingestion from proxy

### DIFF
--- a/java-lib/src/main/java/com/wavefront/api/WavefrontAPI.java
+++ b/java-lib/src/main/java/com/wavefront/api/WavefrontAPI.java
@@ -145,22 +145,25 @@ public interface WavefrontAPI {
   @DELETE
   @Path("v2/source/{id}/tag/{tagValue}")
   @Produces(MediaType.APPLICATION_JSON)
-  Response removeTag(@PathParam("id") String id, @PathParam("tagValue") String tagValue);
+  Response removeTag(@PathParam("id") String id, @QueryParam("t") String token,
+                     @PathParam("tagValue") String tagValue);
 
   @DELETE
   @Path("v2/source/{id}/description")
   @Produces(MediaType.APPLICATION_JSON)
-  Response removeDescription(@PathParam("id") String id);
+  Response removeDescription(@PathParam("id") String id, @QueryParam("t") String token);
 
   @POST
   @Path("v2/source/{id}/tag")
   @Consumes(MediaType.APPLICATION_JSON)
   @Produces(MediaType.APPLICATION_JSON)
-  Response setTags(@PathParam ("id") String id, List<String> tagValuesToSet);
+  Response setTags(@PathParam ("id") String id, @QueryParam("t") String token,
+                   List<String> tagValuesToSet);
 
   @POST
   @Path("v2/source/{id}/description")
   @Consumes(MediaType.APPLICATION_JSON)
   @Produces(MediaType.APPLICATION_JSON)
-  Response setDescription(@PathParam("id") String id, String description);
+  Response setDescription(@PathParam("id") String id, @QueryParam("t") String token,
+                          String description);
 }

--- a/proxy/src/main/java/com/wavefront/agent/AbstractAgent.java
+++ b/proxy/src/main/java/com/wavefront/agent/AbstractAgent.java
@@ -128,7 +128,7 @@ public abstract class AbstractAgent {
 
   @Parameter(names = {"-t", "--token"}, description =
       "Token to auto-register agent with an account")
-  private String token = null;
+  protected String token = null;
 
   @Parameter(names = {"--testLogs"}, description = "Run interactive session for crafting logsIngestionConfig.yaml")
   private boolean testLogs = false;
@@ -189,7 +189,7 @@ public abstract class AbstractAgent {
       "2878.")
   protected String pushListenerPorts = "" + GRAPHITE_LISTENING_PORT;
 
-  @Parameter(names = {"--metadataListernerPorts"}, description = "Comma-separated list of ports " +
+  @Parameter(names = {"--metadataListenerPorts"}, description = "Comma-separated list of ports " +
       "to listen on for metadata. Defaults to " + METADATA_LISTENING_PORT + ".")
   protected String metadataListenerPorts = "" + METADATA_LISTENING_PORT;
 
@@ -1389,8 +1389,8 @@ public abstract class AbstractAgent {
     logger.info("Using " + flushThreads + " flush threads to send batched data to Wavefront for " +
         "data received on port: " + port);
     for (int i = 0; i < flushThreads; i++) {
-      final PostSourceTagTimedTask postSourceTagTimedTask = new PostSourceTagTimedTask(agentAPI,
-          pushLogLevel, port, i);
+      final PostSourceTagTimedTask postSourceTagTimedTask = new PostSourceTagTimedTask(agentAPI, pushLogLevel, port,
+          i, pushFlushInterval.get(), token);
       toReturn[i] = postSourceTagTimedTask;
       managedSourceTagTasks.add(postSourceTagTimedTask);
     }

--- a/proxy/src/main/java/com/wavefront/agent/PostSourceTagTimedTask.java
+++ b/proxy/src/main/java/com/wavefront/agent/PostSourceTagTimedTask.java
@@ -98,7 +98,6 @@ public class PostSourceTagTimedTask implements Runnable {
 
   @Override
   public void run() {
-    long nextRunMillis = this.pushFlushInterval;
     try {
       List<ReportSourceTag> current = createAgentPostBatch();
       batchesSent.inc();
@@ -134,7 +133,7 @@ public class PostSourceTagTimedTask implements Runnable {
                 break;
               default:
                 logger.warning("None of the literals matched. Expected SourceTag or " +
-                    "SourceDescription.");
+                    "SourceDescription. Input = " + sourceTag);
             }
             this.sourceTagsAttempted.inc();
             if (response.getStatus() == Response.Status.NOT_ACCEPTABLE.getStatusCode()) {
@@ -160,7 +159,7 @@ public class PostSourceTagTimedTask implements Runnable {
     } catch (Throwable t) {
       logger.log(Level.SEVERE, "Unexpected error in flush loop", t);
     } finally {
-      scheduler.schedule(this, nextRunMillis, TimeUnit.MILLISECONDS);
+      scheduler.schedule(this, this.pushFlushInterval, TimeUnit.MILLISECONDS);
     }
   }
 

--- a/proxy/src/main/java/com/wavefront/agent/PushAgent.java
+++ b/proxy/src/main/java/com/wavefront/agent/PushAgent.java
@@ -198,12 +198,24 @@ public class PushAgent extends AbstractAgent {
     }
 
     // ------ Start the listener for source metadata, such as sourceTags and description ----------
-    if (metadataListenerPorts != null) {
-      Iterable<String> ports = Splitter.on(",").omitEmptyStrings().trimResults().split
-          (metadataListenerPorts);
+    if (metadataListenerPorts != null && token != null) {
+      Iterable<String> ports = Splitter.on(",").omitEmptyStrings().trimResults().split(metadataListenerPorts);
       for (String port : ports) {
         startMetadataListener(port);
+        logger.info("listening on port: " + port + " for metadata (e.g. SourceTag and " +
+            "SourceDescription).");
       }
+    } else {
+      StringBuilder strBuilder = new StringBuilder();
+      if (metadataListenerPorts == null)
+        strBuilder.append("metadata listener port is null");
+      if (token == null) {
+        if (strBuilder.length() != 0)
+          strBuilder.append(" and ");
+        strBuilder.append("token is null");
+      }
+      logger.warning("Could not start the metadata listener because " + strBuilder.toString() +
+          ".");
     }
 
     GraphiteFormatter graphiteFormatter = null;

--- a/proxy/src/main/java/com/wavefront/agent/PushAgent.java
+++ b/proxy/src/main/java/com/wavefront/agent/PushAgent.java
@@ -43,6 +43,7 @@ import com.wavefront.ingester.TcpIngester;
 import net.openhft.chronicle.map.ChronicleMap;
 
 import org.apache.commons.lang.BooleanUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.logstash.beats.Server;
 
 import java.io.File;
@@ -198,7 +199,7 @@ public class PushAgent extends AbstractAgent {
     }
 
     // ------ Start the listener for source metadata, such as sourceTags and description ----------
-    if (metadataListenerPorts != null && token != null) {
+    if (!StringUtils.isEmpty(metadataListenerPorts) && !StringUtils.isEmpty(token)) {
       Iterable<String> ports = Splitter.on(",").omitEmptyStrings().trimResults().split(metadataListenerPorts);
       for (String port : ports) {
         startMetadataListener(port);
@@ -207,9 +208,9 @@ public class PushAgent extends AbstractAgent {
       }
     } else {
       StringBuilder strBuilder = new StringBuilder();
-      if (metadataListenerPorts == null)
+      if (StringUtils.isEmpty(metadataListenerPorts))
         strBuilder.append("metadata listener port is null");
-      if (token == null) {
+      if (StringUtils.isEmpty(token)) {
         if (strBuilder.length() != 0)
           strBuilder.append(" and ");
         strBuilder.append("token is null");

--- a/proxy/src/main/java/com/wavefront/agent/QueuedAgentService.java
+++ b/proxy/src/main/java/com/wavefront/agent/QueuedAgentService.java
@@ -230,7 +230,7 @@ public class QueuedAgentService implements ForceQueueEnabledAgentAPI {
       // rate-limited on the server-side as well. We don't want the retry logic to keep hitting
       // that rate-limit.
       Runnable sourceTagTaskRunnable = createRunnable(executorService, splitPushWhenRateLimited,
-          threadId, sourceTagQueue, RecyclableRateLimiter.create(1,1));
+          threadId, sourceTagQueue, RecyclableRateLimiter.create(1, 1));
       executorService.schedule(sourceTagTaskRunnable, (long) (Math.random() * retryThreads),
           TimeUnit.SECONDS);
       sourceTagTaskQueues.add(sourceTagQueue);

--- a/proxy/src/main/java/com/wavefront/agent/api/ForceQueueEnabledAgentAPI.java
+++ b/proxy/src/main/java/com/wavefront/agent/api/ForceQueueEnabledAgentAPI.java
@@ -26,11 +26,11 @@ public interface ForceQueueEnabledAgentAPI extends WavefrontAPI {
                         String pushData,
                         boolean forceToQueue);
 
-  Response removeTag(String id, String tagValue, boolean forceToQueue);
+  Response removeTag(String id, String token, String tagValue, boolean forceToQueue);
 
-  Response setTags(String id, List<String> tagsValuesToSet, boolean forceToQueue);
+  Response setTags(String id, String token, List<String> tagsValuesToSet, boolean forceToQueue);
 
-  Response removeDescription(String id, boolean forceToQueue);
+  Response removeDescription(String id, String token, boolean forceToQueue);
 
-  Response setDescription(String id, String desc, boolean forceToQueue);
+  Response setDescription(String id, String token, String desc, boolean forceToQueue);
 }

--- a/proxy/src/test/java/com/wavefront/agent/QueuedAgentServiceTest.java
+++ b/proxy/src/test/java/com/wavefront/agent/QueuedAgentServiceTest.java
@@ -12,6 +12,7 @@ import com.wavefront.ingester.StringLineIngester;
 import net.jcip.annotations.NotThreadSafe;
 
 import org.apache.commons.lang.RandomStringUtils;
+import org.apache.commons.lang.StringUtils;
 import org.easymock.EasyMock;
 import org.junit.Before;
 import org.junit.Test;
@@ -78,9 +79,9 @@ public class QueuedAgentServiceTest {
   public void postSourceTagDataPoint() throws Exception {
     String id = "localhost";
     String tagValue = "sourceTag1";
-    EasyMock.expect(mockAgentAPI.removeTag(id, tagValue)).andReturn(Response.ok().build()).once();
+    EasyMock.expect(mockAgentAPI.removeTag(id, StringUtils.EMPTY, tagValue)).andReturn(Response.ok().build()).once();
     EasyMock.replay(mockAgentAPI);
-    Response response = queuedAgentService.removeTag(id, tagValue);
+    Response response = queuedAgentService.removeTag(id, StringUtils.EMPTY, tagValue);
     EasyMock.verify(mockAgentAPI);
     assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
   }
@@ -92,7 +93,7 @@ public class QueuedAgentServiceTest {
   public void postSourceTagIntoQueue() {
     String id = "localhost";
     String tagValue = "sourceTag1";
-    Response response = queuedAgentService.removeTag(id, tagValue, true);
+    Response response = queuedAgentService.removeTag(id, StringUtils.EMPTY, tagValue, true);
     assertEquals(Response.Status.NOT_ACCEPTABLE.getStatusCode(), response.getStatus());
     assertEquals(1, queuedAgentService.getQueuedSourceTagTasksCount());
   }
@@ -105,9 +106,9 @@ public class QueuedAgentServiceTest {
   @Test
   public void removeSourceDescription() throws Exception {
     String id = "dummy";
-    EasyMock.expect(mockAgentAPI.removeDescription(id)).andReturn(Response.ok().build()).once();
+    EasyMock.expect(mockAgentAPI.removeDescription(id, StringUtils.EMPTY)).andReturn(Response.ok().build()).once();
     EasyMock.replay(mockAgentAPI);
-    Response response = queuedAgentService.removeDescription(id);
+    Response response = queuedAgentService.removeDescription(id, StringUtils.EMPTY);
     EasyMock.verify(mockAgentAPI);
     assertEquals("Response code was incorrect.", Response.Status.OK.getStatusCode(), response
         .getStatus());
@@ -123,7 +124,7 @@ public class QueuedAgentServiceTest {
   public void postSourceDescriptionIntoQueue() throws Exception {
     String id = "localhost";
     String desc = "A Description";
-    Response response = queuedAgentService.setDescription(id, desc, true);
+    Response response = queuedAgentService.setDescription(id, StringUtils.EMPTY, desc, true);
     assertEquals("Response code did not match", Response.Status.NOT_ACCEPTABLE.getStatusCode(),
         response.getStatus());
     assertEquals("No task found in the backlog queue", 1, queuedAgentService
@@ -139,10 +140,10 @@ public class QueuedAgentServiceTest {
   public void postSourceTagsDataPoint() throws Exception {
     String id = "dummy";
     String tags[] = new String[]{"tag1", "tag2", "tag3"};
-    EasyMock.expect(mockAgentAPI.setTags(id, Arrays.asList(tags))).andReturn(Response.ok().build
-        ()).once();
+    EasyMock.expect(mockAgentAPI.setTags(id, StringUtils.EMPTY,
+        Arrays.asList(tags))).andReturn(Response.ok().build()).once();
     EasyMock.replay(mockAgentAPI);
-    Response response = queuedAgentService.setTags(id, Arrays.asList(tags));
+    Response response = queuedAgentService.setTags(id, StringUtils.EMPTY, Arrays.asList(tags));
     EasyMock.verify(mockAgentAPI);
     assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
   }
@@ -157,10 +158,10 @@ public class QueuedAgentServiceTest {
   public void postSourceDescriptionData() throws Exception {
     String id = "dummy";
     String desc = "A Description";
-    EasyMock.expect(mockAgentAPI.setDescription(id, desc)).andReturn(Response.ok()
+    EasyMock.expect(mockAgentAPI.setDescription(id, StringUtils.EMPTY, desc)).andReturn(Response.ok()
         .build()).once();
     EasyMock.replay(mockAgentAPI);
-    Response response = queuedAgentService.setDescription(id, desc);
+    Response response = queuedAgentService.setDescription(id, StringUtils.EMPTY, desc);
     EasyMock.verify(mockAgentAPI);
     assertEquals("Response code did not match.", Response.Status.OK.getStatusCode(),
         response.getStatus());
@@ -177,14 +178,14 @@ public class QueuedAgentServiceTest {
     // set up the mocks
     String id = "localhost";
     String tagValue = "sourceTag1";
-    EasyMock.expect(mockAgentAPI.removeTag(id, tagValue)).andReturn(Response.status(Response
+    EasyMock.expect(mockAgentAPI.removeTag(id, StringUtils.EMPTY, tagValue)).andReturn(Response.status(Response
         .Status.NOT_ACCEPTABLE).build())
         .once();
-    EasyMock.expect(mockAgentAPI.removeTag(id, tagValue)).andReturn(Response.status(Response
+    EasyMock.expect(mockAgentAPI.removeTag(id, StringUtils.EMPTY, tagValue)).andReturn(Response.status(Response
         .Status.OK).build()).once();
     EasyMock.replay(mockAgentAPI);
     // call the api
-    Response response = queuedAgentService.removeTag(id, tagValue);
+    Response response = queuedAgentService.removeTag(id, StringUtils.EMPTY, tagValue);
     // verify
     assertEquals(Response.Status.NOT_ACCEPTABLE.getStatusCode(), response.getStatus());
     assertEquals(1, queuedAgentService.getQueuedSourceTagTasksCount());
@@ -204,12 +205,12 @@ public class QueuedAgentServiceTest {
   public void postSourceTagsAndHandle406Response() throws Exception {
     String id = "dummy";
     String tags[] = new String[]{"tag1", "tag2", "tag3"};
-    EasyMock.expect(mockAgentAPI.setTags(id, Arrays.asList(tags))).andReturn(Response.status
-        (Response.Status.NOT_ACCEPTABLE).build()).once();
-    EasyMock.expect(mockAgentAPI.setTags(id, Arrays.asList(tags))).andReturn(Response.status
-        (Response.Status.OK).build()).once();
+    EasyMock.expect(mockAgentAPI.setTags(id, StringUtils.EMPTY, Arrays.asList(tags))).andReturn(
+        Response.status(Response.Status.NOT_ACCEPTABLE).build()).once();
+    EasyMock.expect(mockAgentAPI.setTags(id, StringUtils.EMPTY, Arrays.asList(tags))).andReturn(
+        Response.status(Response.Status.OK).build()).once();
     EasyMock.replay(mockAgentAPI);
-    Response response = queuedAgentService.setTags(id, Arrays.asList(tags));
+    Response response = queuedAgentService.setTags(id, StringUtils.EMPTY, Arrays.asList(tags));
     // verify
     assertEquals(Response.Status.NOT_ACCEPTABLE.getStatusCode(), response.getStatus());
     assertEquals(1, queuedAgentService.getQueuedSourceTagTasksCount());
@@ -229,14 +230,14 @@ public class QueuedAgentServiceTest {
   public void postSourceDescriptionAndHandle406Response() throws Exception {
     String id = "dummy";
     String description = "A Description";
-    EasyMock.expect(mockAgentAPI.setDescription(id, description)).andReturn(Response
+    EasyMock.expect(mockAgentAPI.setDescription(id, StringUtils.EMPTY, description)).andReturn(Response
         .status
         (Response.Status.NOT_ACCEPTABLE).build()).once();
-    EasyMock.expect(mockAgentAPI.setDescription(id, description)).andReturn(Response
+    EasyMock.expect(mockAgentAPI.setDescription(id, StringUtils.EMPTY, description)).andReturn(Response
         .status
         (Response.Status.OK).build()).once();
     EasyMock.replay(mockAgentAPI);
-    Response response = queuedAgentService.setDescription(id, description);
+    Response response = queuedAgentService.setDescription(id, StringUtils.EMPTY, description);
     // verify
     assertEquals(Response.Status.NOT_ACCEPTABLE.getStatusCode(), response.getStatus());
     assertEquals(1, queuedAgentService.getQueuedSourceTagTasksCount());

--- a/proxy/src/test/java/com/wavefront/agent/SourceTagHandlerTest.java
+++ b/proxy/src/test/java/com/wavefront/agent/SourceTagHandlerTest.java
@@ -2,6 +2,7 @@ package com.wavefront.agent;
 
 import com.wavefront.agent.api.ForceQueueEnabledAgentAPI;
 
+import org.apache.commons.lang3.StringUtils;
 import org.easymock.EasyMock;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -61,12 +62,9 @@ public class SourceTagHandlerTest {
   private static PostSourceTagTimedTask[] getSourceTagFlushTasks(int port) {
     int flushThreads = 2;
     PostSourceTagTimedTask[] toReturn = new PostSourceTagTimedTask[flushThreads];
-    ScheduledExecutorService es = Executors.newScheduledThreadPool(flushThreads);
     for (int i = 0; i < flushThreads; i++) {
       final PostSourceTagTimedTask postSourceTagTimedTask = new PostSourceTagTimedTask(mockAgentAPI,
-          "NONE", port, i);
-      es.scheduleWithFixedDelay(postSourceTagTimedTask, 1000 , 1000,
-          TimeUnit.MILLISECONDS);
+          "NONE", port, i, 100, StringUtils.EMPTY);
       toReturn[i] = postSourceTagTimedTask;
     }
     return toReturn;
@@ -83,9 +81,8 @@ public class SourceTagHandlerTest {
     String[] annotations = new String[]{"tag1", "tag2", "tag3"};
     sourceTags[0] = new ReportSourceTag("SourceTag", "save", "dummy", "desc", Arrays.asList
         (annotations));
-    EasyMock.expect(mockAgentAPI.setTags("dummy", Arrays.asList(annotations), false)).andReturn
-        (Response.ok()
-        .build()).once();
+    EasyMock.expect(mockAgentAPI.setTags("dummy", StringUtils.EMPTY, Arrays.asList(annotations), false)).andReturn(
+        Response.ok().build()).once();
 
     EasyMock.replay(mockAgentAPI);
 


### PR DESCRIPTION
The metadata API calls will send the token as QueryParam to the server. Also added a scheduler to run sending metadata tasks periodically.