### PR TITLE
Update copyright

### DIFF
--- a/pkg/usr/share/doc/wavefront-proxy/copyright
+++ b/pkg/usr/share/doc/wavefront-proxy/copyright
@@ -3,8 +3,8 @@ Upstream-Name: wavefront-proxy
 Source: <https://github.com/wavefrontHQ/java/tree/master/proxy>
 
 Files: *
-Copyright: 2014-2016 Wavefront, Inc.
-Copyright: 2016 Wavefront <support@wavefront.com>
+Copyright: 2014-2018 Wavefront, Inc.
+Copyright: 2018 Wavefront
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at


### PR DESCRIPTION
Updating copyright date, removing support@wavefront.com