### PR TITLE
change fpm to version 1.10.0

### DIFF
--- a/pkg/Dockerfile
+++ b/pkg/Dockerfile
@@ -9,7 +9,7 @@ RUN curl -L get.rvm.io | bash -s stable
 ENV PATH /usr/local/rvm/gems/ruby-1.9.3-p551/bin:/usr/local/rvm/gems/ruby-1.9.3-p551@global/bin:/usr/local/rvm/rubies/ruby-1.9.3-p551/bin:/usr/local/rvm/bin:$PATH
 ENV LC_ALL en_US.UTF-8
 RUN rvm install 1.9.3
-RUN gem install fpm --version 1.6.2
+RUN gem install fpm --version 1.10.0
 RUN gem install package_cloud --version 0.2.35
 
 # Wavefront software. This repo contains build scripts for the agent, to be run


### PR DESCRIPTION
* This is to fix the error in building wf-proxy-builder docker image
* Broken Jenkins job:  https://jenkins-dev.corp.wavefront.com/job/ProxyJava_2_Package/82/console
* Error log:
```
18:10:34 Step 8/11 : RUN gem install fpm --version 1.6.2
18:10:34  ---> Running in 42bf5564f93d
18:10:35 [91mERROR:  Error installing fpm:
18:10:35 	ruby-xz requires Ruby version >= 2.3.0.
```
* Related webpages: https://github.com/jordansissel/fpm/issues/1493, https://github.com/jordansissel/fpm/pull/1494
* Working Jenkins build (after upgrade fpm to 1.10.0): https://jenkins-dev.corp.wavefront.com/job/ProxyJava_2_Package/84/
