### PR TITLE
Yooh/pub 110

### DIFF
--- a/pkg/etc/wavefront/wavefront-proxy/wavefront.conf.default
+++ b/pkg/etc/wavefront/wavefront-proxy/wavefront.conf.default
@@ -136,6 +136,9 @@ buffer=/var/spool/wavefront-proxy/buffer
 ## This setting defines the cut-off point for what is considered a valid timestamp for back-dated points.
 ## Default (and recommended) value is 8760 (1 year), so all the data points from more than 1 year ago will be rejected.
 #dataBackfillCutoffHours=8760
+## This setting defines the cut-off point for what is considered a valid timestamp for pre-dated points.
+## Default (and recommended) value is 24 (1 day), so all the data points from more than 1 day in future will be rejected.
+#dataPrefillCutoffHours=24
 
 ## The following settings are used to configure histogram ingestion:
 ## Histograms can be ingested in wavefront scalar and distribution format. For scalar samples ports can be specified for

--- a/proxy/src/main/java/com/wavefront/agent/AbstractAgent.java
+++ b/proxy/src/main/java/com/wavefront/agent/AbstractAgent.java
@@ -558,6 +558,9 @@ public abstract class AbstractAgent {
   @Parameter(names = {"--dataBackfillCutoffHours"}, description = "The cut-off point for what is considered a valid timestamp for back-dated points. Default is 8760 (1 year)")
   protected Integer dataBackfillCutoffHours = 8760;
 
+  @Parameter(names = {"--dataPrefillCutoffHours"}, description = "The cut-off point for what is considered a valid timestamp for pre-dated points. Default is 24 (1 day)")
+  protected Integer dataPrefillCutoffHours = 24;
+
   @Parameter(names = {"--logsIngestionConfigFile"}, description = "Location of logs ingestions config yaml file.")
   protected String logsIngestionConfigFile = null;
 
@@ -905,6 +908,7 @@ public abstract class AbstractAgent {
         bufferFile = config.getString("buffer", bufferFile);
         preprocessorConfigFile = config.getString("preprocessorConfigFile", preprocessorConfigFile);
         dataBackfillCutoffHours = config.getNumber("dataBackfillCutoffHours", dataBackfillCutoffHours).intValue();
+        dataPrefillCutoffHours = config.getNumber("dataPrefillCutoffHours", dataPrefillCutoffHours).intValue();
         filebeatPort = config.getNumber("filebeatPort", filebeatPort).intValue();
         rawLogsPort = config.getNumber("rawLogsPort", rawLogsPort).intValue();
         logsIngestionConfigFile = config.getString("logsIngestionConfigFile", logsIngestionConfigFile);

--- a/proxy/src/main/java/com/wavefront/agent/PushAgent.java
+++ b/proxy/src/main/java/com/wavefront/agent/PushAgent.java
@@ -238,7 +238,7 @@ public class PushAgent extends AbstractAgent {
       Iterable<String> ports = Splitter.on(",").omitEmptyStrings().trimResults().split(httpJsonPorts);
       for (String strPort : ports) {
         preprocessors.forPort(strPort).forReportPoint()
-            .addFilter(new ReportPointTimestampInRangeFilter(dataBackfillCutoffHours));
+            .addFilter(new ReportPointTimestampInRangeFilter(dataBackfillCutoffHours, dataPrefillCutoffHours));
 
         startAsManagedThread(() -> {
               activeListeners.inc();
@@ -265,7 +265,7 @@ public class PushAgent extends AbstractAgent {
       Iterable<String> ports = Splitter.on(",").omitEmptyStrings().trimResults().split(writeHttpJsonPorts);
       for (String strPort : ports) {
         preprocessors.forPort(strPort).forReportPoint()
-            .addFilter(new ReportPointTimestampInRangeFilter(dataBackfillCutoffHours));
+            .addFilter(new ReportPointTimestampInRangeFilter(dataBackfillCutoffHours, dataPrefillCutoffHours));
 
         startAsManagedThread(() -> {
               activeListeners.inc();
@@ -351,7 +351,7 @@ public class PushAgent extends AbstractAgent {
       preprocessors.forPort(strPort).forReportPoint().addTransformer(new ReportPointAddPrefixTransformer(prefix));
     }
     preprocessors.forPort(strPort).forReportPoint()
-        .addFilter(new ReportPointTimestampInRangeFilter(dataBackfillCutoffHours));
+        .addFilter(new ReportPointTimestampInRangeFilter(dataBackfillCutoffHours, dataPrefillCutoffHours));
     final int port = Integer.parseInt(strPort);
     final PostPushDataTimedTask[] flushTasks = getFlushTasks(strPort);
     ChannelInitializer initializer = new ChannelInitializer<SocketChannel>() {
@@ -375,7 +375,7 @@ public class PushAgent extends AbstractAgent {
       preprocessors.forPort(strPort).forReportPoint().addTransformer(new ReportPointAddPrefixTransformer(prefix));
     }
     preprocessors.forPort(strPort).forReportPoint()
-        .addFilter(new ReportPointTimestampInRangeFilter(dataBackfillCutoffHours));
+        .addFilter(new ReportPointTimestampInRangeFilter(dataBackfillCutoffHours, dataPrefillCutoffHours));
     int port = Integer.parseInt(strPort);
     // Set up a custom handler
     ChannelHandler handler = new ChannelByteArrayHandler(
@@ -428,7 +428,7 @@ public class PushAgent extends AbstractAgent {
       preprocessors.forPort(strPort).forReportPoint().addTransformer(new ReportPointAddPrefixTransformer(prefix));
     }
     preprocessors.forPort(strPort).forReportPoint()
-        .addFilter(new ReportPointTimestampInRangeFilter(dataBackfillCutoffHours));
+        .addFilter(new ReportPointTimestampInRangeFilter(dataBackfillCutoffHours, dataPrefillCutoffHours));
     // Add a metadatahandler, to handle @SourceTag, @SourceDescription, etc.
     SourceTagHandler metadataHandler = new SourceTagHandlerImpl(getSourceTagFlushTasks(port));
     // Set up a custom graphite handler, with no formatter

--- a/proxy/src/main/java/com/wavefront/agent/preprocessor/ReportPointTimestampInRangeFilter.java
+++ b/proxy/src/main/java/com/wavefront/agent/preprocessor/ReportPointTimestampInRangeFilter.java
@@ -15,10 +15,9 @@ import wavefront.report.ReportPoint;
 /**
  * Filter condition for valid timestamp - should be no more than 1 day in the future
  * and no more than X hours (usually 8760, or 1 year) in the past
- * 
- * now have additional cutOff values where 
  *
  * Created by Vasily on 9/16/16.
+ * Updated by Howard on 1/10/18 to add support for preCutOffHours
  */
 public class ReportPointTimestampInRangeFilter extends AnnotatedPredicate<ReportPoint> {
 
@@ -41,7 +40,7 @@ public class ReportPointTimestampInRangeFilter extends AnnotatedPredicate<Report
     long pointTime = point.getTimestamp();
     long rightNow = Clock.now();
 
-    // within <cutoffHours> ago and within preCutoffHours
+    // within <backCutoffHours> ago and within <preCutoffHours>
     boolean pointInRange = (pointTime > (rightNow - this.backCutoffHours * DateUtils.MILLIS_PER_HOUR)) &&
         (pointTime < (rightNow + (this.preCutoffHours * DateUtils.MILLIS_PER_HOUR));
     if (!pointInRange) {

--- a/proxy/src/main/java/com/wavefront/agent/preprocessor/ReportPointTimestampInRangeFilter.java
+++ b/proxy/src/main/java/com/wavefront/agent/preprocessor/ReportPointTimestampInRangeFilter.java
@@ -17,20 +17,22 @@ import wavefront.report.ReportPoint;
  * and no more than X hours (usually 8760, or 1 year) in the past
  *
  * Created by Vasily on 9/16/16.
- * Updated by Howard on 1/10/18 to add support for preCutOffHours
+ * Updated by Howard on 1/10/18 
+ * - to add support for hoursInFutureAllowed
+ * - changed variable names to hoursInPastAllowed and hoursInFutureAllowed
  */
 public class ReportPointTimestampInRangeFilter extends AnnotatedPredicate<ReportPoint> {
 
-  private final int backCutoffHours;
-  private final int preCutoffHours;
+  private final int hoursInPastAllowed;
+  private final int hoursInFutureAllowed;
 
   private final Counter outOfRangePointTimes;
   @Nullable
   private String message = null;
 
-  public ReportPointTimestampInRangeFilter(final int backCutoffHours, final int preCutoffHours) {
-    this.backCutoffHours = backCutoffHours;
-    this.preCutoffHours = preCutoffHours;
+  public ReportPointTimestampInRangeFilter(final int hoursInPastAllowed, final int hoursInFutureAllowed) {
+    this.hoursInPastAllowed = hoursInPastAllowed;
+    this.hoursInFutureAllowed = hoursInFutureAllowed;
     this.outOfRangePointTimes = Metrics.newCounter(new MetricName("point", "", "badtime"));
   }
 
@@ -40,9 +42,9 @@ public class ReportPointTimestampInRangeFilter extends AnnotatedPredicate<Report
     long pointTime = point.getTimestamp();
     long rightNow = Clock.now();
 
-    // within <backCutoffHours> ago and within <preCutoffHours>
-    boolean pointInRange = (pointTime > (rightNow - this.backCutoffHours * DateUtils.MILLIS_PER_HOUR)) &&
-        (pointTime < (rightNow + (this.preCutoffHours * DateUtils.MILLIS_PER_HOUR)));
+    // within <hoursInPastAllowed> ago and within <hoursInFutureAllowed>
+    boolean pointInRange = (pointTime > (rightNow - this.hoursInPastAllowed * DateUtils.MILLIS_PER_HOUR)) &&
+        (pointTime < (rightNow + (this.hoursInFutureAllowed * DateUtils.MILLIS_PER_HOUR)));
     if (!pointInRange) {
       outOfRangePointTimes.inc();
       this.message = "WF-402: Point outside of reasonable timeframe (" + point.toString() + ")";

--- a/proxy/src/main/java/com/wavefront/agent/preprocessor/ReportPointTimestampInRangeFilter.java
+++ b/proxy/src/main/java/com/wavefront/agent/preprocessor/ReportPointTimestampInRangeFilter.java
@@ -42,7 +42,7 @@ public class ReportPointTimestampInRangeFilter extends AnnotatedPredicate<Report
 
     // within <backCutoffHours> ago and within <preCutoffHours>
     boolean pointInRange = (pointTime > (rightNow - this.backCutoffHours * DateUtils.MILLIS_PER_HOUR)) &&
-        (pointTime < (rightNow + (this.preCutoffHours * DateUtils.MILLIS_PER_HOUR));
+        (pointTime < (rightNow + (this.preCutoffHours * DateUtils.MILLIS_PER_HOUR)));
     if (!pointInRange) {
       outOfRangePointTimes.inc();
       this.message = "WF-402: Point outside of reasonable timeframe (" + point.toString() + ")";

--- a/proxy/src/test/java/com/wavefront/agent/preprocessor/PreprocessorRulesTest.java
+++ b/proxy/src/test/java/com/wavefront/agent/preprocessor/PreprocessorRulesTest.java
@@ -41,7 +41,7 @@ public class PreprocessorRulesTest {
     long millisPerYear = 31536000000L;
     long millisPerDay = 86400000L;
 
-    AnnotatedPredicate<ReportPoint> pointInRange1year = new ReportPointTimestampInRangeFilter(8760);
+    AnnotatedPredicate<ReportPoint> pointInRange1year = new ReportPointTimestampInRangeFilter(8760, 24);
 
     // not in range if over a year ago
     ReportPoint rp = new ReportPoint("some metric", System.currentTimeMillis() - millisPerYear, 10L, "host", "table",
@@ -68,7 +68,7 @@ public class PreprocessorRulesTest {
     Assert.assertFalse(pointInRange1year.apply(rp));
 
     // now test with 1 day limit
-    AnnotatedPredicate<ReportPoint> pointInRange1day = new ReportPointTimestampInRangeFilter(24);
+    AnnotatedPredicate<ReportPoint> pointInRange1day = new ReportPointTimestampInRangeFilter(24, 24);
 
     rp.setTimestamp(System.currentTimeMillis() - millisPerDay - 1);
     Assert.assertFalse(pointInRange1day.apply(rp));

--- a/proxy/src/test/java/com/wavefront/agent/preprocessor/PreprocessorRulesTest.java
+++ b/proxy/src/test/java/com/wavefront/agent/preprocessor/PreprocessorRulesTest.java
@@ -40,6 +40,7 @@ public class PreprocessorRulesTest {
 
     long millisPerYear = 31536000000L;
     long millisPerDay = 86400000L;
+    long millisPerHour = 3600000L;
 
     AnnotatedPredicate<ReportPoint> pointInRange1year = new ReportPointTimestampInRangeFilter(8760, 24);
 
@@ -80,6 +81,36 @@ public class PreprocessorRulesTest {
     // in range for right now
     rp.setTimestamp(System.currentTimeMillis());
     Assert.assertTrue(pointInRange1day.apply(rp));
+
+    // assert for future range within 12 hours
+    AnnotatedPredicate<ReportPoint> pointInRange12hours = new ReportPointTimestampInRangeFilter(12, 12);
+
+    rp.setTimestamp(System.currentTimeMillis() + (millisPerHour * 10));
+    Assert.assertTrue(pointInRange12hours.apply(rp));
+
+    rp.setTimestamp(System.currentTimeMillis() - (millisPerHour * 10));
+    Assert.assertTrue(pointInRange12hours.apply(rp));
+
+    rp.setTimestamp(System.currentTimeMillis() + (millisPerHour * 20));
+    Assert.assertFalse(pointInRange12hours.apply(rp));
+
+    rp.setTimestamp(System.currentTimeMillis() - (millisPerHour * 20));
+    Assert.assertFalse(pointInRange12hours.apply(rp));
+
+    AnnotatedPredicate<ReportPoint> pointInRange10Days = new ReportPointTimestampInRangeFilter(240, 240);
+
+    rp.setTimestamp(System.currentTimeMillis() + (millisPerDay * 9));
+    Assert.assertTrue(pointInRange10Days.apply(rp));
+
+    rp.setTimestamp(System.currentTimeMillis() - (millisPerDay * 9));
+    Assert.assertTrue(pointInRange10Days.apply(rp));
+
+    rp.setTimestamp(System.currentTimeMillis() + (millisPerDay * 20));
+    Assert.assertFalse(pointInRange10Days.apply(rp));
+
+    rp.setTimestamp(System.currentTimeMillis() - (millisPerDay * 20));
+    Assert.assertFalse(pointInRange10Days.apply(rp));
+
   }
 
   @Test(expected = NullPointerException.class)


### PR DESCRIPTION
https://wavefront.atlassian.net/browse/PUB-110
This PR adds a configuration to proxy which enabled it to specify pre hour limit which is originally defaulted to 24 hours. With this enhancement, user can now specify a specific hours of which proxy will receive the future timestamps on the point data. Please note however, that the default limit is set to 24 hours (1 day) and user should be careful not to set too large a value, as enabling to ingest future time series can seriously impact the performance.