### PR TITLE
Add a Wavefront Reporter based on Dropwizard 5.0.0-rc2

### DIFF
--- a/dropwizard-metrics/dropwizard-metrics5/README.md
+++ b/dropwizard-metrics/dropwizard-metrics5/README.md
@@ -1,0 +1,96 @@
+# Wavefront Reporter
+
+This is a Wavefront Reporter for the Stable (5.0.0-rc2) version of [Dropwizard Metrics](https://dropwizard.github.io) (formerly Coda Hale & Yammer Metrics).
+
+It sends data to the Wavefront service via a proxy and supports point tags being assigned at the Reporter level.
+
+## Usage
+
+This Reporter sends data to Wavefront via a proxy. Version 3.5 or later is required. You can easily install the proxy by following [these instructions](https://docs.wavefront.com/proxies_installing.html).
+
+To use the Reporter you'll need to know the hostname and port (which by default is 2878) where the Wavefront proxy is running.
+
+It is designed to be used with the [stable version 5.0.0-rc2 of Dropwizard Metrics](https://github.com/dropwizard/metrics/tree/v5.0.0-rc2).
+
+### Setting up Maven
+
+You will need both the DropWizard `metrics-core` and the Wavefront `metrics-wavefront` libraries as dependencies. Logging depends on `org.slf4j`:
+
+```Maven
+   <dependency>
+      <groupId>io.dropwizard.metrics5</groupId>
+      <artifactId>metrics-core</artifactId>
+      <version>5.0.0-rc2</version>
+    </dependency>
+    <dependency>
+      <groupId>com.wavefront</groupId>
+      <artifactId>dropwizard-metrics5</artifactId>
+      <version>[LATEST VERSION]</version>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-simple</artifactId>
+      <version>1.7.16</version>
+    </dependency>       
+```
+
+### Example Usage
+
+The Wavefront Reporter lets you use DropWizard metrics exactly as you normally would. See its [getting started guide](https://dropwizard.github.io/metrics/3.1.0/getting-started/) if you haven't used it before.
+
+It simply gives you a new Reporter that will seamlessly work with Wavefront. First `import com.wavefront.integrations.metrics.WavefrontDropwizardReporter;`
+
+Then for example to create a Reporter which will emit data every 10 seconds for:
+
+- A `MetricsRegistry` named `metrics`
+- A Wavefront proxy on `localhost` at port `2878`
+- Data that should appear in Wavefront as `source=app-1.company.com`
+- Two point tags named `dc` and `service`
+
+you would do something like this:
+
+```java
+WavefrontDropwizardReporter reporter = WavefrontDropwizardReporter.forRegistry(metrics)
+        .withSource("app-1.company.com")
+    	.withPointTag("dc", "dallas")
+    	.withPointTag("service", "query")
+    	.build("localhost", 2878);
+```
+
+You must provide the source using the `.withSource(String source)` method and pass the Hostname and Port of the Wavefront proxy using the `.build(String hostname, long port)` method.
+
+The Reporter provides all the same options that the [GraphiteReporter](http://metrics.dropwizard.io/3.1.0/manual/graphite/) does. By default:
+
+- There is no prefix on the Metrics
+- Rates will be converted to Seconds
+- Durations will be converted to Milliseconds
+- `MetricFilter.ALL` will be used for the Filter
+- `Clock.defaultClock()` will be used for the Clock
+
+In addition you can also:
+
+- Supply point tags for the Reporter to use. There are two ways to specify point tags at the Reporter level, individually using `.withPointTag(String tagK, String tagV)` or create a `Map<String,String>` and call `.withPointTags(my-map)` to do many at once.
+- Call `.withJvmMetrics()` when building the Reporter if you want it to add some default JVM metrics to the given MetricsRegistry
+
+If `.withJvmMetrics()` is used the following metrics will be added to the registry:
+
+```java
+registry.register("jvm.uptime", new Gauge<Long>() {
+    @Override
+	public Long getValue() {
+	    return ManagementFactory.getRuntimeMXBean().getUptime();
+	}
+});
+registry.register("jvm.current_time", new Gauge<Long>() {
+    @Override
+	public Long getValue() {
+	    return clock.getTime();
+    }
+});
+    
+registry.register("jvm.classes", new ClassLoadingGaugeSet());
+registry.register("jvm.fd_usage", new FileDescriptorRatioGauge());
+registry.register("jvm.buffers", new BufferPoolMetricSet(ManagementFactory.getPlatformMBeanServer()));
+registry.register("jvm.gc", new GarbageCollectorMetricSet());
+registry.register("jvm.memory", new MemoryUsageGaugeSet());
+```

--- a/dropwizard-metrics/dropwizard-metrics5/README.md
+++ b/dropwizard-metrics/dropwizard-metrics5/README.md
@@ -2,11 +2,11 @@
 
 This is a Wavefront Reporter for the Stable (5.0.0-rc2) version of [Dropwizard Metrics](https://dropwizard.github.io) (formerly Coda Hale & Yammer Metrics).
 
-It sends data to the Wavefront service via a proxy and supports point tags being assigned at the Reporter level.
+It sends data to the Wavefront service via proxy or direct ingestion and supports point tags being assigned at the Reporter level as well as at the individual metric level.
 
 ## Usage
 
-This Reporter sends data to Wavefront via a proxy. Version 3.5 or later is required. You can easily install the proxy by following [these instructions](https://docs.wavefront.com/proxies_installing.html).
+This Reporter sends data to Wavefront via proxy or direct ingestion. Version 3.5 or later is required. You can easily install the proxy by following [these instructions](https://docs.wavefront.com/proxies_installing.html).
 
 To use the Reporter you'll need to know the hostname and port (which by default is 2878) where the Wavefront proxy is running.
 
@@ -38,7 +38,7 @@ You will need both the DropWizard `metrics-core` and the Wavefront `metrics-wave
 
 The Wavefront Reporter lets you use DropWizard metrics exactly as you normally would. See its [getting started guide](https://dropwizard.github.io/metrics/3.1.0/getting-started/) if you haven't used it before.
 
-It simply gives you a new Reporter that will seamlessly work with Wavefront. First `import com.wavefront.integrations.metrics.WavefrontDropwizardReporter;`
+It simply gives you a new Reporter that will seamlessly work with Wavefront. First `import com.wavefront.integrations.metrics5.WavefrontReporter;`
 
 Then for example to create a Reporter which will emit data every 10 seconds for:
 
@@ -46,11 +46,19 @@ Then for example to create a Reporter which will emit data every 10 seconds for:
 - A Wavefront proxy on `localhost` at port `2878`
 - Data that should appear in Wavefront as `source=app-1.company.com`
 - Two point tags named `dc` and `service`
+- Two metric level point tags named `pointTag1` and `pointTag2`
 
 you would do something like this:
 
 ```java
-WavefrontDropwizardReporter reporter = WavefrontDropwizardReporter.forRegistry(metrics)
+MetricRegistry registry = new MetricRegistry();
+HashMap<String, String> tags = new HashMap<>();
+tags.put("pointTag1", "ptag1");
+tags.put("pointTag2", "ptag2");
+MetricName counterMetric = new MetricName("proxy.foo.bar", tags);
+// Register the counter with the metric registry
+Counter counter = registry.counter(counterMetric);
+WavefrontReporter reporter = WavefrontReporter.forRegistry(metrics)
         .withSource("app-1.company.com")
     	.withPointTag("dc", "dallas")
     	.withPointTag("service", "query")

--- a/dropwizard-metrics/dropwizard-metrics5/pom.xml
+++ b/dropwizard-metrics/dropwizard-metrics5/pom.xml
@@ -1,0 +1,39 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.wavefront</groupId>
+        <artifactId>wavefront</artifactId>
+        <version>4.30-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>dropwizard-metrics5</artifactId>
+    <version>4.30-SNAPSHOT</version>
+    <name>Wavefront Dropwizard5 Metrics eporter</name>
+    <description>Report metrics via the Wavefront Proxy</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.wavefront</groupId>
+            <artifactId>java-client</artifactId>
+            <version>4.30-SNAPSHOT</version>
+        </dependency>
+        <dependency>
+            <groupId>io.dropwizard.metrics5</groupId>
+            <artifactId>metrics-core</artifactId>
+            <version>5.0.0-rc2</version>
+        </dependency>
+        <dependency>
+            <groupId>io.dropwizard.metrics5</groupId>
+            <artifactId>metrics-jvm</artifactId>
+            <version>5.0.0-rc2</version>
+        </dependency>
+        <dependency>
+            <groupId>org.json</groupId>
+            <artifactId>json</artifactId>
+            <version>20160212</version>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/dropwizard-metrics/dropwizard-metrics5/src/main/java/com/wavefront/integrations/metrics/WavefrontDropwizardReporter.java
+++ b/dropwizard-metrics/dropwizard-metrics5/src/main/java/com/wavefront/integrations/metrics/WavefrontDropwizardReporter.java
@@ -1,0 +1,533 @@
+package com.wavefront.integrations.metrics;
+
+import com.google.common.base.Preconditions;
+import com.wavefront.common.MetricConstants;
+import com.wavefront.integrations.Wavefront;
+import com.wavefront.integrations.WavefrontDirectSender;
+import com.wavefront.integrations.WavefrontSender;
+import io.dropwizard.metrics5.*;
+import io.dropwizard.metrics5.Timer;
+import io.dropwizard.metrics5.jvm.*;
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.validation.constraints.NotNull;
+import java.io.IOException;
+import java.lang.management.ManagementFactory;
+import java.util.*;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.regex.Pattern;
+
+/**
+ * A reporter which publishes metric values to a Wavefront Proxy from a Dropwizard {@link MetricRegistry}.
+ */
+public class WavefrontDropwizardReporter extends ScheduledReporter {
+	
+  private static final Logger LOGGER = LoggerFactory.getLogger(WavefrontDropwizardReporter.class);
+  
+  /**
+   * Returns a new {@link Builder} for {@link WavefrontDropwizardReporter}.
+   *
+   * @param registry the registry to report
+   * @return a {@link Builder} instance for a {@link WavefrontDropwizardReporter}
+   */
+  public static Builder forRegistry(MetricRegistry registry) {
+    return new Builder(registry);
+  }
+
+  /**
+   * A builder for {@link WavefrontDropwizardReporter} instances. Defaults to not using a prefix, using the
+   * default clock, converting rates to events/second, converting durations to milliseconds, a host
+   * named "unknown", no point Tags, and not filtering any metrics.
+   */
+  public static class Builder {
+    private final MetricRegistry registry;
+    private Clock clock;
+    private String prefix;
+    private TimeUnit rateUnit;
+    private TimeUnit durationUnit;
+    private MetricFilter filter;
+    private String source;
+    private Map<String, String> pointTags;
+    private boolean includeJvmMetrics;
+    private Set<MetricAttribute> disabledMetricAttributes;
+
+    private Builder(MetricRegistry registry) {
+      this.registry = registry;
+      this.clock = Clock.defaultClock();
+      this.prefix = null;
+      this.rateUnit = TimeUnit.SECONDS;
+      this.durationUnit = TimeUnit.MILLISECONDS;
+      this.filter = MetricFilter.ALL;
+      this.source = "dropwizard-metrics";
+      this.pointTags = new HashMap<>();
+      this.includeJvmMetrics = false;
+      this.disabledMetricAttributes = Collections.emptySet();
+    }
+
+    /**
+     * Use the given {@link Clock} instance for the time. Defaults to Clock.defaultClock()
+     *
+     * @param clock a {@link Clock} instance
+     * @return {@code this}
+     */
+    public Builder withClock(Clock clock) {
+      this.clock = clock;
+      return this;
+    }
+
+    /**
+     * Prefix all metric names with the given string. Defaults to null.
+     *
+     * @param prefix the prefix for all metric names
+     * @return {@code this}
+     */
+    public Builder prefixedWith(String prefix) {
+      this.prefix = prefix;
+      return this;
+    }
+
+    /**
+     * Set the host for this reporter. This is equivalent to withSource.
+     *
+     * @param host the host for all metrics
+     * @return {@code this}
+     */
+    public Builder withHost(String host) {
+      this.source = host;
+      return this;
+    }
+
+    /**
+     * Set the source for this reporter. This is equivalent to withHost.
+     *
+     * @param source the host for all metrics
+     * @return {@code this}
+     */
+    public Builder withSource(String source) {
+      this.source = source;
+      return this;
+    }
+
+    /**
+     * Set the Point Tags for this reporter.
+     *
+     * @param pointTags the pointTags Map for all metrics
+     * @return {@code this}
+     */
+    public Builder withPointTags(Map<String, String> pointTags) {
+      this.pointTags.putAll(pointTags);
+      return this;
+    }
+
+    /**
+     * Set a point tag for this reporter.
+     *
+     * @param ptagK the key of the Point Tag
+     * @param ptagV the value of the Point Tag
+     * @return {@code this}
+     */
+    public Builder withPointTag(String ptagK, String ptagV) {
+      this.pointTags.put(ptagK, ptagV);
+      return this;
+    }
+
+    /**
+     * Convert rates to the given time unit. Defaults to Seconds.
+     *
+     * @param rateUnit a unit of time
+     * @return {@code this}
+     */
+    public Builder convertRatesTo(TimeUnit rateUnit) {
+      this.rateUnit = rateUnit;
+      return this;
+    }
+
+    /**
+     * Convert durations to the given time unit. Defaults to Milliseconds.
+     *
+     * @param durationUnit a unit of time
+     * @return {@code this}
+     */
+    public Builder convertDurationsTo(TimeUnit durationUnit) {
+      this.durationUnit = durationUnit;
+      return this;
+    }
+
+    /**
+     * Only report metrics which match the given filter. Defaults to MetricFilter.ALL
+     *
+     * @param filter a {@link MetricFilter}
+     * @return {@code this}
+     */
+    public Builder filter(MetricFilter filter) {
+      this.filter = filter;
+      return this;
+    }
+
+    /**
+     * Don't report the passed metric attributes for all metrics (e.g. "p999", "stddev" or "m15").
+     * See {@link MetricAttribute}.
+     *
+     * @param disabledMetricAttributes a set of {@link MetricAttribute}
+     * @return {@code this}
+     */
+    public Builder disabledMetricAttributes(Set<MetricAttribute> disabledMetricAttributes) {
+      this.disabledMetricAttributes = disabledMetricAttributes;
+      return this;
+    }
+
+    /**
+     * Include JVM Metrics from this Reporter.
+     *
+     * @return {@code this}
+     */
+    public Builder withJvmMetrics() {
+      this.includeJvmMetrics = true;
+      return this;
+    }
+
+    /**
+     * Builds a {@link WavefrontDropwizardReporter} from the VCAP_SERVICES env variable, sending metrics
+     * using the given {@link WavefrontSender}. This should be used in PCF environment only. It
+     * uses 'wavefront-proxy' as the name to fetch the proxy details from VCAP_SERVICES.
+     *
+     * @return a {@link WavefrontDropwizardReporter}
+     */
+    public WavefrontDropwizardReporter bindToCloudFoundryService() {
+      return bindToCloudFoundryService("wavefront-proxy", false);
+    }
+
+    /**
+     * Builds a {@link WavefrontDropwizardReporter} from the VCAP_SERVICES env variable, sending metrics
+     * using the given {@link WavefrontSender}. This should be used in PCF environment only. It
+     * assumes failOnError to be false.
+     *
+     * @return a {@link WavefrontDropwizardReporter}
+     */
+    public WavefrontDropwizardReporter bindToCloudFoundryService(@NotNull String proxyServiceName) {
+      return bindToCloudFoundryService(proxyServiceName, false);
+    }
+
+    /**
+     * Builds a {@link WavefrontDropwizardReporter} from the VCAP_SERVICES env variable, sending metrics
+     * using the given {@link WavefrontSender}. This should be used in PCF environment only.
+     *
+     * @param proxyServiceName The name of the wavefront proxy service. If wavefront-tile is used to
+     *                         deploy the proxy, then the service name will be 'wavefront-proxy'.
+     * @param failOnError      A flag to determine what to do if the service parameters are not
+     *                         available. If 'true' then the method will throw RuntimeException else
+     *                         it will log an error message and continue.
+     * @return a {@link WavefrontDropwizardReporter}
+     */
+    public WavefrontDropwizardReporter bindToCloudFoundryService(@NotNull String proxyServiceName,
+                                                       boolean failOnError) {
+
+      Preconditions.checkNotNull(proxyServiceName, "proxyServiceName arg should not be null");
+
+      String proxyHostname;
+      int proxyPort;
+      // read the env variable VCAP_SERVICES
+      String services = System.getenv("VCAP_SERVICES");
+      if (services == null || services.length() == 0) {
+        if (failOnError) {
+          throw new RuntimeException("VCAP_SERVICES environment variable is unavailable.");
+        } else {
+          LOGGER.error("Environment variable VCAP_SERVICES is empty. No metrics will be reported " +
+              "to wavefront proxy.");
+          // since the wavefront-proxy is not tied to the app, use dummy hostname and port.
+          proxyHostname = "";
+          proxyPort = 2878;
+        }
+      } else {
+        // parse the json to read the hostname and port
+        JSONObject json = new JSONObject(services);
+        // When wavefront tile is installed on PCF, it will be automatically named wavefront-proxy
+        JSONArray jsonArray = json.getJSONArray(proxyServiceName);
+        if (jsonArray == null || jsonArray.isNull(0)) {
+          if (failOnError) {
+            throw new RuntimeException(proxyServiceName + " is not present in the VCAP_SERVICES " +
+                "env variable. Please verify and provide the wavefront proxy service name.");
+          } else {
+            LOGGER.error(proxyServiceName + " is not present in VCAP_SERVICES env variable. No " +
+                "metrics will be reported to wavefront proxy.");
+            // since the wavefront-proxy is not tied to the app, use dummy hostname and port.
+            proxyHostname = "";
+            proxyPort = 2878;
+          }
+        } else {
+          JSONObject details = jsonArray.getJSONObject(0);
+          JSONObject credentials = details.getJSONObject("credentials");
+          proxyHostname = credentials.getString("hostname");
+          proxyPort = credentials.getInt("port");
+        }
+      }
+      return new WavefrontDropwizardReporter(registry,
+          proxyHostname,
+          proxyPort,
+          clock,
+          prefix,
+          source,
+          pointTags,
+          rateUnit,
+          durationUnit,
+          filter,
+          includeJvmMetrics,
+          disabledMetricAttributes);
+    }
+
+    /**
+     * Builds a {@link WavefrontDropwizardReporter} with the given properties, sending metrics directly
+     * to a given Wavefront server using direct ingestion APIs.
+     *
+     * @param server Wavefront server hostname of the form "https://serverName.wavefront.com"
+     * @param token  Wavefront API token with direct ingestion permission
+     * @return a {@link WavefrontDropwizardReporter}
+     */
+    public WavefrontDropwizardReporter buildDirect(String server, String token) {
+      WavefrontSender wavefrontSender = new WavefrontDirectSender(server, token);
+      return new WavefrontDropwizardReporter(registry, wavefrontSender, clock, prefix, source, pointTags, rateUnit,
+          durationUnit, filter, includeJvmMetrics, disabledMetricAttributes);
+    }
+
+    /**
+     * Builds a {@link WavefrontDropwizardReporter} with the given properties, sending metrics using the given
+     * {@link WavefrontSender}.
+     *
+     * @param proxyHostname Wavefront Proxy hostname.
+     * @param proxyPort     Wavefront Proxy port.
+     * @return a {@link WavefrontDropwizardReporter}
+     */
+    public WavefrontDropwizardReporter build(String proxyHostname, int proxyPort) {
+      return new WavefrontDropwizardReporter(registry,
+          proxyHostname,
+          proxyPort,
+          clock,
+          prefix,
+          source,
+          pointTags,
+          rateUnit,
+          durationUnit,
+          filter,
+          includeJvmMetrics,
+          disabledMetricAttributes);
+    }
+
+  /**
+   * Builds a {@link WavefrontDropwizardReporter} with the given properties, sending metrics using the given
+   * {@link WavefrontSender}.
+   *
+   * @param wavefrontSender a {@link WavefrontSender}.
+   * @return a {@link WavefrontDropwizardReporter}
+   */
+  public WavefrontDropwizardReporter build(WavefrontSender wavefrontSender) {
+    return new WavefrontDropwizardReporter(registry,
+            wavefrontSender,
+            clock,
+            prefix,
+            source,
+            pointTags,
+            rateUnit,
+            durationUnit,
+            filter,
+            includeJvmMetrics,
+            disabledMetricAttributes);
+  }
+}
+
+  private final WavefrontSender wavefront;
+  private final Clock clock;
+  private final String prefix;
+  private final String source;
+  private final Map<String, String> pointTags;
+
+  private WavefrontDropwizardReporter(MetricRegistry registry,
+                            WavefrontSender wavefrontSender,
+                            final Clock clock,
+                            String prefix,
+                            String source,
+                            Map<String, String> pointTags,
+                            TimeUnit rateUnit,
+                            TimeUnit durationUnit,
+                            MetricFilter filter,
+                            boolean includeJvmMetrics,
+                            Set<MetricAttribute> disabledMetricAttributes) {
+    super(registry, "wavefront-reporter", filter, rateUnit, durationUnit, Executors.newSingleThreadScheduledExecutor(),
+        true, disabledMetricAttributes == null ? Collections.emptySet() : disabledMetricAttributes);
+    this.wavefront = wavefrontSender;
+    this.clock = clock;
+    this.prefix = prefix;
+    this.source = source;
+    this.pointTags = pointTags;
+
+    if (includeJvmMetrics) {
+      registry.register("jvm.uptime", (Gauge<Long>) () -> ManagementFactory.getRuntimeMXBean().getUptime());
+      registry.register("jvm.current_time", (Gauge<Long>) clock::getTime);
+      registry.register("jvm.classes", new ClassLoadingGaugeSet());
+      registry.register("jvm.fd_usage", new SafeFileDescriptorRatioGauge());
+      registry.register("jvm.buffers", new BufferPoolMetricSet(ManagementFactory.getPlatformMBeanServer()));
+      registry.register("jvm.gc", new GarbageCollectorMetricSet());
+      registry.register("jvm.memory", new MemoryUsageGaugeSet());
+      registry.register("jvm.thread-states", new ThreadStatesGaugeSet());
+    }
+  }
+
+  private WavefrontDropwizardReporter(MetricRegistry registry,
+                            String proxyHostname,
+                            int proxyPort,
+                            final Clock clock,
+                            String prefix,
+                            String source,
+                            Map<String, String> pointTags,
+                            TimeUnit rateUnit,
+                            TimeUnit durationUnit,
+                            MetricFilter filter,
+                            boolean includeJvmMetrics,
+                            Set<MetricAttribute> disabledMetricAttributes) {
+    this(registry, new Wavefront(proxyHostname, proxyPort), clock, prefix, source, pointTags, rateUnit,
+        durationUnit, filter, includeJvmMetrics, disabledMetricAttributes);
+  }
+
+  /**
+   * Called periodically by the polling thread. Subclasses should report all the given metrics.
+   *
+   * @param gauges     all of the gauges in the registry
+   * @param counters   all of the counters in the registry
+   * @param histograms all of the histograms in the registry
+   * @param meters     all of the meters in the registry
+   * @param timers     all of the timers in the registry
+   */
+  @Override
+  @SuppressWarnings("rawtypes")
+  public void report(SortedMap<MetricName, Gauge> gauges,
+                              SortedMap<MetricName, Counter> counters,
+                              SortedMap<MetricName, Histogram> histograms,
+                              SortedMap<MetricName, Meter> meters,
+                              SortedMap<MetricName, Timer> timers) {
+    try {
+      if (!wavefront.isConnected()) {
+        wavefront.connect();
+      }
+
+      for (Map.Entry<MetricName, Gauge> entry : gauges.entrySet()) {
+        if (entry.getValue().getValue() instanceof Number) {
+          reportGauge(entry.getKey().getKey(), entry.getValue());
+        }
+      }
+
+      for (Map.Entry<MetricName, Counter> entry : counters.entrySet()) {
+        reportCounter(entry.getKey().getKey(), entry.getValue());
+      }
+
+      for (Map.Entry<MetricName, Histogram> entry : histograms.entrySet()) {
+        reportHistogram(entry.getKey().getKey(), entry.getValue());
+      }
+
+      for (Map.Entry<MetricName, Meter> entry : meters.entrySet()) {
+        reportMetered(entry.getKey().getKey(), entry.getValue());
+      }
+
+      for (Map.Entry<MetricName, Timer> entry : timers.entrySet()) {
+        reportTimer(entry.getKey().getKey(), entry.getValue());
+      }
+
+      wavefront.flush();
+    } catch (IOException e) {
+      LOGGER.warn("Unable to report to Wavefront", wavefront, e);
+      try {
+        wavefront.close();
+      } catch (IOException e1) {
+        LOGGER.warn("Error closing Wavefront", wavefront, e);
+      }
+    }
+  }
+
+  @Override
+  public void stop() {
+    try {
+      super.stop();
+    } finally {
+      try {
+        wavefront.close();
+      } catch (IOException e) {
+        LOGGER.debug("Error disconnecting from Wavefront", wavefront, e);
+      }
+    }
+  }
+
+  private void reportTimer(String name, Timer timer) throws IOException {
+    final Snapshot snapshot = timer.getSnapshot();
+    final long time = clock.getTime() / 1000;
+    sendIfEnabled(MetricAttribute.MAX, name, convertDuration(snapshot.getMax()), time);
+    sendIfEnabled(MetricAttribute.MEAN, name, convertDuration(snapshot.getMean()), time);
+    sendIfEnabled(MetricAttribute.MIN, name, convertDuration(snapshot.getMin()), time);
+    sendIfEnabled(MetricAttribute.STDDEV, name, convertDuration(snapshot.getStdDev()), time);
+    sendIfEnabled(MetricAttribute.P50, name, convertDuration(snapshot.getMedian()), time);
+    sendIfEnabled(MetricAttribute.P75, name, convertDuration(snapshot.get75thPercentile()), time);
+    sendIfEnabled(MetricAttribute.P95, name, convertDuration(snapshot.get95thPercentile()), time);
+    sendIfEnabled(MetricAttribute.P98, name, convertDuration(snapshot.get98thPercentile()), time);
+    sendIfEnabled(MetricAttribute.P99, name, convertDuration(snapshot.get99thPercentile()), time);
+    sendIfEnabled(MetricAttribute.P999, name, convertDuration(snapshot.get999thPercentile()), time);
+
+    reportMetered(name, timer);
+  }
+
+  private void reportMetered(String name, Metered meter) throws IOException {
+    final long time = clock.getTime() / 1000;
+    sendIfEnabled(MetricAttribute.COUNT, name, meter.getCount(), time);
+    sendIfEnabled(MetricAttribute.M1_RATE, name, convertRate(meter.getOneMinuteRate()), time);
+    sendIfEnabled(MetricAttribute.M5_RATE, name, convertRate(meter.getFiveMinuteRate()), time);
+    sendIfEnabled(MetricAttribute.M15_RATE, name, convertRate(meter.getFifteenMinuteRate()), time);
+    sendIfEnabled(MetricAttribute.MEAN_RATE, name, convertRate(meter.getMeanRate()), time);
+  }
+
+  private void reportHistogram(String name, Histogram histogram) throws IOException {
+    final Snapshot snapshot = histogram.getSnapshot();
+    final long time = clock.getTime() / 1000;
+    sendIfEnabled(MetricAttribute.COUNT, name, histogram.getCount(), time);
+    sendIfEnabled(MetricAttribute.MAX, name, snapshot.getMax(), time);
+    sendIfEnabled(MetricAttribute.MEAN, name, snapshot.getMean(), time);
+    sendIfEnabled(MetricAttribute.MIN, name, snapshot.getMin(), time);
+    sendIfEnabled(MetricAttribute.STDDEV, name, snapshot.getStdDev(), time);
+    sendIfEnabled(MetricAttribute.P50, name, snapshot.getMedian(), time);
+    sendIfEnabled(MetricAttribute.P75, name, snapshot.get75thPercentile(), time);
+    sendIfEnabled(MetricAttribute.P95, name, snapshot.get95thPercentile(), time);
+    sendIfEnabled(MetricAttribute.P98, name, snapshot.get98thPercentile(), time);
+    sendIfEnabled(MetricAttribute.P99, name, snapshot.get99thPercentile(), time);
+    sendIfEnabled(MetricAttribute.P999, name, snapshot.get999thPercentile(), time);
+  }
+
+  private void reportCounter(String name, Counter counter) throws IOException {
+    if (counter instanceof DeltaCounter) {
+      long count = counter.getCount();
+      name = MetricConstants.DELTA_PREFIX + prefixAndSanitize(name.substring(1), "count");
+      wavefront.send(name, count,clock.getTime() / 1000, source, pointTags);
+      counter.dec(count);
+    } else {
+      wavefront.send(prefixAndSanitize(name, "count"), counter.getCount(), clock.getTime() / 1000, source, pointTags);
+    }
+  }
+
+  private void reportGauge(String name, Gauge<Number> gauge) throws IOException {
+    wavefront.send(prefixAndSanitize(name), gauge.getValue().doubleValue(), clock.getTime() / 1000, source, pointTags);
+  }
+
+  private void sendIfEnabled(MetricAttribute type, String name, double value, long timestamp) throws IOException {
+    if (!getDisabledMetricAttributes().contains(type)) {
+      wavefront.send(prefixAndSanitize(name, type.getCode()), value, timestamp, source, pointTags);
+    }
+  }
+
+  private String prefixAndSanitize(String... components) {
+    return sanitize(MetricRegistry.name(prefix, components).getKey());
+  }
+
+  private static String sanitize(String name) {
+    return SIMPLE_NAMES.matcher(name).replaceAll("_");
+  }
+
+  private static final Pattern SIMPLE_NAMES = Pattern.compile("[^a-zA-Z0-9_.\\-~]");
+}

--- a/dropwizard-metrics/dropwizard-metrics5/src/main/java/com/wavefront/integrations/metrics/WavefrontReporter.java
+++ b/dropwizard-metrics/dropwizard-metrics5/src/main/java/com/wavefront/integrations/metrics/WavefrontReporter.java
@@ -1,6 +1,7 @@
 package com.wavefront.integrations.metrics;
 
 import com.google.common.base.Preconditions;
+import com.google.common.collect.Maps;
 import com.wavefront.common.MetricConstants;
 import com.wavefront.integrations.Wavefront;
 import com.wavefront.integrations.WavefrontDirectSender;
@@ -542,14 +543,20 @@ public class WavefrontReporter extends ScheduledReporter {
     }
   }
 
-  private HashMap<String, String> getMetricTags(MetricName metricName) {
-    HashMap<String, String> metricTags = new HashMap<>(pointTags);
+  private Map<String, String> getMetricTags(MetricName metricName) {
+    int tagCount = pointTags.size() + metricName.getTags().size();
+    // If there are no tags(point tag(s) or global return an empty map
+    if (tagCount == 0) {
+      return Collections.emptyMap();
+    }
 
     // NOTE: If the individual metric share the same key as the global point tag key, the
     // metric level value will override global level value for that point tag.
     // Example: Global point tag is    <"Key1", "Value-Global">
     // and metric level point tag is:  <"Key1", "Value-Metric1">
     // the point tag sent to Wavefront will be <"Key1", "Value-Metric1">
+    HashMap<String, String> metricTags = Maps.newHashMapWithExpectedSize(tagCount);
+    metricTags.putAll(pointTags);
     metricName.getTags().forEach((k, v) -> metricTags.putIfAbsent(k, v));
     return metricTags;
   }

--- a/examples/dropwizard-metrics5/dependency-reduced-pom.xml
+++ b/examples/dropwizard-metrics5/dependency-reduced-pom.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <parent>
+    <artifactId>wavefront</artifactId>
+    <groupId>com.wavefront</groupId>
+    <version>4.30-SNAPSHOT</version>
+    <relativePath>../pom.xml/pom.xml</relativePath>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+  <artifactId>dropwizard-metrics5-examples</artifactId>
+  <name>Wavefront Dropwizard Metrics Examples</name>
+  <version>0.0.1-SNAPSHOT</version>
+  <description>Wavefront Dropwizard5 Metrics Examples</description>
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.5.1</version>
+        <configuration>
+          <source>1.8</source>
+          <target>1.8</target>
+        </configuration>
+      </plugin>
+      <plugin>
+        <artifactId>maven-shade-plugin</artifactId>
+        <version>3.0.0</version>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <configuration>
+              <filters>
+                <filter>
+                  <excludes>
+                    <exclude>META-INF/license/**</exclude>
+                    <exclude>license/**</exclude>
+                  </excludes>
+                </filter>
+              </filters>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>
+

--- a/examples/dropwizard-metrics5/pom.xml
+++ b/examples/dropwizard-metrics5/pom.xml
@@ -1,0 +1,70 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<artifactId>dropwizard-metrics5-examples</artifactId>
+	<version>0.0.1-SNAPSHOT</version>
+    <name>Wavefront Dropwizard Metrics Examples</name>
+	<description>Wavefront Dropwizard5 Metrics Examples</description>
+
+	<parent>
+		<groupId>com.wavefront</groupId>
+		<artifactId>wavefront</artifactId>
+		<version>4.30-SNAPSHOT</version>
+	</parent>
+
+	<dependencies>
+		<dependency>
+			<groupId>io.dropwizard.metrics5</groupId>
+			<artifactId>metrics-core</artifactId>
+			<version>5.0.0-rc2</version>
+		</dependency>
+		<dependency>
+			<groupId>io.dropwizard.metrics5</groupId>
+			<artifactId>metrics-jvm</artifactId>
+			<version>5.0.0-rc2</version>
+		</dependency>
+		<dependency>
+			<groupId>com.wavefront</groupId>
+			<artifactId>dropwizard-metrics5</artifactId>
+			<version>4.30-SNAPSHOT</version>
+		</dependency>
+	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<version>3.5.1</version>
+				<configuration>
+					<source>1.8</source>
+					<target>1.8</target>
+				</configuration>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-shade-plugin</artifactId>
+				<version>3.0.0</version>
+				<executions>
+					<execution>
+						<phase>package</phase>
+						<goals>
+							<goal>shade</goal>
+						</goals>
+						<configuration>
+							<filters>
+								<filter>
+									<excludes>
+										<exclude>META-INF/license/**</exclude>
+										<exclude>license/**</exclude>
+									</excludes>
+								</filter>
+							</filters>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build> 
+</project>

--- a/examples/dropwizard-metrics5/src/main/java/com/wavefront/examples/DirectReporting.java
+++ b/examples/dropwizard-metrics5/src/main/java/com/wavefront/examples/DirectReporting.java
@@ -1,0 +1,38 @@
+package com.wavefront.examples;
+
+import com.wavefront.integrations.metrics.WavefrontDropwizardReporter;
+import io.dropwizard.metrics5.Counter;
+import io.dropwizard.metrics5.MetricRegistry;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Example for reporting dropwizard metrics into Wavefront via Direct Ingestion.
+ *
+ * @author Vikram Raman
+ */
+public class DirectReporting {
+
+  public static void main(String args[]) throws InterruptedException {
+
+    String server = args[0];
+    String token = args[1];
+
+    MetricRegistry registry = new MetricRegistry();
+    Counter counter = registry.counter("direct.dw5metric.foo.bar");
+
+    WavefrontDropwizardReporter reporter = WavefrontDropwizardReporter.forRegistry(registry).
+        withSource("app-1.company.com").
+        withPointTag("dc", "dallas").
+        withPointTag("service", "query").
+        buildDirect(server, token);
+    reporter.start(5, TimeUnit.SECONDS);
+
+    int i = 0;
+    while (i++ < 30) {
+      counter.inc(10);
+      Thread.sleep(1000);
+    }
+    reporter.stop();
+  }
+}

--- a/examples/dropwizard-metrics5/src/main/java/com/wavefront/examples/DirectReporting.java
+++ b/examples/dropwizard-metrics5/src/main/java/com/wavefront/examples/DirectReporting.java
@@ -1,35 +1,43 @@
 package com.wavefront.examples;
 
-import com.wavefront.integrations.metrics.WavefrontDropwizardReporter;
+import com.wavefront.integrations.metrics.WavefrontReporter;
 import io.dropwizard.metrics5.Counter;
+import io.dropwizard.metrics5.MetricName;
 import io.dropwizard.metrics5.MetricRegistry;
 
+import java.util.HashMap;
 import java.util.concurrent.TimeUnit;
 
 /**
  * Example for reporting dropwizard metrics into Wavefront via Direct Ingestion.
  *
- * @author Vikram Raman
+ * @author Subramaniam Narayanan
  */
 public class DirectReporting {
-
   public static void main(String args[]) throws InterruptedException {
-
     String server = args[0];
     String token = args[1];
 
     MetricRegistry registry = new MetricRegistry();
-    Counter counter = registry.counter("direct.dw5metric.foo.bar");
+    HashMap<String, String> tags = new HashMap<>();
+    tags.put("pointkey1", "ptag1");
+    tags.put("pointkey2", "ptag2");
+    // Create metric name object to associated with the metric type. The key is the
+    // metric name and the value are the optional point tags.
+    MetricName counterMetric = new MetricName("direct.dw5metric.foo.bar", tags);
+    // Register the counter with the metric registry
+    Counter counter = registry.counter(counterMetric);
 
-    WavefrontDropwizardReporter reporter = WavefrontDropwizardReporter.forRegistry(registry).
+    // Create a Wavefront Reporter as a direct reporter - requires knowledge of
+    // Wavefront server to connect to along with a valid token.
+    WavefrontReporter reporter = WavefrontReporter.forRegistry(registry).
         withSource("app-1.company.com").
-        withPointTag("dc", "dallas").
-        withPointTag("service", "query").
         buildDirect(server, token);
     reporter.start(5, TimeUnit.SECONDS);
 
     int i = 0;
     while (i++ < 30) {
+      // Periodically update counter
       counter.inc(10);
       Thread.sleep(1000);
     }

--- a/examples/dropwizard-metrics5/src/main/java/com/wavefront/examples/DirectReporting.java
+++ b/examples/dropwizard-metrics5/src/main/java/com/wavefront/examples/DirectReporting.java
@@ -30,8 +30,14 @@ public class DirectReporting {
 
     // Create a Wavefront Reporter as a direct reporter - requires knowledge of
     // Wavefront server to connect to along with a valid token.
+    // NOTE: If the individual metric share the same key as the global point tag key, the
+    // metric level value will override global level value for that point tag.
+    // Example: Global point tag is    <"Key1", "Value-Global">
+    // and metric level point tag is:  <"Key1", "Value-Metric1">
+    // the point tag sent to Wavefront will be <"Key1", "Value-Metric1">
     WavefrontReporter reporter = WavefrontReporter.forRegistry(registry).
         withSource("app-1.company.com").
+        withPointTag("gkey1", "gvalue1").
         buildDirect(server, token);
     reporter.start(5, TimeUnit.SECONDS);
 

--- a/examples/dropwizard-metrics5/src/main/java/com/wavefront/examples/ProxyReporting.java
+++ b/examples/dropwizard-metrics5/src/main/java/com/wavefront/examples/ProxyReporting.java
@@ -1,34 +1,42 @@
 package com.wavefront.examples;
 
-import com.wavefront.integrations.metrics.WavefrontDropwizardReporter;
+import com.wavefront.integrations.metrics.WavefrontReporter;
 import io.dropwizard.metrics5.Counter;
+import io.dropwizard.metrics5.MetricName;
 import io.dropwizard.metrics5.MetricRegistry;
 
+import java.util.HashMap;
 import java.util.concurrent.TimeUnit;
 
 /**
  * Example for reporting dropwizard metrics into Wavefront via proxy.
  *
- * @author Vikram Raman
+ * @author Subramaniam Narayanan
  */
 public class ProxyReporting {
   public static void main(String args[]) throws InterruptedException {
-
     String host = args[0];
     int port = Integer.parseInt(args[1]);
 
     MetricRegistry registry = new MetricRegistry();
-    Counter counter = registry.counter("proxy.dw5metric.foo.bar");
-
-    WavefrontDropwizardReporter reporter = WavefrontDropwizardReporter.forRegistry(registry).
+    HashMap<String, String> tags = new HashMap<>();
+    tags.put("pointkey1", "ptag1");
+    tags.put("pointkey2", "ptag2");
+    // Create metric name object to associated with the metric type. The key is the
+    // metric name and the value are the optional point tags.
+    MetricName counterMetric = new MetricName("proxy.dw5metric.foo.bar", tags);
+    // Register the counter with the metric registry
+    Counter counter = registry.counter(counterMetric);
+    // Create a Wavefront Reporter as a direct reporter - requires knowledge of
+    // Wavefront server to connect to along with a valid token.
+    WavefrontReporter reporter = WavefrontReporter.forRegistry(registry).
         withSource("app-1.company.com").
-        withPointTag("pointkey1", "ptag1").
-        withPointTag("pointkey2", "ptag2").
         build(host, port);
     reporter.start(5, TimeUnit.SECONDS);
 
     int i = 0;
-    while (i++ < 40) {
+    while (i++ < 30) {
+      // Periodically update counter
       counter.inc(10);
       Thread.sleep(5000);
     }

--- a/examples/dropwizard-metrics5/src/main/java/com/wavefront/examples/ProxyReporting.java
+++ b/examples/dropwizard-metrics5/src/main/java/com/wavefront/examples/ProxyReporting.java
@@ -24,6 +24,11 @@ public class ProxyReporting {
     tags.put("pointkey2", "ptag2");
     // Create metric name object to associated with the metric type. The key is the
     // metric name and the value are the optional point tags.
+    // NOTE: If the individual metric share the same key as the global point tag key, the
+    // metric level value will override global level value for that point tag.
+    // Example: Global point tag is    <"Key1", "Value-Global">
+    // and metric level point tag is:  <"Key1", "Value-Metric1">
+    // the point tag sent to Wavefront will be <"Key1", "Value-Metric1">
     MetricName counterMetric = new MetricName("proxy.dw5metric.foo.bar", tags);
     // Register the counter with the metric registry
     Counter counter = registry.counter(counterMetric);
@@ -31,6 +36,7 @@ public class ProxyReporting {
     // Wavefront server to connect to along with a valid token.
     WavefrontReporter reporter = WavefrontReporter.forRegistry(registry).
         withSource("app-1.company.com").
+        withPointTag("gkey1", "gvalue1").
         build(host, port);
     reporter.start(5, TimeUnit.SECONDS);
 

--- a/examples/dropwizard-metrics5/src/main/java/com/wavefront/examples/ProxyReporting.java
+++ b/examples/dropwizard-metrics5/src/main/java/com/wavefront/examples/ProxyReporting.java
@@ -1,0 +1,37 @@
+package com.wavefront.examples;
+
+import com.wavefront.integrations.metrics.WavefrontDropwizardReporter;
+import io.dropwizard.metrics5.Counter;
+import io.dropwizard.metrics5.MetricRegistry;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Example for reporting dropwizard metrics into Wavefront via proxy.
+ *
+ * @author Vikram Raman
+ */
+public class ProxyReporting {
+  public static void main(String args[]) throws InterruptedException {
+
+    String host = args[0];
+    int port = Integer.parseInt(args[1]);
+
+    MetricRegistry registry = new MetricRegistry();
+    Counter counter = registry.counter("proxy.dw5metric.foo.bar");
+
+    WavefrontDropwizardReporter reporter = WavefrontDropwizardReporter.forRegistry(registry).
+        withSource("app-1.company.com").
+        withPointTag("pointkey1", "ptag1").
+        withPointTag("pointkey2", "ptag2").
+        build(host, port);
+    reporter.start(5, TimeUnit.SECONDS);
+
+    int i = 0;
+    while (i++ < 40) {
+      counter.inc(10);
+      Thread.sleep(5000);
+    }
+    reporter.stop();
+  }
+}

--- a/java-lib/pom.xml
+++ b/java-lib/pom.xml
@@ -103,6 +103,11 @@
       <artifactId>metrics-core</artifactId>
       <version>3.1.2</version>
     </dependency>
+    <dependency>
+      <groupId>io.dropwizard.metrics5</groupId>
+      <artifactId>metrics-core</artifactId>
+      <version>5.0.0-rc2</version>
+    </dependency>
   </dependencies>
 
   <build>

--- a/java-lib/src/main/java/io/dropwizard/metrics5/DeltaCounter.java
+++ b/java-lib/src/main/java/io/dropwizard/metrics5/DeltaCounter.java
@@ -1,0 +1,29 @@
+package io.dropwizard.metrics5;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.wavefront.common.MetricConstants;
+
+/**
+ * A counter for Wavefront delta metrics.
+ *
+ * Differs from a counter in that it is reset in the WavefrontReporter every time the value is reported.
+ *
+ * @author Vikram Raman (vikram@wavefront.com)
+ */
+public class DeltaCounter extends Counter {
+
+  @VisibleForTesting
+  public static synchronized DeltaCounter get(MetricRegistry registry, String metricName) {
+
+    if (registry == null || metricName == null || metricName.isEmpty()) {
+      throw new IllegalArgumentException("Invalid arguments");
+    }
+
+    if (!(metricName.startsWith(MetricConstants.DELTA_PREFIX) || metricName.startsWith(MetricConstants.DELTA_PREFIX_2))) {
+      metricName = MetricConstants.DELTA_PREFIX + metricName;
+    }
+    DeltaCounter counter = new DeltaCounter();
+    registry.register(metricName, counter);
+    return counter;
+  }
+}

--- a/java-lib/src/main/java/io/dropwizard/metrics5/jvm/SafeFileDescriptorRatioGauge.java
+++ b/java-lib/src/main/java/io/dropwizard/metrics5/jvm/SafeFileDescriptorRatioGauge.java
@@ -1,0 +1,47 @@
+package io.dropwizard.metrics5.jvm;
+
+import io.dropwizard.metrics5.RatioGauge;
+import com.sun.management.UnixOperatingSystemMXBean;
+
+import java.lang.management.ManagementFactory;
+import java.lang.management.OperatingSystemMXBean;
+
+/**
+ * Java 9 compatible implementation of FileDescriptorRatioGauge that doesn't use reflection
+ * and is not susceptible to an InaccessibleObjectException
+ *
+ * The gauge represents a ratio of used to total file descriptors.
+ *
+ * @author Vasily Vorontsov (vasily@wavefront.com)
+ */
+public class SafeFileDescriptorRatioGauge extends RatioGauge {
+  private final OperatingSystemMXBean os;
+
+  /**
+   * Creates a new gauge using the platform OS bean.
+   */
+  public SafeFileDescriptorRatioGauge() {
+    this(ManagementFactory.getOperatingSystemMXBean());
+  }
+
+  /**
+   * Creates a new gauge using the given OS bean.
+   *
+   * @param os    an {@link OperatingSystemMXBean}
+   */
+  public SafeFileDescriptorRatioGauge(OperatingSystemMXBean os) {
+    this.os = os;
+  }
+
+  /**
+   * @return  {@link com.codahale.metrics.RatioGauge.Ratio} of used to total file descriptors.
+   */
+  protected Ratio getRatio() {
+    if (!(this.os instanceof UnixOperatingSystemMXBean)) {
+      return Ratio.of(Double.NaN, Double.NaN);
+    }
+    Long openFds = ((UnixOperatingSystemMXBean)os).getOpenFileDescriptorCount();
+    Long maxFds = ((UnixOperatingSystemMXBean)os).getMaxFileDescriptorCount();
+    return Ratio.of(openFds.doubleValue(), maxFds.doubleValue());
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -9,6 +9,8 @@
     <module>java-lib</module>
     <module>proxy</module>
     <module>java-client</module>
+    <module>dropwizard-metrics/dropwizard-metrics5</module>
+    <module>examples/dropwizard-metrics5</module>
     <module>dropwizard-metrics/dropwizard-metrics</module>
     <module>dropwizard-metrics/dropwizard-metrics-wavefront</module>
     <module>yammer-metrics</module>
@@ -113,6 +115,11 @@
       <dependency>
         <groupId>com.wavefront</groupId>
         <artifactId>dropwizard-metrics</artifactId>
+        <version>${public.project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.wavefront</groupId>
+        <artifactId>dropwizard-metrics5</artifactId>
         <version>${public.project.version}</version>
       </dependency>
       <dependency>


### PR DESCRIPTION
Implement WavefrontDropwizardReporter based on dropwizard version 5.0.0-rc2. Add examples for proxy based reporting as well as sending metrics directly to Wavefront. 