### PR TITLE
Preprocessor improvements

### DIFF
--- a/pkg/etc/wavefront/wavefront-proxy/preprocessor_rules.yaml.default
+++ b/pkg/etc/wavefront/wavefront-proxy/preprocessor_rules.yaml.default
@@ -16,8 +16,9 @@
 ##   - forceLowercase: convert a point's component (metric name, source, point tag value) to lowercase
 ##   - dropTag: remove a point tag. optional: remove tag only when its value matches a regex pattern (full match))
 ##   - addTag: add a new point tag. if such point tag already exists, an existing value will be replaced
-##   - addTagIfNotExists: add a new point tag, but don't overwrite an existing value if such point tag already exists
+##   - addTagIfNotExists: add a new point tag, but don't overwrite existing value if such point tag already exists
 ##   - extractTag: create a new point tag based on a metric name, source name or another point tag
+##   - extractTagIfNotExists: same as above, but don't overwrite existing value if such point tag already exists
 ##   - renameTag: rename a point tag, preserving its value. optional: rename it only when the point tag value matches
 ##                a regex pattern (full match). this functionality allows separating a point tag with mixed data into
 ##                separate tags.
@@ -188,6 +189,20 @@
   #  action  : blacklistRegex
   #  scope   : blocker
   #  match   : ".*"
+
+  ## extract 3rd dot-delimited node from the metric name into newTag
+  ## point tag, and remove it from the metric, i.e. from
+  ## "delimited.metric.tagValue.foo" metric extract "newTag=tagValue"
+  ## tag and change metric name to "delimited.metric.foo"
+  ################################################################
+  #- rule          : example-extract-tag-from-delimited-metric
+  #  action        : extractTag
+  #  tag           : newTag
+  #  source        : metricName
+  #  match         : "delimited.*"
+  #  search        : "^([^\\.]*\\.[^\\.]*\\.)([^\\.]*)\\.(.*)$"
+  #  replace       : "$2"
+  #  replaceSource : "$1$3" # optional, omit if you plan on just extracting the tag leaving the metric name intact
 
 
 # rules for port 4242

--- a/proxy/src/main/java/com/wavefront/agent/preprocessor/AgentPreprocessorConfiguration.java
+++ b/proxy/src/main/java/com/wavefront/agent/preprocessor/AgentPreprocessorConfiguration.java
@@ -74,11 +74,12 @@ public class AgentPreprocessorConfiguration {
           try {
             requireArguments(rule, "rule", "action");
             allowArguments(rule, "rule", "action", "scope", "search", "replace", "match",
-                "tag", "newtag", "value", "source", "iterations");
+                "tag", "newtag", "value", "source", "iterations", "replaceSource");
             String ruleName = rule.get("rule").replaceAll("[^a-z0-9_-]", "");
             PreprocessorRuleMetrics ruleMetrics = new PreprocessorRuleMetrics(
                 Metrics.newCounter(new TaggedMetricName("preprocessor." + ruleName, "count", "port", strPort)),
-                Metrics.newCounter(new TaggedMetricName("preprocessor." + ruleName, "cpu_nanos", "port", strPort)));
+                Metrics.newCounter(new TaggedMetricName("preprocessor." + ruleName, "cpu_nanos", "port", strPort)),
+                Metrics.newCounter(new TaggedMetricName("preprocessor." + ruleName, "checked.count", "port", strPort)));
 
             if (rule.get("scope") != null && rule.get("scope").equals("pointLine")) {
               switch (rule.get("action")) {
@@ -131,10 +132,19 @@ public class AgentPreprocessorConfiguration {
                       new ReportPointDropTagTransformer(rule.get("tag"), rule.get("match"), ruleMetrics));
                   break;
                 case "extractTag":
-                  allowArguments(rule, "rule", "action", "tag", "source", "search", "replace", "match");
+                  allowArguments(rule, "rule", "action", "tag", "source", "search", "replace", "replaceSource",
+                      "match");
                   this.forPort(strPort).forReportPoint().addTransformer(
                       new ReportPointExtractTagTransformer(rule.get("tag"), rule.get("source"), rule.get("search"),
-                          rule.get("replace"), rule.get("match"), ruleMetrics));
+                          rule.get("replace"), rule.get("replaceSource"), rule.get("match"), ruleMetrics));
+                  break;
+                case "extractTagIfNotExists":
+                  allowArguments(rule, "rule", "action", "tag", "source", "search", "replace", "replaceSource",
+                      "match");
+                  this.forPort(strPort).forReportPoint().addTransformer(
+                      new ReportPointExtractTagIfNotExistsTransformer(rule.get("tag"), rule.get("source"),
+                          rule.get("search"), rule.get("replace"), rule.get("replaceSource"), rule.get("match"),
+                          ruleMetrics));
                   break;
                 case "renameTag":
                   allowArguments(rule, "rule", "action", "tag", "newtag", "match");

