### PR TITLE
Changed the package name for the WavefrontReporter 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 *.class
 
+.DS_Store
+
 # Mobile Tools for Java (J2ME)
 .mtj.tmp/
 

--- a/dropwizard-metrics/dropwizard-metrics/pom.xml
+++ b/dropwizard-metrics/dropwizard-metrics/pom.xml
@@ -10,7 +10,7 @@
 
     <artifactId>dropwizard-metrics</artifactId>
     <version>4.30-SNAPSHOT</version>
-    <name>Wavefront Dropwizard Metrics eporter</name>
+    <name>Wavefront Dropwizard Metrics Reporter</name>
     <description>Report metrics via the Wavefront Proxy</description>
 
     <dependencies>

--- a/dropwizard-metrics/dropwizard-metrics5/pom.xml
+++ b/dropwizard-metrics/dropwizard-metrics5/pom.xml
@@ -10,7 +10,7 @@
 
     <artifactId>dropwizard-metrics5</artifactId>
     <version>4.30-SNAPSHOT</version>
-    <name>Wavefront Dropwizard5 Metrics eporter</name>
+    <name>Wavefront Dropwizard5 Metrics reporter</name>
     <description>Report metrics via the Wavefront Proxy</description>
 
     <dependencies>

--- a/dropwizard-metrics/dropwizard-metrics5/src/main/java/com/wavefront/integrations/dropwizard_metrics5/WavefrontReporter.java
+++ b/dropwizard-metrics/dropwizard-metrics5/src/main/java/com/wavefront/integrations/dropwizard_metrics5/WavefrontReporter.java
@@ -1,4 +1,4 @@
-package com.wavefront.integrations.metrics;
+package com.wavefront.integrations.dropwizard_metrics5;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Maps;

--- a/examples/dropwizard-metrics5/src/main/java/com/wavefront/examples/DirectReporting.java
+++ b/examples/dropwizard-metrics5/src/main/java/com/wavefront/examples/DirectReporting.java
@@ -1,6 +1,7 @@
 package com.wavefront.examples;
 
-import com.wavefront.integrations.metrics.WavefrontReporter;
+import com.wavefront.integrations.dropwizard_metrics5.WavefrontReporter;
+
 import io.dropwizard.metrics5.Counter;
 import io.dropwizard.metrics5.MetricName;
 import io.dropwizard.metrics5.MetricRegistry;

--- a/examples/dropwizard-metrics5/src/main/java/com/wavefront/examples/ProxyReporting.java
+++ b/examples/dropwizard-metrics5/src/main/java/com/wavefront/examples/ProxyReporting.java
@@ -1,6 +1,7 @@
 package com.wavefront.examples;
 
-import com.wavefront.integrations.metrics.WavefrontReporter;
+import com.wavefront.integrations.dropwizard_metrics5.WavefrontReporter;
+
 import io.dropwizard.metrics5.Counter;
 import io.dropwizard.metrics5.MetricName;
 import io.dropwizard.metrics5.MetricRegistry;


### PR DESCRIPTION
 Changed the package name for the WavefrontReporter for 5.0 to com.wavefront.integrations.dropwizard_metrics5.WavefrontReporter to avoid conflict with existing reporter com.wavefront.integrations.metrics.WavefrontReporter