### PR TITLE
Configurable httpClient connection settings + misc bugfixes

### DIFF
--- a/proxy/src/main/java/com/wavefront/agent/ChannelStringHandler.java
+++ b/proxy/src/main/java/com/wavefront/agent/ChannelStringHandler.java
@@ -121,6 +121,7 @@ public class ChannelStringHandler extends SimpleChannelInboundHandler<String> {
       }
       blockedPointsLogger.warning(pointLine);
       pointHandler.handleBlockedPoint(errMsg);
+      return;
     }
 
     // transform the point after parsing, and apply additional white/black lists if any

--- a/proxy/src/main/java/com/wavefront/agent/OpenTSDBPortUnificationHandler.java
+++ b/proxy/src/main/java/com/wavefront/agent/OpenTSDBPortUnificationHandler.java
@@ -5,6 +5,7 @@ import com.google.common.base.Throwables;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.wavefront.agent.preprocessor.PointPreprocessor;
+import com.wavefront.common.Clock;
 import com.wavefront.ingester.OpenTSDBDecoder;
 import com.wavefront.metrics.JsonMetricsParser;
 
@@ -237,7 +238,7 @@ class OpenTSDBPortUnificationHandler extends SimpleChannelInboundHandler<Object>
       ReportPoint.Builder builder = ReportPoint.newBuilder();
       builder.setMetric(metricName);
       JsonNode time = metric.get("timestamp");
-      long ts = 0;
+      long ts = Clock.now(); // if timestamp is not available, fall back to Clock.now()
       if (time != null) {
         int timestampSize = Long.toString(time.asLong()).length();
         if (timestampSize == 19) { // nanoseconds
@@ -275,6 +276,7 @@ class OpenTSDBPortUnificationHandler extends SimpleChannelInboundHandler<Object>
             blockedPointsLogger.info(PointHandlerImpl.pointToString(point));
           }
           pointHandler.handleBlockedPoint(preprocessor.forReportPoint().getLastFilterResult());
+          return false;
         }
       }
 


### PR DESCRIPTION
- configurable httpMaxConnTotal & httpMaxConnPerRoute (capped at 200 and 100 respectively)
- change default httpRequestTimeout to 10s to match our recommended settings
- fixed: auto-retries were disabled
- fixed: fall-through logic for some blocked points  
- fixed: division by zero when no pushListenerPorts are active
- fixed: timestamp defaults to 0 instead of now() for OpenTSDB 
