### PR TITLE
PUB-118 fix (logs ingestion histogram precision)

### DIFF
--- a/java-lib/src/main/java/com/yammer/metrics/core/WavefrontHistogram.java
+++ b/java-lib/src/main/java/com/yammer/metrics/core/WavefrontHistogram.java
@@ -94,7 +94,7 @@ public class WavefrontHistogram extends Histogram implements Metric {
 
   @Override
   public void update(int value) {
-    update((long) value);
+    update((double) value);
   }
 
   /**
@@ -142,15 +142,21 @@ public class WavefrontHistogram extends Histogram implements Metric {
     }
   }
 
+  public void update(double value) {
+    getCurrent().dist.add(value);
+  }
+
   @Override
   public void update(long value) {
-    getCurrent().dist.add(value);
+    update((double)value);
   }
 
   @Override
   public double mean() {
     Collection<Centroid> centroids = snapshot().centroids();
-    return centroids.stream().mapToDouble(c -> (c.count() * c.mean()) / centroids.size()).sum();
+    return centroids.size() == 0 ?
+        Double.NaN :
+        centroids.stream().mapToDouble(c -> (c.count() * c.mean()) / centroids.size()).sum();
   }
 
   public double min() {
@@ -168,6 +174,16 @@ public class WavefrontHistogram extends Histogram implements Metric {
   @Override
   public long count() {
     return perThreadHistogramBins.values().stream().flatMap(List::stream).mapToLong(bin -> bin.dist.size()).sum();
+  }
+
+  @Override
+  public double sum() {
+    return Double.NaN;
+  }
+
+  @Override
+  public double stdDev() {
+    return Double.NaN;
   }
 
   /**

--- a/proxy/src/main/java/com/wavefront/agent/config/LogsIngestionConfig.java
+++ b/proxy/src/main/java/com/wavefront/agent/config/LogsIngestionConfig.java
@@ -135,6 +135,13 @@ public class LogsIngestionConfig extends Configuration {
   public boolean useWavefrontHistograms = false;
 
   /**
+   * If true (default), simulate Yammer histogram behavior (report all stats as zeroes when histogram is empty).
+   * Otherwise, only .count is reported with a zero value.
+   */
+  @JsonProperty
+  public boolean reportEmptyHistogramStats = true;
+
+  /**
    * How often to check this config file for updates.
    */
   @JsonProperty

--- a/proxy/src/main/java/com/wavefront/agent/logsharvesting/LogsIngester.java
+++ b/proxy/src/main/java/com/wavefront/agent/logsharvesting/LogsIngester.java
@@ -54,14 +54,15 @@ public class LogsIngester {
     LogsIngestionConfig logsIngestionConfig = logsIngestionConfigManager.getConfig();
 
     this.evictingMetricsRegistry = new EvictingMetricsRegistry(
-        logsIngestionConfig.expiryMillis, logsIngestionConfig.useWavefrontHistograms, currentMillis);
+        logsIngestionConfig.expiryMillis, true, currentMillis);
 
     // Logs harvesting metrics.
     this.unparsed = Metrics.newCounter(new MetricName("logsharvesting", "", "unparsed"));
     this.parsed = Metrics.newCounter(new MetricName("logsharvesting", "", "parsed"));
     this.sent = Metrics.newCounter(new MetricName("logsharvesting", "", "sent"));
     this.currentMillis = currentMillis;
-    this.flushProcessor = new FlushProcessor(sent, currentMillis);
+    this.flushProcessor = new FlushProcessor(sent, currentMillis, logsIngestionConfig.useWavefrontHistograms,
+        logsIngestionConfig.reportEmptyHistogramStats);
 
     // Set up user specified metric harvesting.
     this.pointHandler = pointHandler;

--- a/proxy/src/main/java/com/wavefront/agent/logsharvesting/ReadProcessor.java
+++ b/proxy/src/main/java/com/wavefront/agent/logsharvesting/ReadProcessor.java
@@ -7,6 +7,7 @@ import com.yammer.metrics.core.Metered;
 import com.yammer.metrics.core.MetricName;
 import com.yammer.metrics.core.MetricProcessor;
 import com.yammer.metrics.core.Timer;
+import com.yammer.metrics.core.WavefrontHistogram;
 
 /**
  * @author Mori Bellamy (mori@wavefront.com)
@@ -24,7 +25,11 @@ public class ReadProcessor implements MetricProcessor<ReadProcessorContext> {
 
   @Override
   public void processHistogram(MetricName name, Histogram histogram, ReadProcessorContext context) throws Exception {
-    histogram.update(Math.round(context.getValue()));
+    if (histogram instanceof WavefrontHistogram) {
+      ((WavefrontHistogram) histogram).update(context.getValue());
+    } else {
+      histogram.update(Math.round(context.getValue()));
+    }
   }
 
   @Override

--- a/proxy/src/test/java/com/wavefront/agent/logsharvesting/LogsIngesterTest.java
+++ b/proxy/src/test/java/com/wavefront/agent/logsharvesting/LogsIngesterTest.java
@@ -307,12 +307,12 @@ public class LogsIngesterTest {
             PointMatchers.almostMatches(100.0, "myHisto.max", ImmutableMap.of()),
             PointMatchers.almostMatches(50.5, "myHisto.mean", ImmutableMap.of()),
             PointMatchers.almostMatches(50.5, "myHisto.median", ImmutableMap.of()),
-            PointMatchers.almostMatches(75.75, "myHisto.p75", ImmutableMap.of()),
-            PointMatchers.almostMatches(95.95, "myHisto.p95", ImmutableMap.of()),
-            PointMatchers.almostMatches(99.99, "myHisto.p99", ImmutableMap.of()),
-            PointMatchers.almostMatches(100.0, "myHisto.p999", ImmutableMap.of()),
-            PointMatchers.almostMatches(5050.0, "myHisto.sum", ImmutableMap.of()),
-            PointMatchers.almostMatches(29.011491, "myHisto.stddev", ImmutableMap.of())
+            PointMatchers.almostMatches(75.25, "myHisto.p75", ImmutableMap.of()),
+            PointMatchers.almostMatches(95.05, "myHisto.p95", ImmutableMap.of()),
+            PointMatchers.almostMatches(99.01, "myHisto.p99", ImmutableMap.of()),
+            PointMatchers.almostMatches(99.901, "myHisto.p999", ImmutableMap.of()),
+            PointMatchers.matches(Double.NaN, "myHisto.sum", ImmutableMap.of()),
+            PointMatchers.matches(Double.NaN, "myHisto.stddev", ImmutableMap.of())
         ))
     );
   }


### PR DESCRIPTION
- Add support for double-precision float samples to WavefrontHistogram
- Use WavefrontHistogram internally for logs ingestion 
- Add ability to export stats from WavefrontHistogram in legacy Histogram format (all stats default to zeroes for empty histograms), controlled by reportEmptyHistogramStats setting in logsingestion.yaml config
