### PR TITLE
Constants -> MetricConstants

### DIFF
--- a/dropwizard-metrics/dropwizard-metrics/src/main/java/com/wavefront/integrations/metrics/WavefrontReporter.java
+++ b/dropwizard-metrics/dropwizard-metrics/src/main/java/com/wavefront/integrations/metrics/WavefrontReporter.java
@@ -21,7 +21,7 @@ import com.codahale.metrics.jvm.GarbageCollectorMetricSet;
 import com.codahale.metrics.jvm.MemoryUsageGaugeSet;
 import com.codahale.metrics.jvm.SafeFileDescriptorRatioGauge;
 import com.codahale.metrics.jvm.ThreadStatesGaugeSet;
-import com.wavefront.common.Constants;
+import com.wavefront.common.MetricConstants;
 import com.wavefront.integrations.Wavefront;
 import com.wavefront.integrations.WavefrontDirectSender;
 import com.wavefront.integrations.WavefrontSender;
@@ -517,7 +517,7 @@ public class WavefrontReporter extends ScheduledReporter {
   private void reportCounter(String name, Counter counter) throws IOException {
     if (counter instanceof DeltaCounter) {
       long count = counter.getCount();
-      name = Constants.DELTA_PREFIX + prefixAndSanitize(name.substring(1), "count");
+      name = MetricConstants.DELTA_PREFIX + prefixAndSanitize(name.substring(1), "count");
       wavefront.send(name, count,clock.getTime() / 1000, source, pointTags);
       counter.dec(count);
     } else {

--- a/java-lib/src/main/java/com/codahale/metrics/DeltaCounter.java
+++ b/java-lib/src/main/java/com/codahale/metrics/DeltaCounter.java
@@ -2,7 +2,7 @@ package com.codahale.metrics;
 
 import com.google.common.annotations.VisibleForTesting;
 
-import com.wavefront.common.Constants;
+import com.wavefront.common.MetricConstants;
 
 /**
  * A counter for Wavefront delta metrics.
@@ -20,8 +20,8 @@ public class DeltaCounter extends Counter {
       throw new IllegalArgumentException("Invalid arguments");
     }
 
-    if (!(metricName.startsWith(Constants.DELTA_PREFIX) || metricName.startsWith(Constants.DELTA_PREFIX_2))) {
-      metricName = Constants.DELTA_PREFIX + metricName;
+    if (!(metricName.startsWith(MetricConstants.DELTA_PREFIX) || metricName.startsWith(MetricConstants.DELTA_PREFIX_2))) {
+      metricName = MetricConstants.DELTA_PREFIX + metricName;
     }
     DeltaCounter counter = new DeltaCounter();
     registry.register(metricName, counter);

--- a/java-lib/src/main/java/com/wavefront/api/agent/Constants.java
+++ b/java-lib/src/main/java/com/wavefront/api/agent/Constants.java
@@ -3,7 +3,7 @@ package com.wavefront.api.agent;
 import java.util.UUID;
 
 /**
- * Agent Constants.
+ * Agent MetricConstants.
  *
  * @author Clement Pang (clement@wavefront.com)
  */

--- a/java-lib/src/main/java/com/wavefront/common/MetricConstants.java
+++ b/java-lib/src/main/java/com/wavefront/common/MetricConstants.java
@@ -5,7 +5,7 @@ package com.wavefront.common;
  *
  * @author Vikram Raman (vikram@wavefront.com)
  */
-public abstract class Constants {
+public abstract class MetricConstants {
   public static final String DELTA_PREFIX = "\u2206"; // ∆: INCREMENT
   public static final String DELTA_PREFIX_2 = "\u0394"; // Δ: GREEK CAPITAL LETTER DELTA
 }

--- a/java-lib/src/main/java/com/wavefront/ingester/ReportPointIngesterFormatter.java
+++ b/java-lib/src/main/java/com/wavefront/ingester/ReportPointIngesterFormatter.java
@@ -1,7 +1,7 @@
 package com.wavefront.ingester;
 
 import com.wavefront.common.Clock;
-import com.wavefront.common.Constants;
+import com.wavefront.common.MetricConstants;
 
 import org.antlr.v4.runtime.Token;
 
@@ -62,7 +62,7 @@ public class ReportPointIngesterFormatter extends AbstractIngesterFormatter<Repo
     }
 
     // Delta metrics cannot have negative values
-    if ((point.getMetric().startsWith(Constants.DELTA_PREFIX) || point.getMetric().startsWith(Constants.DELTA_PREFIX_2)) &&
+    if ((point.getMetric().startsWith(MetricConstants.DELTA_PREFIX) || point.getMetric().startsWith(MetricConstants.DELTA_PREFIX_2)) &&
         point.getValue() instanceof Number) {
       double v = ((Number) point.getValue()).doubleValue();
       if (v <= 0) {


### PR DESCRIPTION
Moved `com.wavefront.common.Constants` to `com.wavefront.common.MetricConstants` to avoid system conflicts.