### PR TITLE
PUB-145: fix preprocessorConfigfile args issue

### DIFF
--- a/proxy/docker/Dockerfile
+++ b/proxy/docker/Dockerfile
@@ -32,7 +32,11 @@ RUN curl -s https://s3-us-west-2.amazonaws.com/wavefront-misc/proxy-jre.tgz | ta
 RUN apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 # Configure agent
+ENV DO_SERVICE_RESTART=false
+RUN cp /etc/wavefront/wavefront-proxy/wavefront.conf.default /etc/wavefront/wavefront-proxy/wavefront.conf
 RUN cp /etc/wavefront/wavefront-proxy/log4j2-stdout.xml.default /etc/wavefront/wavefront-proxy/log4j2.xml
+RUN echo '\nephemeral=true' >> /etc/wavefront/wavefront-proxy/wavefront.conf
+RUN echo '\nflushThreads=6' >> /etc/wavefront/wavefront-proxy/wavefront.conf
 
 # Run the agent
 EXPOSE 3878
@@ -40,5 +44,6 @@ EXPOSE 2878
 EXPOSE 4242
 
 ENV PATH=/opt/wavefront/wavefront-proxy/jre/bin:$PATH
+ENV WAVEFRONT_USE_GRAPHITE=false
 ADD run.sh run.sh
 CMD ["/bin/bash", "/run.sh"]

--- a/proxy/docker/run.sh
+++ b/proxy/docker/run.sh
@@ -4,17 +4,17 @@ set -x
 spool_dir="/var/spool/wavefront-proxy"
 mkdir -p $spool_dir
 
+WAVEFRONT_HOSTNAME=${WAVEFRONT_HOSTNAME:-$(hostname)}
+export WAVEFRONT_HOSTNAME
+
+autoconf=/opt/wavefront/wavefront-proxy/bin/autoconf-wavefront-proxy.sh
+/bin/bash -x $autoconf
+
 java_heap_usage=${JAVA_HEAP_USAGE:-4G}
 java \
-	-Xmx$java_heap_usage -Xms$java_heap_usage $JAVA_ARGS\
+	-Xmx$java_heap_usage -Xms$java_heap_usage \
 	-Djava.util.logging.manager=org.apache.logging.log4j.jul.LogManager \
 	-Dlog4j.configurationFile=/etc/wavefront/wavefront-proxy/log4j2.xml \
 	-jar /opt/wavefront/wavefront-proxy/bin/wavefront-push-agent.jar \
-	-h $WAVEFRONT_URL \
-	-t $WAVEFRONT_TOKEN \
-	--hostname ${WAVEFRONT_HOSTNAME:-$(hostname)} \
-	--ephemeral true \
-	--buffer ${spool_dir}/buffer} \
-	--flushThreads 6 \
-	--retryThreads 6 \
+	-f /etc/wavefront/wavefront-proxy/wavefront.conf \
 	$WAVEFRONT_PROXY_ARGS


### PR DESCRIPTION
* This is to partially revert this change (https://github.com/wavefrontHQ/java/commit/28f7b924c33f1cc8dda518ce0a565c46b43b1bc4). 

* Because of this line(https://github.com/wavefrontHQ/java/blob/master/proxy/src/main/java/com/wavefront/agent/AbstractAgent.java#L816), if there is no config file ("-f") is provided, then lots of config parameters won't be taken effect. This pull request is just a quick workaround, but we might need to modify AbstractAgent.java file more.

* Or maybe we can simply remove this line (https://github.com/wavefrontHQ/java/blob/master/proxy/src/main/java/com/wavefront/agent/AbstractAgent.java#L816) ?!