### PR TITLE
Fix DockerFile

### DIFF
--- a/proxy/docker/Dockerfile
+++ b/proxy/docker/Dockerfile
@@ -24,7 +24,7 @@ ENTRYPOINT ["/usr/bin/dumb-init", "--"]
 # Download wavefront proxy (latest release). Merely extract the debian, don't want to try running startup scripts.
 RUN echo "deb https://packagecloud.io/wavefront/proxy/ubuntu/ bionic main" > /etc/apt/sources.list.d/wavefront_proxy.list
 RUN echo "deb-src https://packagecloud.io/wavefront/proxy/ubuntu/ bionic main" >> /etc/apt/sources.list.d/wavefront_proxy.list
-RUN curl -L "https://packagecloud.io/wavefront/proxy/gpgkey" 2> /dev/null | apt-key add - &>/dev/null
+RUN curl -L "https://packagecloud.io/wavefront/proxy/gpgkey" | apt-key add -
 RUN apt-get -y update
 
 RUN apt-get -d install wavefront-proxy


### PR DESCRIPTION
Fix following error as the gpg was not imported successfully.
```
Err:1 https://packagecloud.io/wavefront/proxy/ubuntu bionic InRelease
   The following signatures couldn't be verified because the public key is not available: NO_PUBKEY 1FA5B6918EA8F2D0
 GPG error: https://packagecloud.io/wavefront/proxy/ubuntu bionic InRelease: The following signatures couldn't be verified because the public key is not available: NO_PUBKEY 1FA5B6918EA8F2D0
E: The repository 'https://packagecloud.io/wavefront/proxy/ubuntu bionic InRelease' is not signed.
The command '/bin/sh -c apt-get -y update' returned a non-zero code: 100
```