### PR TITLE
Added direct ingestion/delta metrics support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,8 @@
 *.swp
 *.deb
 *.rpm
+*.releaseBackup
+release.properties
 
 pkg/build
 

--- a/dropwizard-metrics/3.1/src/main/java/com/wavefront/integrations/metrics/WavefrontReporter.java
+++ b/dropwizard-metrics/3.1/src/main/java/com/wavefront/integrations/metrics/WavefrontReporter.java
@@ -301,6 +301,14 @@ public class WavefrontReporter extends ScheduledReporter {
           disabledMetricAttributes);
     }
 
+    /**
+     * Builds a {@link WavefrontReporter} with the given properties, sending metrics directly
+     * to a given Wavefront server using direct ingestion APIs.
+     *
+     * @param server Wavefront server hostname of the form "https://serverName.wavefront.com"
+     * @param token  Wavefront API token with direct ingestion permission
+     * @return a {@link WavefrontReporter}
+     */
     public WavefrontReporter buildDirect(String server, String token) {
       WavefrontSender wavefrontSender = new WavefrontDirectSender(server, token);
       return new WavefrontReporter(registry, wavefrontSender, clock, prefix, source, pointTags, rateUnit,

--- a/dropwizard-metrics/3.1/src/main/java/com/wavefront/integrations/metrics/WavefrontReporter.java
+++ b/dropwizard-metrics/3.1/src/main/java/com/wavefront/integrations/metrics/WavefrontReporter.java
@@ -20,6 +20,7 @@ import com.codahale.metrics.jvm.GarbageCollectorMetricSet;
 import com.codahale.metrics.jvm.MemoryUsageGaugeSet;
 import com.codahale.metrics.jvm.SafeFileDescriptorRatioGauge;
 import com.codahale.metrics.jvm.ThreadStatesGaugeSet;
+import com.wavefront.common.Constants;
 import com.wavefront.integrations.Wavefront;
 import com.wavefront.integrations.WavefrontDirectSender;
 import com.wavefront.integrations.WavefrontSender;
@@ -487,7 +488,7 @@ public class WavefrontReporter extends ScheduledReporter {
   private void reportCounter(String name, Counter counter) throws IOException {
     if (counter instanceof DeltaCounter) {
       long count = counter.getCount();
-      name = DeltaCounter.DELTA_PREFIX + prefixAndSanitize(name.substring(1), "count");
+      name = Constants.DELTA_PREFIX + prefixAndSanitize(name.substring(1), "count");
       wavefront.send(name, count,clock.getTime() / 1000, source, pointTags);
       counter.dec(count);
     } else {

--- a/dropwizard-metrics/dropwizard-metrics-wavefront/pom.xml
+++ b/dropwizard-metrics/dropwizard-metrics-wavefront/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.wavefront</groupId>
         <artifactId>wavefront</artifactId>
-        <version>4.27-SNAPSHOT</version>
+        <version>4.29-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/java-client/pom.xml
+++ b/java-client/pom.xml
@@ -43,5 +43,9 @@
       <groupId>com.wavefront</groupId>
       <artifactId>java-lib</artifactId>
     </dependency>
+      <dependency>
+          <groupId>org.jboss.resteasy</groupId>
+          <artifactId>resteasy-client</artifactId>
+      </dependency>
   </dependencies>
 </project>

--- a/java-client/src/main/java/com/wavefront/integrations/WavefrontDirectSender.java
+++ b/java-client/src/main/java/com/wavefront/integrations/WavefrontDirectSender.java
@@ -1,0 +1,272 @@
+package com.wavefront.integrations;
+
+import com.wavefront.api.DataIngestorAPI;
+import com.wavefront.common.NamedThreadFactory;
+
+import org.apache.commons.lang.StringUtils;
+import org.apache.http.HttpClientConnection;
+import org.apache.http.HttpException;
+import org.apache.http.HttpRequest;
+import org.apache.http.HttpResponse;
+
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.protocol.HttpContext;
+import org.apache.http.protocol.HttpRequestExecutor;
+import org.jboss.resteasy.client.jaxrs.ClientHttpEngine;
+import org.jboss.resteasy.client.jaxrs.ResteasyClient;
+import org.jboss.resteasy.client.jaxrs.ResteasyClientBuilder;
+import org.jboss.resteasy.client.jaxrs.ResteasyWebTarget;
+import org.jboss.resteasy.client.jaxrs.engines.ApacheHttpClient4Engine;
+import org.jboss.resteasy.plugins.interceptors.encoding.AcceptEncodingGZIPFilter;
+import org.jboss.resteasy.plugins.interceptors.encoding.GZIPDecodingInterceptor;
+import org.jboss.resteasy.spi.ResteasyProviderFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+import javax.annotation.Nullable;
+import javax.validation.constraints.NotNull;
+import javax.ws.rs.core.Response;
+
+/**
+ * Wavefront Client that sends data directly to Wavefront via the direct ingestion APIs.
+ *
+ * @author Vikram Raman (vikram@wavefront.com)
+ */
+public class WavefrontDirectSender implements WavefrontSender, Runnable {
+
+  private static final String DEFAULT_SOURCE = "wavefrontDirectSender";
+  private static final Logger LOGGER = LoggerFactory.getLogger(WavefrontDirectSender.class);
+  private static String quote = "\"";
+  private static String escapedQuote = "\\\"";
+
+  private final Object pointsMutex = new Object();
+  private final ScheduledExecutorService scheduler;
+  private final String server;
+  private final String token;
+  private DataIngestorAPI directService;
+  private CloseableHttpClient httpClient;
+  private Future<?> scheduledFuture;
+
+  //TODO: bounded buffer?
+  private List<String> buffer = new ArrayList<>();
+
+  public WavefrontDirectSender(String server, String token) {
+    this.server = server;
+    this.token = token;
+    scheduler = Executors.newScheduledThreadPool(1, new NamedThreadFactory(DEFAULT_SOURCE));
+  }
+
+  private DataIngestorAPI createWavefrontService(String server, String token) {
+    httpClient = HttpClientBuilder.create().
+        setUserAgent(DEFAULT_SOURCE).
+        setRequestExecutor(new TokenHeaderHttpRequestExectutor(token)).
+        build();
+
+    final ApacheHttpClient4Engine apacheHttpClient4Engine = new ApacheHttpClient4Engine(httpClient, true);
+    apacheHttpClient4Engine.setFileUploadInMemoryThresholdLimit(100);
+    apacheHttpClient4Engine.setFileUploadMemoryUnit(ApacheHttpClient4Engine.MemoryUnit.MB);
+
+    ResteasyProviderFactory factory = ResteasyProviderFactory.getInstance();
+    ClientHttpEngine httpEngine = apacheHttpClient4Engine;
+
+    ResteasyClient client = new ResteasyClientBuilder().
+        httpEngine(httpEngine).
+        providerFactory(factory).
+        register(GZIPDecodingInterceptor.class).
+        register(AcceptEncodingGZIPFilter.class).
+        build();
+    ResteasyWebTarget target = client.target(server);
+    return target.proxy(DataIngestorAPI.class);
+  }
+
+  @Override
+  public synchronized void connect() throws IllegalStateException, IOException {
+    if (httpClient == null) {
+      directService = createWavefrontService(server, token);
+      scheduledFuture = scheduler.scheduleAtFixedRate(this, 1, 1, TimeUnit.SECONDS);
+    }
+  }
+
+  @Override
+  public void send(String name, double value) throws IOException {
+    addPoint(name, value, null, DEFAULT_SOURCE, null);
+  }
+
+  @Override
+  public void send(String name, double value, @Nullable Long timestamp) throws IOException {
+    addPoint(name, value, timestamp, DEFAULT_SOURCE, null);
+  }
+
+  @Override
+  public void send(String name, double value, @Nullable Long timestamp, String source) throws IOException {
+    addPoint(name, value, timestamp, source, null);
+  }
+
+  @Override
+  public void send(String name, double value, String source, @Nullable Map<String, String> pointTags) throws IOException {
+    addPoint(name, value, null, source, pointTags);
+  }
+
+  @Override
+  public void send(String name, double value, @Nullable Long timestamp, String source,
+                   @Nullable Map<String, String> pointTags) throws IOException {
+    addPoint(name, value, timestamp, source, pointTags);
+  }
+
+  private void addPoint(@NotNull String name, double value, @Nullable Long timestamp, @NotNull String source,
+                        @Nullable Map<String, String> pointTags) throws IOException {
+
+    //TODO: extra validation required?
+    String point = pointToString(name, value, timestamp, source, pointTags);
+    if (point != null) {
+      synchronized(pointsMutex) {
+        this.buffer.add(point);
+      }
+    }
+  }
+
+  private static String escapeQuotes(String raw) {
+    return StringUtils.replace(raw, quote, escapedQuote);
+  }
+
+  @Nullable
+  static String pointToString(String name, double value, @Nullable Long timestamp, String source,
+                               @Nullable Map<String, String> pointTags) {
+
+    if (name == null || name.isEmpty() || source == null || source.isEmpty()) {
+      LOGGER.debug("Invalid point: Empty name/source");
+      return null;
+    }
+
+    if (timestamp == null) {
+      timestamp = System.currentTimeMillis()/1000;
+    }
+
+    StringBuilder sb = new StringBuilder(quote)
+        .append(escapeQuotes(name)).append(quote).append(" ")
+        .append(Double.toString(value)).append(" ")
+        .append(Long.toString(timestamp)).append(" ")
+        .append("source=").append(quote).append(escapeQuotes(source)).append(quote);
+
+    if (pointTags != null) {
+      for (Map.Entry<String, String> entry : pointTags.entrySet()) {
+        sb.append(' ').append(quote).append(escapeQuotes(entry.getKey())).append(quote)
+            .append("=")
+            .append(quote).append(escapeQuotes(entry.getValue())).append(quote);
+      }
+    }
+    return sb.toString();
+  }
+
+  @Override
+  public void flush() throws IOException {
+    internalFlush();
+  }
+
+  private void internalFlush() throws IOException {
+
+    if (!isConnected()) {
+        return;
+    }
+
+    List<String> points = getPointsBatch();
+    if (points.isEmpty()) {
+      return;
+    }
+
+    Response response = null;
+    try (InputStream is = pointsToStream(points)) {
+      response = directService.report("graphite_v2", is);
+      if (response.getStatusInfo().getFamily() == Response.Status.Family.SERVER_ERROR ||
+          response.getStatusInfo().getFamily() == Response.Status.Family.CLIENT_ERROR) {
+        LOGGER.debug("Error reporting points, respStatus=" + response.getStatus());
+      }
+    } finally {
+      if (response != null) {
+        // releases the connection for reuse
+        response.close();
+      }
+    }
+  }
+
+  private InputStream pointsToStream(List<String> points) {
+    StringBuilder sb = new StringBuilder();
+    boolean newLine = false;
+    for (String point : points) {
+      if (newLine) {
+        sb.append("\n");
+      }
+      sb.append(point);
+      newLine = true;
+    }
+    return new ByteArrayInputStream(sb.toString().getBytes());
+  }
+
+  private List<String> getPointsBatch() {
+    List<String> points;
+    synchronized(pointsMutex) {
+      int blockSize = Math.min(buffer.size(), 10000);
+      points = buffer.subList(0, blockSize);
+      buffer = new ArrayList<>(buffer.subList(blockSize, buffer.size()));
+    }
+    return points;
+  }
+
+  @Override
+  public synchronized boolean isConnected() {
+    return httpClient != null;
+  }
+
+  @Override
+  public int getFailureCount() {
+    return 0;
+  }
+
+  @Override
+  public synchronized void close() throws IOException {
+    if (httpClient != null) {
+      scheduledFuture.cancel(false);
+      scheduledFuture = null;
+      httpClient.close();
+      httpClient = null;
+      directService = null;
+    }
+  }
+
+  @Override
+  public void run() {
+    try {
+      this.internalFlush();
+    } catch (Exception ex) {
+      LOGGER.debug("Unable to report to Wavefront", ex);
+    }
+  }
+
+  private static final class TokenHeaderHttpRequestExectutor extends HttpRequestExecutor {
+    private final String token;
+
+    public TokenHeaderHttpRequestExectutor(String token) {
+      this.token = "Bearer " + token;
+    }
+
+    @Override
+    public HttpResponse execute(final HttpRequest request, final HttpClientConnection conn, final HttpContext context)
+        throws IOException, HttpException {
+      request.addHeader("Authorization", this.token);
+      return super.execute(request, conn, context);
+    }
+  }
+}

--- a/java-client/src/main/java/com/wavefront/integrations/WavefrontDirectSender.java
+++ b/java-client/src/main/java/com/wavefront/integrations/WavefrontDirectSender.java
@@ -49,8 +49,8 @@ public class WavefrontDirectSender implements WavefrontSender, Runnable {
 
   private static final String DEFAULT_SOURCE = "wavefrontDirectSender";
   private static final Logger LOGGER = LoggerFactory.getLogger(WavefrontDirectSender.class);
-  private static String quote = "\"";
-  private static String escapedQuote = "\\\"";
+  private static final String quote = "\"";
+  private static final String escapedQuote = "\\\"";
 
   private final Object pointsMutex = new Object();
   private final ScheduledExecutorService scheduler;
@@ -155,17 +155,17 @@ public class WavefrontDirectSender implements WavefrontSender, Runnable {
       timestamp = System.currentTimeMillis()/1000;
     }
 
-    StringBuilder sb = new StringBuilder(quote)
-        .append(escapeQuotes(name)).append(quote).append(" ")
-        .append(Double.toString(value)).append(" ")
-        .append(Long.toString(timestamp)).append(" ")
-        .append("source=").append(quote).append(escapeQuotes(source)).append(quote);
+    StringBuilder sb = new StringBuilder(quote).
+        append(escapeQuotes(name)).append(quote).append(" ").
+        append(Double.toString(value)).append(" ").
+        append(Long.toString(timestamp)).append(" ").
+        append("source=").append(quote).append(escapeQuotes(source)).append(quote);
 
     if (pointTags != null) {
       for (Map.Entry<String, String> entry : pointTags.entrySet()) {
-        sb.append(' ').append(quote).append(escapeQuotes(entry.getKey())).append(quote)
-            .append("=")
-            .append(quote).append(escapeQuotes(entry.getValue())).append(quote);
+        sb.append(' ').append(quote).append(escapeQuotes(entry.getKey())).append(quote).
+            append("=").
+            append(quote).append(escapeQuotes(entry.getValue())).append(quote);
       }
     }
     return sb.toString();

--- a/java-client/src/test/java/com/wavefront/integrations/WavefrontDirectSenderTest.java
+++ b/java-client/src/test/java/com/wavefront/integrations/WavefrontDirectSenderTest.java
@@ -1,0 +1,26 @@
+package com.wavefront.integrations;
+
+import com.google.common.collect.ImmutableMap;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import static org.junit.Assert.assertNull;
+
+/**
+ * Tests for {@link WavefrontDirectSender}
+ *
+ * @author Vikram Raman (vikram@wavefront.com).
+ */
+public class WavefrontDirectSenderTest {
+
+  @Test
+  public void testPointToString() {
+    assertNull(WavefrontDirectSender.pointToString(null, 0.0, null, "source", null));
+    assertNull(WavefrontDirectSender.pointToString("name", 0.0, null, null, null));
+
+    Assert.assertEquals("\"name\" 10 1469751813 source=\"source\" \"foo\"=\"bar\" \"bar\"=\"foo\"",
+        WavefrontDirectSender.pointToString("name",1469751813000L, 10L, "source",
+            ImmutableMap.of("foo", "bar", "bar", "foo")));
+  }
+}

--- a/java-client/src/test/java/com/wavefront/integrations/WavefrontDirectSenderTest.java
+++ b/java-client/src/test/java/com/wavefront/integrations/WavefrontDirectSenderTest.java
@@ -19,8 +19,8 @@ public class WavefrontDirectSenderTest {
     assertNull(WavefrontDirectSender.pointToString(null, 0.0, null, "source", null));
     assertNull(WavefrontDirectSender.pointToString("name", 0.0, null, null, null));
 
-    Assert.assertEquals("\"name\" 10 1469751813 source=\"source\" \"foo\"=\"bar\" \"bar\"=\"foo\"",
-        WavefrontDirectSender.pointToString("name",1469751813000L, 10L, "source",
+    Assert.assertEquals("\"name\" 10.0 1469751813 source=\"source\" \"foo\"=\"bar\" \"bar\"=\"foo\"",
+        WavefrontDirectSender.pointToString("name",10L, 1469751813L, "source",
             ImmutableMap.of("foo", "bar", "bar", "foo")));
   }
 }

--- a/java-lib/pom.xml
+++ b/java-lib/pom.xml
@@ -96,7 +96,7 @@
     <dependency>
       <groupId>com.tdunning</groupId>
       <artifactId>t-digest</artifactId>
-      <version>3.1</version>
+      <version>3.2</version>
     </dependency>
     <dependency>
       <groupId>io.dropwizard.metrics</groupId>

--- a/java-lib/src/main/java/com/codahale/metrics/DeltaCounter.java
+++ b/java-lib/src/main/java/com/codahale/metrics/DeltaCounter.java
@@ -2,6 +2,8 @@ package com.codahale.metrics;
 
 import com.google.common.annotations.VisibleForTesting;
 
+import com.wavefront.common.Constants;
+
 /**
  * A counter for Wavefront delta metrics.
  *
@@ -11,9 +13,6 @@ import com.google.common.annotations.VisibleForTesting;
  */
 public class DeltaCounter extends Counter {
 
-  public static final String DELTA_PREFIX = "\u2206"; // ∆: INCREMENT
-  private static final String ALT_DELTA_PREFIX = "\u0394"; // Δ: GREEK CAPITAL LETTER DELTA
-
   @VisibleForTesting
   public static synchronized DeltaCounter get(MetricRegistry registry, String metricName) {
 
@@ -21,8 +20,8 @@ public class DeltaCounter extends Counter {
       throw new IllegalArgumentException("Invalid arguments");
     }
 
-    if (!(metricName.startsWith(DELTA_PREFIX) || metricName.startsWith(ALT_DELTA_PREFIX))) {
-      metricName = DELTA_PREFIX + metricName;
+    if (!(metricName.startsWith(Constants.DELTA_PREFIX) || metricName.startsWith(Constants.DELTA_PREFIX_2))) {
+      metricName = Constants.DELTA_PREFIX + metricName;
     }
     DeltaCounter counter = new DeltaCounter();
     registry.register(metricName, counter);

--- a/java-lib/src/main/java/com/codahale/metrics/DeltaCounter.java
+++ b/java-lib/src/main/java/com/codahale/metrics/DeltaCounter.java
@@ -1,0 +1,31 @@
+package com.codahale.metrics;
+
+import com.google.common.annotations.VisibleForTesting;
+
+/**
+ * A counter for Wavefront delta metrics.
+ *
+ * Differs from a counter in that it is reset in the WavefrontReporter every time the value is reported.
+ *
+ * @author Vikram Raman (vikram@wavefront.com)
+ */
+public class DeltaCounter extends Counter {
+
+  public static final String DELTA_PREFIX = "\u2206"; // ∆: INCREMENT
+  private static final String ALT_DELTA_PREFIX = "\u0394"; // Δ: GREEK CAPITAL LETTER DELTA
+
+  @VisibleForTesting
+  public static synchronized DeltaCounter get(MetricRegistry registry, String metricName) {
+
+    if (registry == null || metricName == null || metricName.isEmpty()) {
+      throw new IllegalArgumentException("Invalid arguments");
+    }
+
+    if (!(metricName.startsWith(DELTA_PREFIX) || metricName.startsWith(ALT_DELTA_PREFIX))) {
+      metricName = DELTA_PREFIX + metricName;
+    }
+    DeltaCounter counter = new DeltaCounter();
+    registry.register(metricName, counter);
+    return counter;
+  }
+}

--- a/java-lib/src/main/java/com/wavefront/api/DataIngesterAPI.java
+++ b/java-lib/src/main/java/com/wavefront/api/DataIngesterAPI.java
@@ -11,23 +11,16 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
 /**
+ * The API for reporting points directly to a Wavefront server.
  *
  * @author Vikram Raman
  */
 @Path("/")
-public interface DataIngestorAPI {
+public interface DataIngesterAPI {
 
   @POST
   @Path("report")
   @Consumes({MediaType.APPLICATION_OCTET_STREAM, MediaType.APPLICATION_FORM_URLENCODED,
       MediaType.TEXT_PLAIN})
   Response report(@QueryParam("f") String format, InputStream stream) throws IOException;
-
-  /*
-  @POST
-  @Path("report")
-  @Consumes(MediaType.MULTIPART_FORM_DATA)
-  Response uploadFile(@QueryParam("f") String format,
-                      @FormDataParam("file") InputStream uploadedInputStream,
-                      @FormDataParam("file") FormDataContentDisposition fileDetails);*/
 }

--- a/java-lib/src/main/java/com/wavefront/api/DataIngestorAPI.java
+++ b/java-lib/src/main/java/com/wavefront/api/DataIngestorAPI.java
@@ -1,0 +1,33 @@
+package com.wavefront.api;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+/**
+ *
+ * @author Vikram Raman
+ */
+@Path("/")
+public interface DataIngestorAPI {
+
+  @POST
+  @Path("report")
+  @Consumes({MediaType.APPLICATION_OCTET_STREAM, MediaType.APPLICATION_FORM_URLENCODED,
+      MediaType.TEXT_PLAIN})
+  Response report(@QueryParam("f") String format, InputStream stream) throws IOException;
+
+  /*
+  @POST
+  @Path("report")
+  @Consumes(MediaType.MULTIPART_FORM_DATA)
+  Response uploadFile(@QueryParam("f") String format,
+                      @FormDataParam("file") InputStream uploadedInputStream,
+                      @FormDataParam("file") FormDataContentDisposition fileDetails);*/
+}

--- a/java-lib/src/main/java/com/wavefront/common/Constants.java
+++ b/java-lib/src/main/java/com/wavefront/common/Constants.java
@@ -1,0 +1,11 @@
+package com.wavefront.common;
+
+/**
+ * Metric constants.
+ *
+ * @author Vikram Raman (vikram@wavefront.com)
+ */
+public abstract class Constants {
+  public static final String DELTA_PREFIX = "\u2206"; // ∆: INCREMENT
+  public static final String DELTA_PREFIX_2 = "\u0394"; // Δ: GREEK CAPITAL LETTER DELTA
+}

--- a/java-lib/src/main/java/com/wavefront/common/NamedThreadFactory.java
+++ b/java-lib/src/main/java/com/wavefront/common/NamedThreadFactory.java
@@ -1,4 +1,4 @@
-package com.wavefront.agent;
+package com.wavefront.common;
 
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.atomic.AtomicInteger;

--- a/java-lib/src/main/java/com/wavefront/ingester/ReportPointIngesterFormatter.java
+++ b/java-lib/src/main/java/com/wavefront/ingester/ReportPointIngesterFormatter.java
@@ -1,6 +1,7 @@
 package com.wavefront.ingester;
 
 import com.wavefront.common.Clock;
+import com.wavefront.common.Constants;
 
 import org.antlr.v4.runtime.Token;
 
@@ -19,9 +20,6 @@ import wavefront.report.ReportPoint;
  * @author Clement Pang (clement@wavefront.com).
  */
 public class ReportPointIngesterFormatter extends AbstractIngesterFormatter<ReportPoint> {
-
-  private static final String DELTA_PREFIX = "\u2206"; // ∆: INCREMENT
-  private static final String DELTA_PREFIX_2 = "\u0394"; // Δ: GREEK CAPITAL LETTER DELTA
 
   private ReportPointIngesterFormatter(List<FormatterElement> elements) {
     super(elements);
@@ -64,7 +62,7 @@ public class ReportPointIngesterFormatter extends AbstractIngesterFormatter<Repo
     }
 
     // Delta metrics cannot have negative values
-    if ((point.getMetric().startsWith(DELTA_PREFIX) || point.getMetric().startsWith(DELTA_PREFIX_2)) &&
+    if ((point.getMetric().startsWith(Constants.DELTA_PREFIX) || point.getMetric().startsWith(Constants.DELTA_PREFIX_2)) &&
         point.getValue() instanceof Number) {
       double v = ((Number) point.getValue()).doubleValue();
       if (v <= 0) {

--- a/proxy/src/main/java/com/wavefront/agent/AbstractAgent.java
+++ b/proxy/src/main/java/com/wavefront/agent/AbstractAgent.java
@@ -26,6 +26,7 @@ import com.wavefront.api.WavefrontAPI;
 import com.wavefront.api.agent.AgentConfiguration;
 import com.wavefront.api.agent.Constants;
 import com.wavefront.common.Clock;
+import com.wavefront.common.NamedThreadFactory;
 import com.wavefront.common.TaggedMetricName;
 import com.wavefront.metrics.ExpectedAgentMetric;
 import com.wavefront.metrics.JsonMetricsGenerator;

--- a/proxy/src/main/java/com/wavefront/agent/PostPushDataTimedTask.java
+++ b/proxy/src/main/java/com/wavefront/agent/PostPushDataTimedTask.java
@@ -5,6 +5,7 @@ import com.google.common.util.concurrent.RecyclableRateLimiter;
 
 import com.wavefront.agent.api.ForceQueueEnabledAgentAPI;
 import com.wavefront.api.agent.Constants;
+import com.wavefront.common.NamedThreadFactory;
 import com.wavefront.ingester.StringLineIngester;
 import com.yammer.metrics.Metrics;
 import com.yammer.metrics.core.Counter;

--- a/proxy/src/main/java/com/wavefront/agent/PostSourceTagTimedTask.java
+++ b/proxy/src/main/java/com/wavefront/agent/PostSourceTagTimedTask.java
@@ -3,6 +3,7 @@ package com.wavefront.agent;
 import com.google.common.util.concurrent.RateLimiter;
 
 import com.wavefront.agent.api.ForceQueueEnabledAgentAPI;
+import com.wavefront.common.NamedThreadFactory;
 import com.yammer.metrics.Metrics;
 import com.yammer.metrics.core.Counter;
 import com.yammer.metrics.core.MetricName;

--- a/proxy/src/main/java/com/wavefront/agent/PushAgent.java
+++ b/proxy/src/main/java/com/wavefront/agent/PushAgent.java
@@ -32,6 +32,7 @@ import com.wavefront.agent.preprocessor.ReportPointAddPrefixTransformer;
 import com.wavefront.agent.preprocessor.ReportPointTimestampInRangeFilter;
 import com.wavefront.api.agent.AgentConfiguration;
 import com.wavefront.api.agent.Constants;
+import com.wavefront.common.NamedThreadFactory;
 import com.wavefront.ingester.Decoder;
 import com.wavefront.ingester.GraphiteDecoder;
 import com.wavefront.ingester.GraphiteHostAnnotator;

--- a/proxy/src/main/java/com/wavefront/agent/QueuedAgentService.java
+++ b/proxy/src/main/java/com/wavefront/agent/QueuedAgentService.java
@@ -25,6 +25,7 @@ import com.wavefront.agent.api.ForceQueueEnabledAgentAPI;
 import com.wavefront.api.WavefrontAPI;
 import com.wavefront.api.agent.AgentConfiguration;
 import com.wavefront.api.agent.ShellOutputDTO;
+import com.wavefront.common.NamedThreadFactory;
 import com.wavefront.ingester.StringLineIngester;
 import com.wavefront.metrics.ExpectedAgentMetric;
 import com.yammer.metrics.Metrics;


### PR DESCRIPTION
MONIT-7066: Added direct ingestion/delta metrics support for Java.

Note: @basilisk487 's PR (https://github.com/wavefrontHQ/java/pull/270) includes changes to the WavefrontReporter. I can merge his changes into this PR once it is merged into master before this is merged.