### PR TITLE
Handle zipkin errors

### DIFF
--- a/proxy/src/main/java/com/wavefront/agent/listeners/ZipkinPortUnificationHandler.java
+++ b/proxy/src/main/java/com/wavefront/agent/listeners/ZipkinPortUnificationHandler.java
@@ -192,7 +192,7 @@ public class ZipkinPortUnificationHandler extends PortUnificationHandler {
     if (zipkinSpan.tags().containsKey(SPAN_TAG_ERROR)) {
       if (zipkinDataLogger.isLoggable(Level.FINER)) {
         zipkinDataLogger.info("Span id :: " + spanId + " with trace id :: " + traceId +
-            " , failed with Error :: " + zipkinSpan.tags().get(SPAN_TAG_ERROR));
+            " , includes error tag :: " + zipkinSpan.tags().get(SPAN_TAG_ERROR));
       }
     }
 


### PR DESCRIPTION
Handling zipkin errors. Zipkin spans usually propagate errors with key='error' and value='actual error message'. We want to ignore this error message for now. Instead report it as 'error'='true' so that the span shows up as RED in the UI.