--- a/proxy/src/main/java/com/wavefront/agent/preprocessor/PointLineBlacklistRegexFilter.java
+++ b/proxy/src/main/java/com/wavefront/agent/preprocessor/PointLineBlacklistRegexFilter.java
@@ -18,6 +18,7 @@ public class PointLineBlacklistRegexFilter extends AnnotatedPredicate<String> {
   private final Pattern compiledPattern;
   private final PreprocessorRuleMetrics ruleMetrics;
 
+  @Deprecated
   public PointLineBlacklistRegexFilter(final String patternMatch,
                                        @Nullable final Counter ruleAppliedCounter) {
     this(patternMatch, new PreprocessorRuleMetrics(ruleAppliedCounter));
@@ -33,13 +34,13 @@ public class PointLineBlacklistRegexFilter extends AnnotatedPredicate<String> {
 
   @Override
   public boolean apply(String pointLine) {
-    Long startNanos = System.nanoTime();
+    long startNanos = ruleMetrics.ruleStart();
     if (compiledPattern.matcher(pointLine).matches()) {
       ruleMetrics.incrementRuleAppliedCounter();
-      ruleMetrics.countCpuNanos(System.nanoTime() - startNanos);
+      ruleMetrics.ruleEnd(startNanos);
       return false;
     }
-    ruleMetrics.countCpuNanos(System.nanoTime() - startNanos);
+    ruleMetrics.ruleEnd(startNanos);
     return true;
   }
 }

--- a/proxy/src/main/java/com/wavefront/agent/preprocessor/PointLineReplaceRegexTransformer.java
+++ b/proxy/src/main/java/com/wavefront/agent/preprocessor/PointLineReplaceRegexTransformer.java
@@ -24,6 +24,7 @@ public class PointLineReplaceRegexTransformer implements Function<String, String
   private final Pattern compiledMatchPattern;
   private final PreprocessorRuleMetrics ruleMetrics;
 
+  @Deprecated
   public PointLineReplaceRegexTransformer(final String patternSearch,
                                           final String patternReplace,
                                           @Nullable final String patternMatch,
@@ -49,15 +50,15 @@ public class PointLineReplaceRegexTransformer implements Function<String, String
 
   @Override
   public String apply(String pointLine) {
-    Long startNanos = System.nanoTime();
+    long startNanos = ruleMetrics.ruleStart();
     if (compiledMatchPattern != null && !compiledMatchPattern.matcher(pointLine).matches()) {
-      ruleMetrics.countCpuNanos(System.nanoTime() - startNanos);
+      ruleMetrics.ruleEnd(startNanos);
       return pointLine;
     }
     Matcher patternMatcher = compiledSearchPattern.matcher(pointLine);
 
     if (!patternMatcher.find()) {
-      ruleMetrics.countCpuNanos(System.nanoTime() - startNanos);
+      ruleMetrics.ruleEnd(startNanos);
       return pointLine;
     }
     ruleMetrics.incrementRuleAppliedCounter(); // count the rule only once regardless of the number of iterations
@@ -74,7 +75,7 @@ public class PointLineReplaceRegexTransformer implements Function<String, String
         break;
       }
     }
-    ruleMetrics.countCpuNanos(System.nanoTime() - startNanos);
+    ruleMetrics.ruleEnd(startNanos);
     return pointLine;
   }
 }

