### PR TITLE
Update README.md

### DIFF
--- a/proxy/README.md
+++ b/proxy/README.md
@@ -1,24 +1,53 @@
 # Wavefront Proxy
 [![Javadocs](http://javadoc.io/badge/com.wavefront/proxy.svg)](http://javadoc.io/doc/com.wavefront/proxy)
 
-The Wavefront proxy is a light-weight Java application that you send your metrics to. It handles authentication and the transmission of your metrics to your Wavefront instance.
+The Wavefront proxy is a light-weight Java application that you send your metrics, histograms, and trace data to. It handles authentication and the transmission of your data to your Wavefront instance.
 
-Source code under org.logstash.* is used from
- [logstash-input-beats](https://github.com/logstash-plugins/logstash-input-beats) via the Apache 2.0 license.
+Source code under `org.logstash.*` is used from [logstash-input-beats](https://github.com/logstash-plugins/logstash-input-beats) via the Apache 2.0 license.
 
-## Installation
 
-### Using The Wavefront Installer
+## Set Up a Wavefront Proxy
+To set up a Wavefront proxy to listen for metrics, histograms, and trace data:
+1.  On the host that will run the proxy, use the Wavefront installer to [install the latest proxy version](http://docs.wavefront.com/proxies_installing.html##proxy-installation).
+    * If you already have an installed proxy, you may need to [upgrade](http://docs.wavefront.com/proxies_installing.html#upgrading-a-proxy) it. You need Version 4.33 or later to listen for trace data.
+    * See [below](#proxy-installation-options) for other installation options.
+2. On the proxy host, open the proxy configuration file `wavefront.conf` for editing. The file location depends on the host:
+    * Linux - `/etc/wavefront/wavefront-proxy/wavefront.conf` 
+    * Mac - `/usr/local/etc/wavefront/wavefront-proxy/wavefront.conf`
+    * Windows - `C:\Program Files (x86)\Wavefront\conf\wavefront.conf`
+    * Additional paths may be listed [here](http://docs.wavefront.com/proxies_configuring.html#paths).
+3. In the `wavefront.conf` file, find and uncomment the property for each listener port you want to enable. You must enable at least one listener port. 
+    * The following example enables the default or recommended listener ports for metrics, histogram distributions, and trace data.  
+    ```
+    ## wavefront.conf file
+    ...
+    # Listens for metric data. Default: 2878
+    pushListenerPort=2878
+    ...
+    # Listens for histogram distributions. Recommended: 40000
+    histogramDistListenerPort=40000
+    ...
+    # Listens for trace data. Recommended: 30000
+    traceListenerPort=30000
+    ```
+4. Save the `wavefront.conf` file.
+5. [Start](http://docs.wavefront.com/proxies_installing.html###starting-and-stopping-a-proxy) the proxy.
 
-The recommended (and by far the easiest) way to install the most recent release of the proxy is to use [The Wavefront Installer](https://docs.wavefront.com/proxies_installing.html) - we've developed a simple, one-line installer that configures the Wavefront proxy and/or collectd to send metrics to Wavefront in as little as one step.
+## Proxy Installation Options
 
-### Using Linux Packages
+### Option 1. Use The Wavefront Installer
 
-We have pre-build packages for popular Linux distros. Packages for released versions are available at https://packagecloud.io/wavefront/proxy, release candidate versions are available at https://packagecloud.io/wavefront/proxy-next.
+The recommended (and by far the easiest) way to install the most recent release of the proxy is to use [the Wavefront installer](https://docs.wavefront.com/proxies_installing.html##proxy-installation). This is a simple, one-line installer that configures the Wavefront proxy and/or `collectd` to send telemetry data to Wavefront in as little as one step.
 
-### Building your own
+### Option 2. Use Linux Packages
 
-To build your own version, run the following commands (you need [Apache Maven](https://maven.apache.org) installed for a successful build)
+We have pre-build packages for popular Linux distros. 
+* Packages for released versions are available at https://packagecloud.io/wavefront/proxy. 
+* Release candidate versions are available at https://packagecloud.io/wavefront/proxy-next.
+
+### Option 3. Build Your Own Proxy
+
+To build your own version, run the following commands (you need [Apache Maven](https://maven.apache.org) installed for a successful build).
 
 ```
 git clone https://github.com/wavefrontHQ/java
@@ -26,6 +55,6 @@ cd java
 mvn install
 ```
 
-## Configuration
+## Advanced Proxy Configuration
 
-For the detailed list of configuration options, please refer to [Wavefront Production Proxy Configuration Guide](https://docs.wavefront.com/proxies_configuring.html) on our docs site.
+You can find [advanced proxy configuration information](https://docs.wavefront.com/proxies_configuring.html) on our docs site.


### PR DESCRIPTION
Edited existing sections, and added a new "Set Up a Wavefront Proxy" section that can be linked to from the READMEs for the new observability SDKs. This section provides a streamlined set of steps for the SDK user, and might eventually be moved into the docs. For now, it enables the SDK README's to link to the information without waiting for 29.x docs to go live.