### PR TITLE
ESO-1291, Fix fpm installation and update DockerFile

### DIFF
--- a/pkg/Dockerfile
+++ b/pkg/Dockerfile
@@ -9,8 +9,7 @@ RUN curl -L get.rvm.io | bash -s stable
 ENV PATH /usr/local/rvm/gems/ruby-2.0.0-p598/bin:/usr/local/rvm/gems/ruby-2.0.0-p598@global/bin:/usr/local/rvm/rubies/ruby-2.0.0-p598/bin:/usr/local/rvm/bin:$PATH
 ENV LC_ALL en_US.UTF-8
 RUN rvm install 2.0.0-p598
-RUN gem install fpm --version 1.10.0
-RUN gem install package_cloud --version 0.2.35
+RUN gem install childprocess:1.0.1 fpm:1.10.0 package_cloud:0.2.35
 
 # Wavefront software. This repo contains build scripts for the agent, to be run
 # inside this container.


### PR DESCRIPTION
Error in build:
```
ERROR:  Error installing fpm:
	The last version of childprocess (>= 0) to support your Ruby & RubyGems was 1.0.1. Try installing it with `gem install childprocess -v 1.0.1` and then running the current command again
	childprocess requires Ruby version >= 2.3.0. The current ruby version is 2.0.0.598.
```