### PR TITLE
Added filtering of empty tags in Jaeger and Zipkin spans

### DIFF
--- a/proxy/src/main/java/com/wavefront/agent/listeners/tracing/JaegerThriftCollectorHandler.java
+++ b/proxy/src/main/java/com/wavefront/agent/listeners/tracing/JaegerThriftCollectorHandler.java
@@ -241,7 +241,7 @@ public class JaegerThriftCollectorHandler extends ThriftRequestHandler<Collector
 
     if (span.getTags() != null) {
       for (Tag tag : span.getTags()) {
-        if (IGNORE_TAGS.contains(tag.getKey()) || (tag.vType == TagType.STRING && StringUtils.isBlank(tag.vStr))) {
+        if (IGNORE_TAGS.contains(tag.getKey()) || (tag.vType == TagType.STRING && StringUtils.isBlank(tag.getVStr()))) {
           continue;
         }
 

--- a/proxy/src/main/java/com/wavefront/agent/listeners/tracing/JaegerThriftCollectorHandler.java
+++ b/proxy/src/main/java/com/wavefront/agent/listeners/tracing/JaegerThriftCollectorHandler.java
@@ -241,7 +241,7 @@ public class JaegerThriftCollectorHandler extends ThriftRequestHandler<Collector
 
     if (span.getTags() != null) {
       for (Tag tag : span.getTags()) {
-        if (IGNORE_TAGS.contains(tag.getKey())) {
+        if (IGNORE_TAGS.contains(tag.getKey()) || (tag.vType == TagType.STRING && tag.vStr.length() == 0)) {
           continue;
         }
 

--- a/proxy/src/main/java/com/wavefront/agent/listeners/tracing/JaegerThriftCollectorHandler.java
+++ b/proxy/src/main/java/com/wavefront/agent/listeners/tracing/JaegerThriftCollectorHandler.java
@@ -241,7 +241,7 @@ public class JaegerThriftCollectorHandler extends ThriftRequestHandler<Collector
 
     if (span.getTags() != null) {
       for (Tag tag : span.getTags()) {
-        if (IGNORE_TAGS.contains(tag.getKey()) || (tag.vType == TagType.STRING && tag.vStr.length() == 0)) {
+        if (IGNORE_TAGS.contains(tag.getKey()) || (tag.vType == TagType.STRING && StringUtils.isBlank(tag.vStr))) {
           continue;
         }
 

--- a/proxy/src/main/java/com/wavefront/agent/listeners/tracing/ZipkinPortUnificationHandler.java
+++ b/proxy/src/main/java/com/wavefront/agent/listeners/tracing/ZipkinPortUnificationHandler.java
@@ -270,7 +270,7 @@ public class ZipkinPortUnificationHandler extends PortUnificationHandler
     Set<String> ignoreKeys = new HashSet<>(ImmutableSet.of(SOURCE_KEY));
     if (zipkinSpan.tags() != null && zipkinSpan.tags().size() > 0) {
       for (Map.Entry<String, String> tag : zipkinSpan.tags().entrySet()) {
-        if (!ignoreKeys.contains(tag.getKey().toLowerCase())) {
+        if (!ignoreKeys.contains(tag.getKey().toLowerCase()) && tag.getValue().length() > 0) {
           Annotation annotation = new Annotation(tag.getKey(), tag.getValue());
           switch (annotation.getKey()) {
             case APPLICATION_TAG_KEY:

--- a/proxy/src/main/java/com/wavefront/agent/listeners/tracing/ZipkinPortUnificationHandler.java
+++ b/proxy/src/main/java/com/wavefront/agent/listeners/tracing/ZipkinPortUnificationHandler.java
@@ -270,7 +270,7 @@ public class ZipkinPortUnificationHandler extends PortUnificationHandler
     Set<String> ignoreKeys = new HashSet<>(ImmutableSet.of(SOURCE_KEY));
     if (zipkinSpan.tags() != null && zipkinSpan.tags().size() > 0) {
       for (Map.Entry<String, String> tag : zipkinSpan.tags().entrySet()) {
-        if (!ignoreKeys.contains(tag.getKey().toLowerCase()) && tag.getValue().length() > 0) {
+        if (!ignoreKeys.contains(tag.getKey().toLowerCase()) && !StringUtils.isBlank(tag.getValue())) {
           Annotation annotation = new Annotation(tag.getKey(), tag.getValue());
           switch (annotation.getKey()) {
             case APPLICATION_TAG_KEY:

--- a/proxy/src/test/java/com/wavefront/agent/listeners/tracing/JaegerThriftCollectorHandlerTest.java
+++ b/proxy/src/test/java/com/wavefront/agent/listeners/tracing/JaegerThriftCollectorHandlerTest.java
@@ -84,6 +84,21 @@ public class JaegerThriftCollectorHandlerTest {
         .build());
     expectLastCall();
 
+    mockTraceHandler.report(Span.newBuilder().setCustomer("dummy").setStartMillis(startTime)
+            .setDuration(3456)
+            .setName("HTTP GET /test")
+            .setSource("10.0.0.1")
+            .setSpanId("00000000-0000-0000-0000-0051759bfc69")
+            .setTraceId("0000011e-ab2a-9944-0000-000049631900")
+            // Note: Order of annotations list matters for this unit test.
+            .setAnnotations(ImmutableList.of(
+                    new Annotation("service", "frontend"),
+                    new Annotation("application", "Jaeger"),
+                    new Annotation("cluster", "none"),
+                    new Annotation("shard", "none")))
+            .build());
+    expectLastCall();
+
     replay(mockTraceHandler);
 
     JaegerThriftCollectorHandler handler = new JaegerThriftCollectorHandler("9876", mockTraceHandler,
@@ -99,6 +114,9 @@ public class JaegerThriftCollectorHandlerTest {
     Tag customApplicationTag = new Tag("application", TagType.STRING);
     customApplicationTag.setVStr("Custom-JaegerApp");
 
+    Tag emptyTag = new Tag("empty", TagType.STRING);
+    emptyTag.setVStr("");
+
     io.jaegertracing.thriftjava.Span span1 = new io.jaegertracing.thriftjava.Span(1234567890123L, 1234567890L,
         1234567L, 0L, "HTTP GET", 1, startTime * 1000, 1234 * 1000);
 
@@ -109,15 +127,19 @@ public class JaegerThriftCollectorHandlerTest {
     io.jaegertracing.thriftjava.Span span3 = new io.jaegertracing.thriftjava.Span(-97803834702328661L, 0L,
         -7344605349865507945L, -97803834702328661L, "HTTP GET /", 1, startTime * 1000, 3456 * 1000);
 
+    io.jaegertracing.thriftjava.Span span4 = new io.jaegertracing.thriftjava.Span(1231231232L, 1231232342340L,
+            349865507945L, 0, "HTTP GET /test", 1, startTime * 1000, 3456 * 1000);
+
     span1.setTags(ImmutableList.of(componentTag));
     span2.setTags(ImmutableList.of(componentTag, customApplicationTag));
+    span4.setTags(ImmutableList.of(emptyTag));
 
     Batch testBatch = new Batch();
     testBatch.process = new Process();
     testBatch.process.serviceName = "frontend";
     testBatch.process.setTags(ImmutableList.of(ipTag));
 
-    testBatch.setSpans(ImmutableList.of(span1, span2, span3));
+    testBatch.setSpans(ImmutableList.of(span1, span2, span3, span4));
 
     Collector.submitBatches_args batches = new Collector.submitBatches_args();
     batches.addToBatches(testBatch);

--- a/proxy/src/test/java/com/wavefront/agent/listeners/tracing/JaegerThriftCollectorHandlerTest.java
+++ b/proxy/src/test/java/com/wavefront/agent/listeners/tracing/JaegerThriftCollectorHandlerTest.java
@@ -84,6 +84,7 @@ public class JaegerThriftCollectorHandlerTest {
         .build());
     expectLastCall();
 
+    // Test filtering empty tags
     mockTraceHandler.report(Span.newBuilder().setCustomer("dummy").setStartMillis(startTime)
             .setDuration(3456)
             .setName("HTTP GET /test")


### PR DESCRIPTION
Having empty tags is not an error in Jaeger's and Zipkin's spans but those spans get silently rejected by Wavefront server.

This PR filters the empty tags for both the protocol.