### PR TITLE
Rename replaceSource to replaceInput in extractTag* rules 

### DIFF
--- a/pkg/etc/wavefront/wavefront-proxy/preprocessor_rules.yaml.default
+++ b/pkg/etc/wavefront/wavefront-proxy/preprocessor_rules.yaml.default
@@ -202,7 +202,7 @@
   #  match         : "delimited.*"
   #  search        : "^([^\\.]*\\.[^\\.]*\\.)([^\\.]*)\\.(.*)$"
   #  replace       : "$2"
-  #  replaceSource : "$1$3" # optional, omit if you plan on just extracting the tag leaving the metric name intact
+  #  replaceInput  : "$1$3" # optional, omit if you plan on just extracting the tag leaving the metric name intact
 
 
 # rules for port 4242

--- a/proxy/src/main/java/com/wavefront/agent/preprocessor/AgentPreprocessorConfiguration.java
+++ b/proxy/src/main/java/com/wavefront/agent/preprocessor/AgentPreprocessorConfiguration.java
@@ -74,7 +74,7 @@ public class AgentPreprocessorConfiguration {
           try {
             requireArguments(rule, "rule", "action");
             allowArguments(rule, "rule", "action", "scope", "search", "replace", "match",
-                "tag", "newtag", "value", "source", "iterations", "replaceSource");
+                "tag", "newtag", "value", "source", "iterations", "replaceSource", "replaceInput");
             String ruleName = rule.get("rule").replaceAll("[^a-z0-9_-]", "");
             PreprocessorRuleMetrics ruleMetrics = new PreprocessorRuleMetrics(
                 Metrics.newCounter(new TaggedMetricName("preprocessor." + ruleName, "count", "port", strPort)),
@@ -133,18 +133,19 @@ public class AgentPreprocessorConfiguration {
                   break;
                 case "extractTag":
                   allowArguments(rule, "rule", "action", "tag", "source", "search", "replace", "replaceSource",
-                      "match");
+                      "replaceInput", "match");
                   this.forPort(strPort).forReportPoint().addTransformer(
                       new ReportPointExtractTagTransformer(rule.get("tag"), rule.get("source"), rule.get("search"),
-                          rule.get("replace"), rule.get("replaceSource"), rule.get("match"), ruleMetrics));
+                          rule.get("replace"), rule.getOrDefault("replaceInput", rule.get("replaceSource")),
+                          rule.get("match"), ruleMetrics));
                   break;
                 case "extractTagIfNotExists":
                   allowArguments(rule, "rule", "action", "tag", "source", "search", "replace", "replaceSource",
-                      "match");
+                      "replaceInput", "match");
                   this.forPort(strPort).forReportPoint().addTransformer(
                       new ReportPointExtractTagIfNotExistsTransformer(rule.get("tag"), rule.get("source"),
-                          rule.get("search"), rule.get("replace"), rule.get("replaceSource"), rule.get("match"),
-                          ruleMetrics));
+                          rule.get("search"), rule.get("replace"), rule.getOrDefault("replaceInput",
+                          rule.get("replaceSource")), rule.get("match"), ruleMetrics));
                   break;
                 case "renameTag":
                   allowArguments(rule, "rule", "action", "tag", "newtag", "match");

--- a/proxy/src/test/resources/com/wavefront/agent/preprocessor/preprocessor_rules.yaml
+++ b/proxy/src/test/resources/com/wavefront/agent/preprocessor/preprocessor_rules.yaml
@@ -194,7 +194,7 @@
       match         : "^.*testExtractTag.*"
       search        : "^([^\\.]*\\.[^\\.]*\\.)([^\\.]*)\\.(.*)$"
       replace       : "$2"
-      replaceSource : "$1$3"
+      replaceInput  : "$1$3"
 
     - rule          : test-extracttag-source
       action        : extractTag
@@ -202,7 +202,7 @@
       source        : sourceName
       search        : "^([^-]*-[^-]*)-(.*)$"
       replace       : "$2"
-      replaceSource : "$1"
+      replaceInput  : "$1"
 
     - rule          : test-extracttagifnotexists-tag
       action        : extractTagIfNotExists


### PR DESCRIPTION
to reduce confusion. replaceSource is still supported for backwards compatibility.