### PR TITLE
Update jetty version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
 
     <java.version>1.8</java.version>
     <log4j.version>2.11.1</log4j.version>
-    <jetty.version>9.4.12.v20180830</jetty.version>
+    <jetty.version>9.4.14.v20181114</jetty.version>
     <jackson.version>2.9.6</jackson.version>
     <netty.version>4.1.25.Final</netty.version>
     <public.project.version>4.33-SNAPSHOT</public.project.version>


### PR DESCRIPTION
Upgrade package Org.eclipse.jetty:Jetty-Server from disallowed version  9.4.12.V20180830 to allowed version 9.4.14.v20181114



