### PR TITLE
TCP connection reuse in building new wavefrontreporter

### DIFF
--- a/dropwizard-metrics/3.1/src/main/java/com/wavefront/integrations/metrics/WavefrontReporter.java
+++ b/dropwizard-metrics/3.1/src/main/java/com/wavefront/integrations/metrics/WavefrontReporter.java
@@ -337,7 +337,7 @@ public class WavefrontReporter extends ScheduledReporter {
           includeJvmMetrics,
           disabledMetricAttributes);
     }
-  }
+  
 
 
   /**

--- a/dropwizard-metrics/3.1/src/main/java/com/wavefront/integrations/metrics/WavefrontReporter.java
+++ b/dropwizard-metrics/3.1/src/main/java/com/wavefront/integrations/metrics/WavefrontReporter.java
@@ -339,6 +339,28 @@ public class WavefrontReporter extends ScheduledReporter {
     }
   }
 
+
+  /**
+   * Builds a {@link WavefrontReporter} with the given properties, sending metrics using the given
+   * {@link WavefrontSender}.
+   *
+   * @param Wavefront a {@link WavefrontSender}.
+   * @return a {@link WavefrontReporter}
+   */
+  public WavefrontReporter build(WavefrontSender wavefrontSender) {
+    return new WavefrontReporter(registry,
+            wavefrontSender,
+            clock,
+            prefix,
+            source,
+            pointTags,
+            rateUnit,
+            durationUnit,
+            filter,
+            includeJvmMetrics,
+            disabledMetricAttributes);
+  }
+}
   private static final Logger LOGGER = LoggerFactory.getLogger(WavefrontReporter.class);
 
   private final WavefrontSender wavefront;

--- a/dropwizard-metrics/3.1/src/main/java/com/wavefront/integrations/metrics/WavefrontReporter.java
+++ b/dropwizard-metrics/3.1/src/main/java/com/wavefront/integrations/metrics/WavefrontReporter.java
@@ -50,6 +50,9 @@ import javax.validation.constraints.NotNull;
  * This sends a DIFFERENT metrics taxonomy than the Wavefront "yammer" metrics reporter.
  */
 public class WavefrontReporter extends ScheduledReporter {
+	
+  private static final Logger LOGGER = LoggerFactory.getLogger(WavefrontReporter.class);
+  
   /**
    * Returns a new {@link Builder} for {@link WavefrontReporter}.
    *
@@ -337,8 +340,6 @@ public class WavefrontReporter extends ScheduledReporter {
           includeJvmMetrics,
           disabledMetricAttributes);
     }
-  
-
 
   /**
    * Builds a {@link WavefrontReporter} with the given properties, sending metrics using the given
@@ -361,7 +362,6 @@ public class WavefrontReporter extends ScheduledReporter {
             disabledMetricAttributes);
   }
 }
-  private static final Logger LOGGER = LoggerFactory.getLogger(WavefrontReporter.class);
 
   private final WavefrontSender wavefront;
   private final Clock clock;

--- a/dropwizard-metrics/4.0/src/main/java/com/wavefront/integrations/metrics/WavefrontReporter.java
+++ b/dropwizard-metrics/4.0/src/main/java/com/wavefront/integrations/metrics/WavefrontReporter.java
@@ -206,7 +206,7 @@ public class WavefrontReporter extends ScheduledReporter {
                                    durationUnit,
                                    filter,
                                    includeJvmMetrics);
-    }
+    
   }
 
   /**

--- a/dropwizard-metrics/4.0/src/main/java/com/wavefront/integrations/metrics/WavefrontReporter.java
+++ b/dropwizard-metrics/4.0/src/main/java/com/wavefront/integrations/metrics/WavefrontReporter.java
@@ -39,6 +39,9 @@ import java.util.concurrent.TimeUnit;
  * This sends a DIFFERENT metrics taxonomy than the Wavefront "yammer" metrics reporter.
  */
 public class WavefrontReporter extends ScheduledReporter {
+  
+  private static final Logger LOGGER = LoggerFactory.getLogger(WavefrontReporter.class);
+	
   /**
    * Returns a new {@link Builder} for {@link WavefrontReporter}.
    *
@@ -206,7 +209,6 @@ public class WavefrontReporter extends ScheduledReporter {
                                    durationUnit,
                                    filter,
                                    includeJvmMetrics);
-    
   }
 
   /**
@@ -229,8 +231,6 @@ public class WavefrontReporter extends ScheduledReporter {
             includeJvmMetrics);
   }
 }
-
-  private static final Logger LOGGER = LoggerFactory.getLogger(WavefrontReporter.class);
 
   private final WavefrontSender wavefront;
   private final Clock clock;
@@ -289,7 +289,6 @@ public class WavefrontReporter extends ScheduledReporter {
                             TimeUnit durationUnit,
                             MetricFilter filter,
                             boolean includeJvmMetrics) {
-
     super(registry, "wavefront-reporter", filter, rateUnit, durationUnit);
     this.wavefront = wavefrontSender;
     this.clock = clock;


### PR DESCRIPTION
This request accommodate changes to build a new wavefrontreporter with existing wavefront connection. (There are chances that tcp connection might be exhausted while sending multiple metrics to server with change in reporter level point tags and building a new client everytime. This code will take care of reusing existing connection while building a new wavefront reporter.)