### PR TITLE
Wavefront Proxy raw data logging

### DIFF
--- a/proxy/src/main/java/com/wavefront/agent/listeners/ChannelStringHandler.java
+++ b/proxy/src/main/java/com/wavefront/agent/listeners/ChannelStringHandler.java
@@ -9,14 +9,21 @@ import com.wavefront.agent.preprocessor.ReportableEntityPreprocessor;
 import com.wavefront.ingester.Decoder;
 
 import java.net.InetSocketAddress;
+import java.net.SocketAddress;
 import java.util.List;
+import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
 
 import javax.annotation.Nullable;
 
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.SimpleChannelInboundHandler;
+
+import org.apache.commons.lang.math.NumberUtils;
+
 import wavefront.report.ReportPoint;
 
 /**
@@ -29,8 +36,10 @@ import wavefront.report.ReportPoint;
 public class ChannelStringHandler extends SimpleChannelInboundHandler<String> {
 
   private static final Logger blockedPointsLogger = Logger.getLogger("RawBlockedPoints");
+  private static final Logger rawDataLogger = Logger.getLogger("RawDataLogger");
 
   private final Decoder<String> decoder;
+  private static final Random RANDOM = new Random();
 
   /**
    * Transformer to transform each line.
@@ -39,17 +48,61 @@ public class ChannelStringHandler extends SimpleChannelInboundHandler<String> {
   private final ReportableEntityPreprocessor preprocessor;
   private final PointHandler pointHandler;
 
+  private boolean logRawData = false;
+  /**
+   * Value of system property wavefront.proxy.lograwdata (for backwards compatibility)
+   */
+  private final boolean logRawDataFlag;
+  private double logRawDataRate;
+  private volatile long logRawUpdatedMillis = 0L;
+
   public ChannelStringHandler(Decoder<String> decoder,
                               final PointHandler pointhandler,
                               @Nullable final ReportableEntityPreprocessor preprocessor) {
     this.decoder = decoder;
     this.pointHandler = pointhandler;
     this.preprocessor = preprocessor;
+
+    // check the property setting for logging raw data
+    String logRawDataProperty = System.getProperty("wavefront.proxy.lograwdata");
+    logRawDataFlag = logRawDataProperty != null && logRawDataProperty.equalsIgnoreCase("true");
+    String logRawDataSampleRateProperty = System.getProperty("wavefront.proxy.lograwdata.sample-rate");
+    this.logRawDataRate = logRawDataSampleRateProperty != null &&
+        NumberUtils.isNumber(logRawDataSampleRateProperty) ? Double.parseDouble(logRawDataSampleRateProperty) : 1.0d;
+
+    // make sure the rate fits between 0.0d - 1.0d
+    if (logRawDataRate < 0.0d) {
+      logRawDataRate = 0.0d;
+    } else if (logRawDataRate > 1.0d) {
+      logRawDataRate = 1.0d;
+    }
   }
 
   @Override
   protected void channelRead0(ChannelHandlerContext ctx, String msg) throws Exception {
-    // if msg does not match metadata keywords then treat it as a point
+    // use data rate to determine sampling rate
+    // logging includes the source host and port
+    if (logRawUpdatedMillis + TimeUnit.SECONDS.toMillis(1) < System.currentTimeMillis()) {
+      if (logRawData != rawDataLogger.isLoggable(Level.FINEST)) {
+        logRawData = !logRawData;
+        rawDataLogger.info("Raw data logging is now " + (logRawData ?
+            "enabled with " + (logRawDataRate * 100) + "% sampling" :
+            "disabled"));
+      }
+      logRawUpdatedMillis = System.currentTimeMillis();
+    }
+
+    if ((logRawData || logRawDataFlag) &&
+        (logRawDataRate >= 1.0d || (logRawDataRate > 0.0d && RANDOM.nextDouble() < logRawDataRate)) {
+      if (ctx.channel().remoteAddress() != null) {
+        String hostAddress = ((InetSocketAddress) ctx.channel().remoteAddress()).getAddress().getHostAddress();
+        int localPort = ((InetSocketAddress) ctx.channel().localAddress()).getPort();
+        rawDataLogger.info(String.format("[%s>%d]%s", hostAddress, localPort, msg));
+      } else {
+        int localPort = ((InetSocketAddress) ctx.channel().localAddress()).getPort();
+        rawDataLogger.info(String.format("[>%d]%s", localPort, msg));
+      }
+    }
     processPointLine(msg, decoder, pointHandler, preprocessor, ctx);
   }
 
@@ -70,7 +123,6 @@ public class ChannelStringHandler extends SimpleChannelInboundHandler<String> {
     // transform the line if needed
     if (preprocessor != null) {
       pointLine = preprocessor.forPointLine().transform(pointLine);
-
       // apply white/black lists after formatting
       if (!preprocessor.forPointLine().filter(pointLine)) {
         if (preprocessor.forPointLine().getLastFilterResult() != null) {

--- a/proxy/src/main/java/com/wavefront/agent/listeners/ChannelStringHandler.java
+++ b/proxy/src/main/java/com/wavefront/agent/listeners/ChannelStringHandler.java
@@ -93,7 +93,7 @@ public class ChannelStringHandler extends SimpleChannelInboundHandler<String> {
     }
 
     if ((logRawData || logRawDataFlag) &&
-        (logRawDataRate >= 1.0d || (logRawDataRate > 0.0d && RANDOM.nextDouble() < logRawDataRate)) {
+        (logRawDataRate >= 1.0d || (logRawDataRate > 0.0d && RANDOM.nextDouble() < logRawDataRate))) {
       if (ctx.channel().remoteAddress() != null) {
         String hostAddress = ((InetSocketAddress) ctx.channel().remoteAddress()).getAddress().getHostAddress();
         int localPort = ((InetSocketAddress) ctx.channel().localAddress()).getPort();

--- a/proxy/src/main/java/com/wavefront/agent/listeners/ChannelStringHandler.java
+++ b/proxy/src/main/java/com/wavefront/agent/listeners/ChannelStringHandler.java
@@ -64,16 +64,18 @@ public class ChannelStringHandler extends SimpleChannelInboundHandler<String> {
     this.preprocessor = preprocessor;
 
     // check the property setting for logging raw data
-    String logRawDataProperty = System.getProperty("wavefront.proxy.lograwdata");
+    @Nullable String logRawDataProperty = System.getProperty("wavefront.proxy.lograwdata");
     logRawDataFlag = logRawDataProperty != null && logRawDataProperty.equalsIgnoreCase("true");
-    String logRawDataSampleRateProperty = System.getProperty("wavefront.proxy.lograwdata.sample-rate");
+    @Nullable String logRawDataSampleRateProperty = System.getProperty("wavefront.proxy.lograwdata.sample-rate");
     this.logRawDataRate = logRawDataSampleRateProperty != null &&
         NumberUtils.isNumber(logRawDataSampleRateProperty) ? Double.parseDouble(logRawDataSampleRateProperty) : 1.0d;
 
     // make sure the rate fits between 0.0d - 1.0d
     if (logRawDataRate < 0.0d) {
+      rawDataLogger.info("Invalid log raw data rate:" + logRawDataRate + ", adjusted to 0.0");
       logRawDataRate = 0.0d;
     } else if (logRawDataRate > 1.0d) {
+      rawDataLogger.info("Invalid log raw data rate:" + logRawDataRate + ", adjusted to 1.0");
       logRawDataRate = 1.0d;
     }
   }

--- a/proxy/src/main/java/com/wavefront/agent/listeners/ChannelStringHandler.java
+++ b/proxy/src/main/java/com/wavefront/agent/listeners/ChannelStringHandler.java
@@ -99,10 +99,11 @@ public class ChannelStringHandler extends SimpleChannelInboundHandler<String> {
       if (ctx.channel().remoteAddress() != null) {
         String hostAddress = ((InetSocketAddress) ctx.channel().remoteAddress()).getAddress().getHostAddress();
         int localPort = ((InetSocketAddress) ctx.channel().localAddress()).getPort();
-        rawDataLogger.info(String.format("[%s>%d]%s", hostAddress, localPort, msg));
+        rawDataLogger.info("[" + hostAddress + ">" + localPort + "]" + msg);
       } else {
         int localPort = ((InetSocketAddress) ctx.channel().localAddress()).getPort();
-        rawDataLogger.info(String.format("[>%d]%s", localPort, msg));
+        rawDataLogger.info("[>" + localPort + "]" + msg);
+        
       }
     }
     processPointLine(msg, decoder, pointHandler, preprocessor, ctx);

--- a/proxy/src/main/java/com/wavefront/agent/listeners/ChannelStringHandler.java
+++ b/proxy/src/main/java/com/wavefront/agent/listeners/ChannelStringHandler.java
@@ -48,13 +48,13 @@ public class ChannelStringHandler extends SimpleChannelInboundHandler<String> {
   private final ReportableEntityPreprocessor preprocessor;
   private final PointHandler pointHandler;
 
-  private boolean logRawData = false;
   /**
    * Value of system property wavefront.proxy.lograwdata (for backwards compatibility)
    */
   private final boolean logRawDataFlag;
   private double logRawDataRate;
   private volatile long logRawUpdatedMillis = 0L;
+  private boolean logRawData = false;
 
   public ChannelStringHandler(Decoder<String> decoder,
                               final PointHandler pointhandler,


### PR DESCRIPTION
What the change is about:
This PR will modify ChannelStringHandler.java to have the ability to sample and log RAW data string that is coming into Wavefront Proxy, before the data gets pre-processed. This will allow users to monitor and troubleshoot their incoming data in a raw form that will make it easy to detect any incorrect or missed out pre-processing rules or simply see if their source data is in the right format.

This feature can be enabled by setting the following system properties when starting up the proxy:
wavefront.proxy.lograwdata = (true|false)
wavefront.proxy.lograwdata.sample-rate = (double value, between 0.0d ~ 1.0d)

Also, you can enable the logging behavior dynamically by setting the "RawDataLogger" in java logging to "FINE" level. Log will be suppressed when either the logging level is not FINE, or the wavefront.proxy.lograwdata is set to false.

The logging works by the set sample-rate, which can be adjusted to control how much the raw data would be 'sampled,' as RAW data can be overwhelming when large data are incoming. For example, if you wish to sample only 1% of the overall data, set this to 0.01. If you wish to sample all of the RAW data, you can set it to 1.0. Setting the rate to 0.0 will not produce any logs.
