### PR TITLE
Java 9 compatibility 

### DIFF
--- a/java-lib/src/main/java/com/wavefront/metrics/JsonMetricsGenerator.java
+++ b/java-lib/src/main/java/com/wavefront/metrics/JsonMetricsGenerator.java
@@ -20,6 +20,7 @@ import com.yammer.metrics.core.Metric;
 import com.yammer.metrics.core.MetricName;
 import com.yammer.metrics.core.MetricProcessor;
 import com.yammer.metrics.core.MetricsRegistry;
+import com.yammer.metrics.core.SafeVirtualMachineMetrics;
 import com.yammer.metrics.core.Sampling;
 import com.yammer.metrics.core.Summarizable;
 import com.yammer.metrics.core.Timer;
@@ -53,7 +54,7 @@ public abstract class JsonMetricsGenerator {
   private static final JsonFactory factory = new JsonFactory();
 
   private static final Clock clock = Clock.defaultClock();
-  private static final VirtualMachineMetrics vm = VirtualMachineMetrics.getInstance();
+  private static final VirtualMachineMetrics vm = SafeVirtualMachineMetrics.getInstance();
 
   public static void generateJsonMetrics(OutputStream outputStream, MetricsRegistry registry, boolean includeVMMetrics,
                                          boolean includeBuildMetrics, boolean clearMetrics, MetricTranslator metricTranslator) throws IOException {

--- a/java-lib/src/main/java/com/yammer/metrics/core/SafeVirtualMachineMetrics.java
+++ b/java-lib/src/main/java/com/yammer/metrics/core/SafeVirtualMachineMetrics.java
@@ -1,0 +1,62 @@
+package com.yammer.metrics.core;
+
+import com.sun.management.UnixOperatingSystemMXBean;
+
+import java.lang.management.GarbageCollectorMXBean;
+import java.lang.management.ManagementFactory;
+import java.lang.management.MemoryMXBean;
+import java.lang.management.MemoryPoolMXBean;
+import java.lang.management.OperatingSystemMXBean;
+import java.lang.management.RuntimeMXBean;
+import java.lang.management.ThreadMXBean;
+import java.util.List;
+
+import javax.management.MBeanServer;
+
+/**
+ * Java 9 compatible implementation of {@link VirtualMachineMetrics} that doesn't use reflection
+ * and is not susceptible to a InaccessibleObjectException in fileDescriptorUsage())
+ *
+ * @author Vasily Vorontsov (vasily@wavefront.com)
+ */
+public class SafeVirtualMachineMetrics extends VirtualMachineMetrics {
+  private static final VirtualMachineMetrics INSTANCE = new SafeVirtualMachineMetrics(
+      ManagementFactory.getMemoryMXBean(), ManagementFactory.getMemoryPoolMXBeans(),
+      ManagementFactory.getOperatingSystemMXBean(), ManagementFactory.getThreadMXBean(),
+      ManagementFactory.getGarbageCollectorMXBeans(), ManagementFactory.getRuntimeMXBean(),
+      ManagementFactory.getPlatformMBeanServer());
+  private final OperatingSystemMXBean os;
+
+  /**
+   * The default instance of {@link SafeVirtualMachineMetrics}.
+   *
+   * @return the default {@link SafeVirtualMachineMetrics instance}
+   */
+  public static VirtualMachineMetrics getInstance() {
+    return INSTANCE;
+  }
+
+  private SafeVirtualMachineMetrics(MemoryMXBean memory, List<MemoryPoolMXBean> memoryPools, OperatingSystemMXBean os,
+                                    ThreadMXBean threads, List<GarbageCollectorMXBean> garbageCollectors,
+                                    RuntimeMXBean runtime, MBeanServer mBeanServer) {
+    super(memory, memoryPools, os, threads, garbageCollectors, runtime, mBeanServer);
+    this.os = os;
+  }
+
+  /**
+   * Returns the percentage of available file descriptors which are currently in use.
+   *
+   * @return the percentage of available file descriptors which are currently in use, or {@code
+   *         NaN} if the running JVM does not have access to this information
+   */
+  @Override
+  public double fileDescriptorUsage() {
+    if (!(this.os instanceof UnixOperatingSystemMXBean)) {
+      return Double.NaN;
+    }
+    Long openFds = ((UnixOperatingSystemMXBean)os).getOpenFileDescriptorCount();
+    Long maxFds = ((UnixOperatingSystemMXBean)os).getMaxFileDescriptorCount();
+    return openFds.doubleValue() / maxFds.doubleValue();
+  }
+
+}


### PR DESCRIPTION
Work around the issue in com.yammer.metrics.core.VirtualMachineMetrics: Java 9 is much more restrictive concerning reflective access to non-public fields/methods, as a result the proxy can't generate JVM metrics and register itself. This problem is specific to Mac installations, as we don't use a sterile environment with a bundled JRE there. 