### PR TITLE
MONIT-8612 Correct shutdown sequence for remote shut-off

### DIFF
--- a/proxy/src/main/java/com/wavefront/agent/AbstractAgent.java
+++ b/proxy/src/main/java/com/wavefront/agent/AbstractAgent.java
@@ -616,7 +616,6 @@ public abstract class AbstractAgent {
     } finally {
       if (doShutDown) {
         logger.warning("Shutting down: Server side flag indicating proxy has to shut down.");
-        shutdown();
         System.exit(1);
       }
     }


### PR DESCRIPTION
Don't go through the shutdown sequence twice and let shutdownHook run its course