### PR TITLE
fix proxy-builder docker image build issue

### DIFF
--- a/pkg/Dockerfile
+++ b/pkg/Dockerfile
@@ -1,10 +1,10 @@
 # Create a docker VM for building the wavefront proxy agent .deb and .rpm
 # packages.
 FROM centos:6
-RUN yum -y install gcc make autoconf wget vim rpm-build git
+RUN yum -y install gcc make autoconf wget vim rpm-build git gpg2
 
 # Set up Ruby 1.9.3 for FPM.
-RUN gpg --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3
+RUN gpg2 --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB
 RUN curl -L get.rvm.io | bash -s stable
 ENV PATH /usr/local/rvm/gems/ruby-1.9.3-p551/bin:/usr/local/rvm/gems/ruby-1.9.3-p551@global/bin:/usr/local/rvm/rubies/ruby-1.9.3-p551/bin:/usr/local/rvm/bin:$PATH
 ENV LC_ALL en_US.UTF-8


### PR DESCRIPTION
Try to fix the following issue while building proxy-builder docker image.

```
11:40:05 Step 4/11 : RUN curl -L get.rvm.io | bash -s stable
11:40:05  ---> Running in 1dd8d835b54d
11:40:05 [91m  % Total    % Received % Xferd  Average Speed   Time    Time     Time  C[0m[91murrent
11:40:05                                  Dload  Upload [0m[91m  Total   Spent    Left  Speed
11:40:05 
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0[0m[91m
194   194  194   194    0     0    993      0 --:--:-- --:--:-- --:--:--  2365[0m[91m
  0   194    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0[0m[91m
100 24593  100 24593    0     0  75741      0 --:--:-- --:--:-- --:--:-- 1334k
11:40:05 [0mDownloading https://github.com/rvm/rvm/archive/1.29.6.tar.gz
11:40:07 Downloading https://github.com/rvm/rvm/releases/download/1.29.6/1.29.6.tar.gz.asc
11:40:07 [91mgpg: Signature made Thu Dec 13 15:09:53 2018 UTC using RSA key ID 39499BDB
11:40:07 [0m[91mgpg: Can't check signature: No public key
11:40:07 [0mWarning, RVM 1.26.0 introduces signed releases and automated check of signatures when GPG software found. Assuming you trust Michal Papis import the mpapis public key (downloading the signatures).
11:40:07 
11:40:07 GPG signature verification failed for '/usr/local/rvm/archives/rvm-1.29.6.tgz' - 'https://github.com/rvm/rvm/releases/download/1.29.6/1.29.6.tar.gz.asc'! Try to install GPG v2 and then fetch the public key:
11:40:07 
11:40:07     gpg2 --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB
11:40:07 
11:40:07 or if it fails:
11:40:07 
11:40:07     command curl -sSL https://rvm.io/mpapis.asc | gpg2 --import -
11:40:07     command curl -sSL https://rvm.io/pkuczynski.asc | gpg2 --import -
11:40:07 
11:40:07 the key can be compared with:
11:40:07 
11:40:07     https://rvm.io/mpapis.asc or https://keybase.io/mpapis
11:40:07     https://rvm.io/pkuczynski.asc
11:40:07 
11:40:07 NOTE: GPG version 2.1.17 have a bug which cause failures during fetching keys from remote server. Please downgrade or upgrade to newer version (if available) or use the second method described above.
11:40:07 
11:40:07 The command '/bin/sh -c curl -L get.rvm.io | bash -s stable' returned a non-zero code: 2
```