--- a/proxy/src/main/java/com/wavefront/agent/preprocessor/PointLineWhitelistRegexFilter.java
+++ b/proxy/src/main/java/com/wavefront/agent/preprocessor/PointLineWhitelistRegexFilter.java
@@ -18,6 +18,7 @@ public class PointLineWhitelistRegexFilter extends AnnotatedPredicate<String> {
   private final Pattern compiledPattern;
   private final PreprocessorRuleMetrics ruleMetrics;
 
+  @Deprecated
   public PointLineWhitelistRegexFilter(final String patternMatch,
                                        @Nullable final Counter ruleAppliedCounter) {
     this(patternMatch, new PreprocessorRuleMetrics(ruleAppliedCounter));
@@ -33,13 +34,13 @@ public class PointLineWhitelistRegexFilter extends AnnotatedPredicate<String> {
 
   @Override
   public boolean apply(String pointLine) {
-  Long startNanos = System.nanoTime();
+  long startNanos = ruleMetrics.ruleStart();
     if (!compiledPattern.matcher(pointLine).matches()) {
       ruleMetrics.incrementRuleAppliedCounter();
-      ruleMetrics.countCpuNanos(System.nanoTime() - startNanos);
+      ruleMetrics.ruleEnd(startNanos);
       return false;
     }
-    ruleMetrics.countCpuNanos(System.nanoTime() - startNanos);
+    ruleMetrics.ruleEnd(startNanos);
     return true;
   }
 }

--- a/proxy/src/main/java/com/wavefront/agent/preprocessor/PreprocessorRuleMetrics.java
+++ b/proxy/src/main/java/com/wavefront/agent/preprocessor/PreprocessorRuleMetrics.java
@@ -16,12 +16,22 @@ public class PreprocessorRuleMetrics {
   private final Counter ruleAppliedCounter;
   @Nullable
   private final Counter ruleCpuTimeNanosCounter;
+  @Nullable
+  private final Counter ruleCheckedCounter;
 
-  public PreprocessorRuleMetrics(@Nullable Counter ruleAppliedCounter, @Nullable Counter ruleCpuTimeNanosCounter) {
+  public PreprocessorRuleMetrics(@Nullable Counter ruleAppliedCounter, @Nullable Counter ruleCpuTimeNanosCounter,
+                                 @Nullable Counter ruleCheckedCounter) {
     this.ruleAppliedCounter = ruleAppliedCounter;
     this.ruleCpuTimeNanosCounter = ruleCpuTimeNanosCounter;
+    this.ruleCheckedCounter = ruleCheckedCounter;
   }
 
+  @Deprecated
+  public PreprocessorRuleMetrics(@Nullable Counter ruleAppliedCounter, @Nullable Counter ruleCpuTimeNanosCounter) {
+    this(ruleAppliedCounter, ruleCpuTimeNanosCounter, null);
+  }
+
+  @Deprecated
   public PreprocessorRuleMetrics(@Nullable Counter ruleAppliedCounter) {
     this(ruleAppliedCounter, null);
   }
@@ -40,9 +50,34 @@ public class PreprocessorRuleMetrics {
    *
    * @param n the amount by which the counter will be increased
    */
+  @Deprecated
   public void countCpuNanos(long n) {
     if (this.ruleCpuTimeNanosCounter != null) {
       this.ruleCpuTimeNanosCounter.inc(n);
     }
+  }
+
+  /**
+   * Measure rule execution time and add it to ruleCpuTimeNanosCounter (if available)
+   *
+   * @param ruleStartTime rule start time
+   */
+  public void ruleEnd(long ruleStartTime) {
+    if (this.ruleCpuTimeNanosCounter != null) {
+      this.ruleCpuTimeNanosCounter.inc(System.nanoTime() - ruleStartTime);
+    }
+  }
+
+
+  /**
+   * Mark rule start time, increment ruleCheckedCounter (if available) by 1
+   *
+   * @return start time in nanos
+   */
+  public long ruleStart() {
+    if (this.ruleCheckedCounter != null) {
+      this.ruleCheckedCounter.inc();
+    }
+    return System.nanoTime();
   }
 }

--- a/proxy/src/main/java/com/wavefront/agent/preprocessor/ReportPointAddTagIfNotExistsTransformer.java
+++ b/proxy/src/main/java/com/wavefront/agent/preprocessor/ReportPointAddTagIfNotExistsTransformer.java
@@ -16,12 +16,9 @@ import wavefront.report.ReportPoint;
  *
  * Created by Vasily on 9/13/16.
  */
-public class ReportPointAddTagIfNotExistsTransformer implements Function<ReportPoint, ReportPoint> {
+public class ReportPointAddTagIfNotExistsTransformer extends ReportPointAddTagTransformer {
 
-  private final String tag;
-  private final String value;
-  private final PreprocessorRuleMetrics ruleMetrics;
-
+  @Deprecated
   public ReportPointAddTagIfNotExistsTransformer(final String tag,
                                                  final String value,
                                                  @Nullable final Counter ruleAppliedCounter) {
@@ -31,17 +28,12 @@ public class ReportPointAddTagIfNotExistsTransformer implements Function<ReportP
   public ReportPointAddTagIfNotExistsTransformer(final String tag,
                                                  final String value,
                                                  final PreprocessorRuleMetrics ruleMetrics) {
-    this.tag = Preconditions.checkNotNull(tag, "[tag] can't be null");
-    this.value = Preconditions.checkNotNull(value, "[value] can't be null");
-    Preconditions.checkArgument(!tag.isEmpty(), "[tag] can't be blank");
-    Preconditions.checkArgument(!value.isEmpty(), "[value] can't be blank");
-    Preconditions.checkNotNull(ruleMetrics, "PreprocessorRuleMetrics can't be null");
-    this.ruleMetrics = ruleMetrics;
+    super(tag, value, ruleMetrics);
   }
 
   @Override
   public ReportPoint apply(@NotNull ReportPoint reportPoint) {
-    Long startNanos = System.nanoTime();
+    long startNanos = ruleMetrics.ruleStart();
     if (reportPoint.getAnnotations() == null) {
       reportPoint.setAnnotations(Maps.<String, String>newHashMap());
     }
@@ -49,7 +41,7 @@ public class ReportPointAddTagIfNotExistsTransformer implements Function<ReportP
       reportPoint.getAnnotations().put(tag, PreprocessorUtil.expandPlaceholders(value, reportPoint));
       ruleMetrics.incrementRuleAppliedCounter();
     }
-    ruleMetrics.countCpuNanos(System.nanoTime() - startNanos);
+    ruleMetrics.ruleEnd(startNanos);
     return reportPoint;
   }
 }

--- a/proxy/src/main/java/com/wavefront/agent/preprocessor/ReportPointAddTagTransformer.java
+++ b/proxy/src/main/java/com/wavefront/agent/preprocessor/ReportPointAddTagTransformer.java
@@ -18,10 +18,11 @@ import wavefront.report.ReportPoint;
  */
 public class ReportPointAddTagTransformer implements Function<ReportPoint, ReportPoint> {
 
-  private final String tag;
-  private final String value;
-  private final PreprocessorRuleMetrics ruleMetrics;
+  protected final String tag;
+  protected final String value;
+  protected final PreprocessorRuleMetrics ruleMetrics;
 
+  @Deprecated
   public ReportPointAddTagTransformer(final String tag,
                                       final String value,
                                       @Nullable final Counter ruleAppliedCounter) {
@@ -41,13 +42,13 @@ public class ReportPointAddTagTransformer implements Function<ReportPoint, Repor
 
   @Override
   public ReportPoint apply(@NotNull ReportPoint reportPoint) {
-    Long startNanos = System.nanoTime();
+    long startNanos = ruleMetrics.ruleStart();
     if (reportPoint.getAnnotations() == null) {
       reportPoint.setAnnotations(Maps.<String, String>newHashMap());
     }
     reportPoint.getAnnotations().put(tag, PreprocessorUtil.expandPlaceholders(value, reportPoint));
     ruleMetrics.incrementRuleAppliedCounter();
-    ruleMetrics.countCpuNanos(System.nanoTime() - startNanos);
+    ruleMetrics.ruleEnd(startNanos);
     return reportPoint;
   }
 }

--- a/proxy/src/main/java/com/wavefront/agent/preprocessor/ReportPointBlacklistRegexFilter.java
+++ b/proxy/src/main/java/com/wavefront/agent/preprocessor/ReportPointBlacklistRegexFilter.java
@@ -23,6 +23,7 @@ public class ReportPointBlacklistRegexFilter extends AnnotatedPredicate<ReportPo
   private final Pattern compiledPattern;
   private final PreprocessorRuleMetrics ruleMetrics;
 
+  @Deprecated
   public ReportPointBlacklistRegexFilter(final String scope,
                                          final String patternMatch,
                                          @Nullable final Counter ruleAppliedCounter) {
@@ -42,19 +43,19 @@ public class ReportPointBlacklistRegexFilter extends AnnotatedPredicate<ReportPo
 
   @Override
   public boolean apply(@NotNull ReportPoint reportPoint) {
-    Long startNanos = System.nanoTime();
+    long startNanos = ruleMetrics.ruleStart();
     switch (scope) {
       case "metricName":
         if (compiledPattern.matcher(reportPoint.getMetric()).matches()) {
           ruleMetrics.incrementRuleAppliedCounter();
-          ruleMetrics.countCpuNanos(System.nanoTime() - startNanos);
+          ruleMetrics.ruleEnd(startNanos);
           return false;
         }
         break;
       case "sourceName":
         if (compiledPattern.matcher(reportPoint.getHost()).matches()) {
           ruleMetrics.incrementRuleAppliedCounter();
-          ruleMetrics.countCpuNanos(System.nanoTime() - startNanos);
+          ruleMetrics.ruleEnd(startNanos);
           return false;
         }
         break;
@@ -64,13 +65,13 @@ public class ReportPointBlacklistRegexFilter extends AnnotatedPredicate<ReportPo
           if (tagValue != null) {
             if (compiledPattern.matcher(tagValue).matches()) {
               ruleMetrics.incrementRuleAppliedCounter();
-              ruleMetrics.countCpuNanos(System.nanoTime() - startNanos);
+              ruleMetrics.ruleEnd(startNanos);
               return false;
             }
           }
         }
     }
-    ruleMetrics.countCpuNanos(System.nanoTime() - startNanos);
+    ruleMetrics.ruleEnd(startNanos);
     return true;
   }
 }

--- a/proxy/src/main/java/com/wavefront/agent/preprocessor/ReportPointDropTagTransformer.java
+++ b/proxy/src/main/java/com/wavefront/agent/preprocessor/ReportPointDropTagTransformer.java
@@ -27,6 +27,7 @@ public class ReportPointDropTagTransformer implements Function<ReportPoint, Repo
   private final Pattern compiledValuePattern;
   private final PreprocessorRuleMetrics ruleMetrics;
 
+  @Deprecated
   public ReportPointDropTagTransformer(final String tag,
                                        @Nullable final String patternMatch,
                                        @Nullable final Counter ruleAppliedCounter) {
@@ -45,9 +46,9 @@ public class ReportPointDropTagTransformer implements Function<ReportPoint, Repo
 
   @Override
   public ReportPoint apply(@NotNull ReportPoint reportPoint) {
-    Long startNanos = System.nanoTime();
+    long startNanos = ruleMetrics.ruleStart();
     if (reportPoint.getAnnotations() == null || compiledTagPattern == null) {
-      ruleMetrics.countCpuNanos(System.nanoTime() - startNanos);
+      ruleMetrics.ruleEnd(startNanos);
       return reportPoint;
     }
     Iterator<Map.Entry<String, String>> iterator = reportPoint.getAnnotations().entrySet().iterator();
@@ -60,7 +61,7 @@ public class ReportPointDropTagTransformer implements Function<ReportPoint, Repo
         }
       }
     }
-    ruleMetrics.countCpuNanos(System.nanoTime() - startNanos);
+    ruleMetrics.ruleEnd(startNanos);
     return reportPoint;
   }
 }

--- a/proxy/src/main/java/com/wavefront/agent/preprocessor/ReportPointExtractTagIfNotExistsTransformer.java
+++ b/proxy/src/main/java/com/wavefront/agent/preprocessor/ReportPointExtractTagIfNotExistsTransformer.java
@@ -1,0 +1,59 @@
+package com.wavefront.agent.preprocessor;
+
+import com.google.common.base.Function;
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Maps;
+
+import com.yammer.metrics.core.Counter;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import javax.annotation.Nullable;
+import javax.validation.constraints.NotNull;
+
+import wavefront.report.ReportPoint;
+
+/**
+ * Create a point tag by extracting a portion of a metric name, source name or another point tag.
+ * If such point tag already exists, the value won't be overwritten.
+ *
+ * @author vasily@wavefront.com
+ * Created 5/18/18
+ */
+public class ReportPointExtractTagIfNotExistsTransformer extends ReportPointExtractTagTransformer {
+
+  @Deprecated
+  public ReportPointExtractTagIfNotExistsTransformer(final String tag,
+                                                     final String source,
+                                                     final String patternSearch,
+                                                     final String patternReplace,
+                                                     @Nullable final String patternMatch,
+                                                     @Nullable final Counter ruleAppliedCounter) {
+    this(tag, source, patternSearch, patternReplace, null, patternMatch,
+        new PreprocessorRuleMetrics(ruleAppliedCounter));
+  }
+
+  public ReportPointExtractTagIfNotExistsTransformer(final String tag,
+                                                     final String source,
+                                                     final String patternSearch,
+                                                     final String patternReplace,
+                                                     @Nullable final String replaceSource,
+                                                     @Nullable final String patternMatch,
+                                                     final PreprocessorRuleMetrics ruleMetrics) {
+    super(tag, source, patternSearch, patternReplace, replaceSource, patternMatch, ruleMetrics);
+  }
+
+  @Override
+  public ReportPoint apply(@NotNull ReportPoint reportPoint) {
+    long startNanos = ruleMetrics.ruleStart();
+    if (reportPoint.getAnnotations() == null) {
+      reportPoint.setAnnotations(Maps.<String, String>newHashMap());
+    }
+    if (reportPoint.getAnnotations().get(tag) == null) {
+      internalApply(reportPoint);
+    }
+    ruleMetrics.ruleEnd(startNanos);
+    return reportPoint;
+  }
+}

--- a/proxy/src/main/java/com/wavefront/agent/preprocessor/ReportPointExtractTagTransformer.java
+++ b/proxy/src/main/java/com/wavefront/agent/preprocessor/ReportPointExtractTagTransformer.java
@@ -21,27 +21,32 @@ import wavefront.report.ReportPoint;
  */
 public class ReportPointExtractTagTransformer implements Function<ReportPoint, ReportPoint>{
 
-  private final String tag;
-  private final String source;
-  private final String patternReplace;
-  private final Pattern compiledSearchPattern;
+  protected final String tag;
+  protected final String source;
+  protected final String patternReplace;
+  protected final Pattern compiledSearchPattern;
   @Nullable
-  private final Pattern compiledMatchPattern;
-  private final PreprocessorRuleMetrics ruleMetrics;
+  protected final Pattern compiledMatchPattern;
+  @Nullable
+  protected final String patternReplaceSource;
+  protected final PreprocessorRuleMetrics ruleMetrics;
 
+  @Deprecated
   public ReportPointExtractTagTransformer(final String tag,
                                           final String source,
                                           final String patternSearch,
                                           final String patternReplace,
                                           @Nullable final String patternMatch,
                                           @Nullable final Counter ruleAppliedCounter) {
-    this(tag, source, patternSearch, patternReplace, patternMatch, new PreprocessorRuleMetrics(ruleAppliedCounter));
+    this(tag, source, patternSearch, patternReplace, null, patternMatch,
+        new PreprocessorRuleMetrics(ruleAppliedCounter));
   }
 
   public ReportPointExtractTagTransformer(final String tag,
                                           final String source,
                                           final String patternSearch,
                                           final String patternReplace,
+                                          @Nullable final String replaceSource,
                                           @Nullable final String patternMatch,
                                           final PreprocessorRuleMetrics ruleMetrics) {
     this.tag = Preconditions.checkNotNull(tag, "[tag] can't be null");
@@ -52,44 +57,64 @@ public class ReportPointExtractTagTransformer implements Function<ReportPoint, R
     Preconditions.checkArgument(!source.isEmpty(), "[source] can't be blank");
     Preconditions.checkArgument(!patternSearch.isEmpty(), "[search] can't be blank");
     this.compiledMatchPattern = patternMatch != null ? Pattern.compile(patternMatch) : null;
+    this.patternReplaceSource = replaceSource;
     Preconditions.checkNotNull(ruleMetrics, "PreprocessorRuleMetrics can't be null");
     this.ruleMetrics = ruleMetrics;
   }
 
-  private void extractTag(@NotNull ReportPoint reportPoint, final String extractFrom) {
+  protected boolean extractTag(@NotNull ReportPoint reportPoint, final String extractFrom) {
     Matcher patternMatcher;
-    if (compiledMatchPattern != null && !compiledMatchPattern.matcher(extractFrom).matches()) {
-      return;
+    if (extractFrom == null || (compiledMatchPattern != null && !compiledMatchPattern.matcher(extractFrom).matches())) {
+      return false;
     }
     patternMatcher = compiledSearchPattern.matcher(extractFrom);
-    if (patternMatcher.find()) {
-      if (reportPoint.getAnnotations() == null) {
-        reportPoint.setAnnotations(Maps.<String, String>newHashMap());
-      }
-      String value = patternMatcher.replaceAll(PreprocessorUtil.expandPlaceholders(patternReplace, reportPoint));
-      if (!value.isEmpty()) {
-        reportPoint.getAnnotations().put(tag, value);
-        ruleMetrics.incrementRuleAppliedCounter();
-      }
+    if (!patternMatcher.find()) {
+      return false;
+    }
+    if (reportPoint.getAnnotations() == null) {
+      reportPoint.setAnnotations(Maps.<String, String>newHashMap());
+    }
+    String value = patternMatcher.replaceAll(PreprocessorUtil.expandPlaceholders(patternReplace, reportPoint));
+    if (!value.isEmpty()) {
+      reportPoint.getAnnotations().put(tag, value);
+      ruleMetrics.incrementRuleAppliedCounter();
+    }
+    return true;
+  }
+
+  protected void internalApply(@NotNull ReportPoint reportPoint) {
+    switch (source) {
+      case "metricName":
+        if (extractTag(reportPoint, reportPoint.getMetric()) && patternReplaceSource != null) {
+          reportPoint.setMetric(compiledSearchPattern.matcher(reportPoint.getMetric()).
+              replaceAll(PreprocessorUtil.expandPlaceholders(patternReplaceSource, reportPoint)));
+        }
+        break;
+      case "sourceName":
+        if (extractTag(reportPoint, reportPoint.getHost()) && patternReplaceSource != null) {
+          reportPoint.setHost(compiledSearchPattern.matcher(reportPoint.getHost()).
+              replaceAll(PreprocessorUtil.expandPlaceholders(patternReplaceSource, reportPoint)));
+        }
+        break;
+      default:
+        if (reportPoint.getAnnotations() != null && reportPoint.getAnnotations().get(source) != null) {
+          if (extractTag(reportPoint, reportPoint.getAnnotations().get(source)) && patternReplaceSource != null) {
+            reportPoint.getAnnotations().put(source,
+                compiledSearchPattern.matcher(reportPoint.getAnnotations().get(source)).
+                    replaceAll(PreprocessorUtil.expandPlaceholders(patternReplaceSource, reportPoint)));
+          }
+        }
     }
   }
 
   @Override
   public ReportPoint apply(@NotNull ReportPoint reportPoint) {
-    Long startNanos = System.nanoTime();
-    switch (source) {
-      case "metricName":
-        extractTag(reportPoint, reportPoint.getMetric());
-        break;
-      case "sourceName":
-        extractTag(reportPoint, reportPoint.getHost());
-        break;
-      default:
-        if (reportPoint.getAnnotations() != null) {
-          extractTag(reportPoint, reportPoint.getAnnotations().get(source));
-        }
+    long startNanos = ruleMetrics.ruleStart();
+    if (reportPoint.getAnnotations() == null) {
+      reportPoint.setAnnotations(Maps.<String, String>newHashMap());
     }
-    ruleMetrics.countCpuNanos(System.nanoTime() - startNanos);
+    internalApply(reportPoint);
+    ruleMetrics.ruleEnd(startNanos);
     return reportPoint;
   }
 }

--- a/proxy/src/main/java/com/wavefront/agent/preprocessor/ReportPointForceLowercaseTransformer.java
+++ b/proxy/src/main/java/com/wavefront/agent/preprocessor/ReportPointForceLowercaseTransformer.java
@@ -25,6 +25,7 @@ public class ReportPointForceLowercaseTransformer implements Function<ReportPoin
   private final Pattern compiledMatchPattern;
   private final PreprocessorRuleMetrics ruleMetrics;
 
+  @Deprecated
   public ReportPointForceLowercaseTransformer(final String scope,
                                               @Nullable final String patternMatch,
                                               @Nullable final Counter ruleAppliedCounter) {
@@ -43,7 +44,7 @@ public class ReportPointForceLowercaseTransformer implements Function<ReportPoin
 
   @Override
   public ReportPoint apply(@NotNull ReportPoint reportPoint) {
-    Long startNanos = System.nanoTime();
+    long startNanos = ruleMetrics.ruleStart();
     switch (scope) {
       case "metricName":
         if (compiledMatchPattern != null && !compiledMatchPattern.matcher(reportPoint.getMetric()).matches()) {
@@ -71,7 +72,7 @@ public class ReportPointForceLowercaseTransformer implements Function<ReportPoin
           }
         }
     }
-    ruleMetrics.countCpuNanos(System.nanoTime() - startNanos);
+    ruleMetrics.ruleEnd(startNanos);
     return reportPoint;
   }
 }

--- a/proxy/src/main/java/com/wavefront/agent/preprocessor/ReportPointRenameTagTransformer.java
+++ b/proxy/src/main/java/com/wavefront/agent/preprocessor/ReportPointRenameTagTransformer.java
@@ -25,6 +25,7 @@ public class ReportPointRenameTagTransformer implements Function<ReportPoint, Re
   private final Pattern compiledPattern;
   private final PreprocessorRuleMetrics ruleMetrics;
 
+  @Deprecated
   public ReportPointRenameTagTransformer(final String tag,
                                          final String newTag,
                                          @Nullable final String patternMatch,
@@ -47,20 +48,20 @@ public class ReportPointRenameTagTransformer implements Function<ReportPoint, Re
 
   @Override
   public ReportPoint apply(@NotNull ReportPoint reportPoint) {
-    Long startNanos = System.nanoTime();
+    long startNanos = ruleMetrics.ruleStart();
     if (reportPoint.getAnnotations() == null) {
-      ruleMetrics.countCpuNanos(System.nanoTime() - startNanos);
+      ruleMetrics.ruleEnd(startNanos);
       return reportPoint;
     }
     String tagValue = reportPoint.getAnnotations().get(tag);
     if (tagValue == null || (compiledPattern != null && !compiledPattern.matcher(tagValue).matches())) {
-      ruleMetrics.countCpuNanos(System.nanoTime() - startNanos);
+      ruleMetrics.ruleEnd(startNanos);
       return reportPoint;
     }
     reportPoint.getAnnotations().remove(tag);
     reportPoint.getAnnotations().put(newTag, tagValue);
     ruleMetrics.incrementRuleAppliedCounter();
-    ruleMetrics.countCpuNanos(System.nanoTime() - startNanos);
+    ruleMetrics.ruleEnd(startNanos);
     return reportPoint;
   }
 }

--- a/proxy/src/main/java/com/wavefront/agent/preprocessor/ReportPointReplaceRegexTransformer.java
+++ b/proxy/src/main/java/com/wavefront/agent/preprocessor/ReportPointReplaceRegexTransformer.java
@@ -29,6 +29,7 @@ public class ReportPointReplaceRegexTransformer implements Function<ReportPoint,
   private final Pattern compiledMatchPattern;
   private final PreprocessorRuleMetrics ruleMetrics;
 
+  @Deprecated
   public ReportPointReplaceRegexTransformer(final String scope,
                                             final String patternSearch,
                                             final String patternReplace,
@@ -80,7 +81,7 @@ public class ReportPointReplaceRegexTransformer implements Function<ReportPoint,
 
   @Override
   public ReportPoint apply(@NotNull ReportPoint reportPoint) {
-    Long startNanos = System.nanoTime();
+    long startNanos = ruleMetrics.ruleStart();
     switch (scope) {
       case "metricName":
         if (compiledMatchPattern != null && !compiledMatchPattern.matcher(reportPoint.getMetric()).matches()) {
@@ -105,7 +106,7 @@ public class ReportPointReplaceRegexTransformer implements Function<ReportPoint,
           }
         }
     }
-    ruleMetrics.countCpuNanos(System.nanoTime() - startNanos);
+    ruleMetrics.ruleEnd(startNanos);
     return reportPoint;
   }
 }

--- a/proxy/src/main/java/com/wavefront/agent/preprocessor/ReportPointWhitelistRegexFilter.java
+++ b/proxy/src/main/java/com/wavefront/agent/preprocessor/ReportPointWhitelistRegexFilter.java
@@ -23,6 +23,7 @@ public class ReportPointWhitelistRegexFilter extends AnnotatedPredicate<ReportPo
   private final Pattern compiledPattern;
   private final PreprocessorRuleMetrics ruleMetrics;
 
+  @Deprecated
   public ReportPointWhitelistRegexFilter(final String scope,
                                          final String patternMatch,
                                          @Nullable final Counter ruleAppliedCounter) {
@@ -42,19 +43,19 @@ public class ReportPointWhitelistRegexFilter extends AnnotatedPredicate<ReportPo
 
   @Override
   public boolean apply(@NotNull ReportPoint reportPoint) {
-    Long startNanos = System.nanoTime();
+    long startNanos = ruleMetrics.ruleStart();
     switch (scope) {
       case "metricName":
         if (!compiledPattern.matcher(reportPoint.getMetric()).matches()) {
           ruleMetrics.incrementRuleAppliedCounter();
-          ruleMetrics.countCpuNanos(System.nanoTime() - startNanos);
+          ruleMetrics.ruleEnd(startNanos);
           return false;
         }
         break;
       case "sourceName":
         if (!compiledPattern.matcher(reportPoint.getHost()).matches()) {
           ruleMetrics.incrementRuleAppliedCounter();
-          ruleMetrics.countCpuNanos(System.nanoTime() - startNanos);
+          ruleMetrics.ruleEnd(startNanos);
           return false;
         }
         break;
@@ -62,15 +63,15 @@ public class ReportPointWhitelistRegexFilter extends AnnotatedPredicate<ReportPo
         if (reportPoint.getAnnotations() != null) {
           String tagValue = reportPoint.getAnnotations().get(scope);
           if (tagValue != null && compiledPattern.matcher(tagValue).matches()) {
-            ruleMetrics.countCpuNanos(System.nanoTime() - startNanos);
+            ruleMetrics.ruleEnd(startNanos);
             return true;
           }
         }
         ruleMetrics.incrementRuleAppliedCounter();
-        ruleMetrics.countCpuNanos(System.nanoTime() - startNanos);
+        ruleMetrics.ruleEnd(startNanos);
         return false;
     }
-    ruleMetrics.countCpuNanos(System.nanoTime() - startNanos);
+    ruleMetrics.ruleEnd(startNanos);
     return true;
   }
 }

--- a/proxy/src/test/java/com/wavefront/agent/preprocessor/AgentConfigurationTest.java
+++ b/proxy/src/test/java/com/wavefront/agent/preprocessor/AgentConfigurationTest.java
@@ -18,7 +18,7 @@ public class AgentConfigurationTest {
       fail("Invalid rules did not cause an exception");
     } catch (RuntimeException ex) {
       Assert.assertEquals(0, config.totalValidRules);
-      Assert.assertEquals(100, config.totalInvalidRules);
+      Assert.assertEquals(111, config.totalInvalidRules);
     }
   }
 
@@ -28,6 +28,6 @@ public class AgentConfigurationTest {
     InputStream stream = PreprocessorRulesTest.class.getResourceAsStream("preprocessor_rules.yaml");
     config.loadFromStream(stream);
     Assert.assertEquals(0, config.totalInvalidRules);
-    Assert.assertEquals(30, config.totalValidRules);
+    Assert.assertEquals(34, config.totalValidRules);
   }
 }

--- a/proxy/src/test/java/com/wavefront/agent/preprocessor/PreprocessorRulesTest.java
+++ b/proxy/src/test/java/com/wavefront/agent/preprocessor/PreprocessorRulesTest.java
@@ -364,6 +364,19 @@ public class PreprocessorRulesTest {
         "\"baz\"=\"bar\" \"newtagkey\"=\"1\" \"numericTag\"=\"12345\" \"prefix\"=\"some\"";
     assertEquals(expectedPoint6, applyAllTransformers(
         "some.metric 7 1459527231 source=hostname foo=bar dc1=baz datacenter=az4 qux=12345", "2878"));
+
+    // in this test the following should happen:
+    // - fromMetric point tag extracted
+    // - "node2" removed from the metric name
+    // - fromSource point tag extracted
+    // - fromTag point tag extracted
+    String expectedPoint7 = "\"node0.node1.testExtractTag.node4\" 7.0 1459527231 source=\"host0-host1\" " +
+        "\"fromMetric\"=\"node2\" \"fromSource\"=\"host2\" \"fromTag\"=\"tag0\" " +
+        "\"testExtractTag\"=\"tag0.tag1.tag2.tag3.tag4\"";
+    assertEquals(expectedPoint7, applyAllTransformers(
+        "node0.node1.node2.testExtractTag.node4 7.0 1459527231 source=host0-host1-host2 " +
+            "testExtractTag=tag0.tag1.tag2.tag3.tag4", "1234"));
+
   }
 
   @Test

--- a/proxy/src/test/resources/com/wavefront/agent/preprocessor/preprocessor_rules.yaml
+++ b/proxy/src/test/resources/com/wavefront/agent/preprocessor/preprocessor_rules.yaml
@@ -184,3 +184,36 @@
       action  : forceLowercase
       scope   : metricName
       match   : "^.*$"
+
+'1234':
+    # extract 3rd dot-delimited node from the metric name into fromMetric tag and remove it from the metric name
+    - rule          : test-extracttag-metric
+      action        : extractTag
+      tag           : fromMetric
+      source        : metricName
+      match         : "^.*testExtractTag.*"
+      search        : "^([^\\.]*\\.[^\\.]*\\.)([^\\.]*)\\.(.*)$"
+      replace       : "$2"
+      replaceSource : "$1$3"
+
+    - rule          : test-extracttag-source
+      action        : extractTag
+      tag           : fromSource
+      source        : sourceName
+      search        : "^([^-]*-[^-]*)-(.*)$"
+      replace       : "$2"
+      replaceSource : "$1"
+
+    - rule          : test-extracttagifnotexists-tag
+      action        : extractTagIfNotExists
+      tag           : fromSource  # should not work because such tag already exists!
+      source        : testExtractTag
+      search        : "^.*$"
+      replace       : "Oi! This should never happen!"
+
+    - rule          : test-extracttagifnotexists-tag-2
+      action        : extractTagIfNotExists
+      tag           : fromTag
+      source        : testExtractTag
+      search        : "^([^\\.]*)\\..*$"
+      replace       : "$1"

--- a/proxy/src/test/resources/com/wavefront/agent/preprocessor/preprocessor_rules_invalid.yaml
+++ b/proxy/src/test/resources/com/wavefront/agent/preprocessor/preprocessor_rules_invalid.yaml
@@ -664,8 +664,107 @@
       replace : ""
 
     # value does not apply
-    - rule    : test-extractTag-10
+    - rule    : test-extractTag-11
       action  : extractTag
+      tag     : tag
+      source  : metricName
+      match   : match
+      search  : tag
+      replace : ""
+      value   : "1"
+
+    # test extractTagIfNotExists
+
+    # missing tag
+    - rule    : test-extractTagIfNotExists-1
+      action  : extractTagIfNotExists
+      match   : tag
+      source  : metricName
+      search  : tag
+      replace : replace
+
+    # null tag
+    - rule    : test-extractTagIfNotExists-2
+      action  : extractTagIfNotExists
+      tag     :
+      match   : tag
+      source  : metricName
+      search  : tag
+      replace : replace
+
+    # empty tag
+    - rule    : test-extractTagIfNotExists-3
+      action  : extractTagIfNotExists
+      tag     : ""
+      match   : match
+      source  : metricName
+      search  : tag
+      replace : replace
+
+    # missing source
+    - rule    : test-extractTagIfNotExists-4
+      action  : extractTagIfNotExists
+      tag     : tag
+      match   : match
+      search  : tag
+      replace : replace
+
+    # empty source
+    - rule    : test-extractTagIfNotExists-5
+      action  : extractTagIfNotExists
+      tag     : tag
+      source  : ""
+      match   : match
+      search  : tag
+      replace : replace
+
+    # missing search
+    - rule    : test-extractTagIfNotExists-6
+      action  : extractTagIfNotExists
+      tag     : tag
+      source  : metricName
+      match   : match
+      replace : replace
+
+    # empty search
+    - rule    : test-extractTagIfNotExists-7
+      action  : extractTagIfNotExists
+      tag     : tag
+      source  : metricName
+      match   : match
+      search  : ""
+      replace : replace
+
+    # missing replace
+    - rule    : test-extractTagIfNotExists-8
+      action  : extractTagIfNotExists
+      tag     : tag
+      source  : metricName
+      match   : match
+      search  : tag
+
+    # null replace
+    - rule    : test-extractTagIfNotExists-9
+      action  : extractTagIfNotExists
+      tag     : tag
+      source  : metricName
+      match   : match
+      search  : tag
+      replace :
+
+    # scope does not apply
+    - rule    : test-extractTagIfNotExists-10
+      action  : extractTagIfNotExists
+      scope   : tag
+      tag     : tag
+      source  : metricName
+      match   : match
+      search  : tag
+      replace : ""
+
+    # value does not apply
+    - rule    : test-extractTagIfNotExists-11
+      action  : extractTagIfNotExists
       tag     : tag
       source  : metricName
       match   : match


### PR DESCRIPTION
- New rule type "extractTagIfNotExists"
- extractTag and extractTagIfNotExists support modifying input data as well (i.e. create new tag from a portion of a metric name, and remove it from the metric name as one operation)
- Track number of times preprocessor rule has been invoked (to make calculating success ratios and identifying CPU hogs easier)