### PR TITLE
PUB-136: improve histogram resilience in gross misconfiguration scenarios

### DIFF
--- a/proxy/src/main/java/com/wavefront/agent/PushAgent.java
+++ b/proxy/src/main/java/com/wavefront/agent/PushAgent.java
@@ -505,10 +505,18 @@ public class PushAgent extends AbstractAgent {
     histogramExecutor.scheduleWithFixedDelay(
         () -> {
           // warn if accumulator is more than 1.5x the original size, as ChronicleMap starts losing efficiency
-          if (accumulator.size() > accumulatorSize * 1.5) {
+          if (accumulator.size() > accumulatorSize * 5) {
+            logger.severe("Histogram " + listenerBinType + " accumulator size (" + accumulator.size() +
+                ") is more than 5x higher than currently configured size (" + accumulatorSize +
+                "), which may cause severe performance degradation issues or crashes! " +
+                "If the data volume is expected to stay at this level, we strongly recommend increasing the value " +
+                "for accumulator size in wavefront.conf and restarting the proxy.");
+          } else if (accumulator.size() > accumulatorSize * 2) {
             logger.warning("Histogram " + listenerBinType + " accumulator size (" + accumulator.size() +
-                ") is much higher than configured size (" + accumulatorSize +
-                "), proxy may experience performance issues or crash!");
+                ") is more than 2x higher than currently configured size (" + accumulatorSize +
+                "), which may cause performance issues. " +
+                "If the data volume is expected to stay at this level, we strongly recommend increasing the value " +
+                "for accumulator size in wavefront.conf and restarting the proxy.");
           }
         },
         10,

--- a/proxy/src/main/java/com/wavefront/agent/PushAgent.java
+++ b/proxy/src/main/java/com/wavefront/agent/PushAgent.java
@@ -508,7 +508,7 @@ public class PushAgent extends AbstractAgent {
           if (accumulator.size() > accumulatorSize * 5) {
             logger.severe("Histogram " + listenerBinType + " accumulator size (" + accumulator.size() +
                 ") is more than 5x higher than currently configured size (" + accumulatorSize +
-                "), which may cause severe performance degradation issues or crashes! " +
+                "), which may cause severe performance degradation issues or data loss! " +
                 "If the data volume is expected to stay at this level, we strongly recommend increasing the value " +
                 "for accumulator size in wavefront.conf and restarting the proxy.");
           } else if (accumulator.size() > accumulatorSize * 2) {

--- a/proxy/src/main/java/com/wavefront/agent/histogram/MapLoader.java
+++ b/proxy/src/main/java/com/wavefront/agent/histogram/MapLoader.java
@@ -41,9 +41,11 @@ public class MapLoader<K, V, KM extends BytesReader<K> & BytesWriter<K>, VM exte
 
   /**
    * Allow ChronicleMap to grow beyond initially allocated size instead of crashing. Since it makes the map a lot less
-   * efficient, we should log a warning if the actual number of elements exceeds the allocated
+   * efficient, we should log a warning if the actual number of elements exceeds the allocated.
+   * A bloat factor of 1000 is the highest possible value which we are going to use here, as we need to prevent
+   * crashes at all costs.
    */
-  private static final double MAX_BLOAT_FACTOR = 5;
+  private static final double MAX_BLOAT_FACTOR = 1000;
 
   private final Class<K> keyClass;
   private final Class<V> valueClass;


### PR DESCRIPTION
- Increase default maxBloatSize to 1000
- Make ChronicleMap allocation failure error message more user friendly 
- Additional metrics to detect increased IO caused by memory cache pressure (also due to incorrectly configured accumulator size)