### PR TITLE
add '--homedir /root/.gnupg' to the front

### DIFF
--- a/pkg/Dockerfile
+++ b/pkg/Dockerfile
@@ -4,7 +4,7 @@ FROM centos:6
 RUN yum -y install gcc make autoconf wget vim rpm-build git gpg2
 
 # Set up Ruby 1.9.3 for FPM.
-RUN gpg2 --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB
+RUN gpg2 --homedir /root/.gnupg --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB
 RUN curl -L get.rvm.io | bash -s stable
 ENV PATH /usr/local/rvm/gems/ruby-1.9.3-p551/bin:/usr/local/rvm/gems/ruby-1.9.3-p551@global/bin:/usr/local/rvm/rubies/ruby-1.9.3-p551/bin:/usr/local/rvm/bin:$PATH
 ENV LC_ALL en_US.UTF-8


### PR DESCRIPTION
This is a suggestion from https://github.com/rvm/rvm/issues/3110.

Although last night I manage to pass the proxy-builder pacakging build stage, yet I think it's because the gpg keyserver was back to normal. Even that, I think it's no harm to commit this code "--homedir /root/.gnupg" to the Dockerfile since it might solve the gpg keyserver issue in the future
